### PR TITLE
Switch Cori from partitions to configurations

### DIFF
--- a/mache/machine_info.py
+++ b/mache/machine_info.py
@@ -282,6 +282,10 @@ class MachineInfo:
             The default partition on the machine, or ``None`` if no partition
             should be specified
 
+        configuration : str
+            The default configuration on the machine, or ``None`` if no
+            configuration should be specified
+
         qos : str
             The default quality of service on the machine, or ``None`` if no
             QOS should be specified
@@ -299,6 +303,13 @@ class MachineInfo:
         else:
             partition = None
 
+        if config.has_option('parallel', 'configurations'):
+            configuration = config.get('parallel', 'configurations')
+            # take the first entry
+            configuration = configuration.split(',')[0].strip()
+        else:
+            configuration = None
+
         if config.has_option('parallel', 'qos'):
             qos = config.get('parallel', 'qos')
             # take the first entry
@@ -306,7 +317,7 @@ class MachineInfo:
         else:
             qos = None
 
-        return account, partition, qos
+        return account, partition, configuration, qos
 
     def _get_config(self):
         """ get a parser for config options """

--- a/mache/machines/cori-haswell.cfg
+++ b/mache/machines/cori-haswell.cfg
@@ -39,8 +39,8 @@ cores_per_node = 32
 # account for running diagnostics jobs
 account = e3sm
 
-# available partition(s) (default is the first)
-partitions = haswell
+# available configurations(s) (default is the first)
+configurations = haswell
 
 # quality of service (default is the first)
 qos = regular, premium, debug

--- a/mache/machines/cori-knl.cfg
+++ b/mache/machines/cori-knl.cfg
@@ -39,8 +39,8 @@ cores_per_node = 68
 # account for running diagnostics jobs
 account = e3sm
 
-# available partition(s) (default is the first)
-partitions = knl
+# available configurations(s) (default is the first)
+configurations = knl
 
 # quality of service (default is the first)
 qos = regular, premium, debug


### PR DESCRIPTION
This merge switches the config options associated with Cori's two configurations (haswell and knl) to be called "configurations" rather than "partitions", to be consistent with their usage in Slrum.

closes #5 