### PR TITLE
Fix LCRC web portal 

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mache" %}
-{% set version = "1.1.1" %}
+{% set version = "1.1.2" %}
 
 package:
   name: {{ name|lower }}

--- a/mache/__init__.py
+++ b/mache/__init__.py
@@ -1,5 +1,5 @@
 from mache.machine_info import MachineInfo
 from mache.discover import discover_machine
 
-__version_info__ = (1, 1, 1)
+__version_info__ = (1, 1, 2)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/mache/machines/anvil.cfg
+++ b/mache/machines/anvil.cfg
@@ -28,10 +28,10 @@ base_path = /lcrc/group/e3sm/diagnostics
 [web_portal]
 
 # The path to the base of the web portals
-base_path = /lcrc/group/e3sm/public_html
+base_path = /lcrc/group/e3sm/public_html/diagnostic_output
 
 # The base URL that corresponds to the base path
-base_url = https://web.lcrc.anl.gov/public/e3sm/
+base_url = https://web.lcrc.anl.gov/public/e3sm/diagnostic_output
 
 
 # The parallel section describes options related to running jobs in parallel

--- a/mache/machines/chrysalis.cfg
+++ b/mache/machines/chrysalis.cfg
@@ -28,10 +28,10 @@ base_path = /lcrc/group/e3sm/diagnostics
 [web_portal]
 
 # The path to the base of the web portals
-base_path = /lcrc/group/e3sm/public_html
+base_path = /lcrc/group/e3sm/public_html/diagnostic_output
 
 # The base URL that corresponds to the base path
-base_url = https://web.lcrc.anl.gov/public/e3sm/
+base_url = https://web.lcrc.anl.gov/public/e3sm/diagnostic_output
 
 
 # The parallel section describes options related to running jobs in parallel

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mache
-version = 1.1.1
+version = 1.1.2
 author = Xylar Asay-Davis
 author_email = xylar@lanl.gov
 description = A package for providing configuration data relate to E3SM supported machines


### PR DESCRIPTION
We want diagnostics to go into `diagnostic_output` directory on the web portal.

Update `mache` to v1.1.2