### PR TITLE
Replace `$SHELL{}` with `$()` in environment variables

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mache" %}
-{% set version = "1.1.3" %}
+{% set version = "1.1.4" %}
 
 package:
   name: {{ name|lower }}

--- a/mache/__init__.py
+++ b/mache/__init__.py
@@ -1,5 +1,5 @@
 from mache.machine_info import MachineInfo
 from mache.discover import discover_machine
 
-__version_info__ = (1, 1, 3)
+__version_info__ = (1, 1, 4)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/mache/machine_info.py
+++ b/mache/machine_info.py
@@ -280,6 +280,10 @@ class MachineInfo:
                     value = var.text
                     # go from the XML syntax to bash variable syntax
                     value = value.replace('$ENV{', '${')
+                    if '$SHELL' in value:
+                        value = value.replace('$SHELL{', '$(')
+                        # replace the last curly bracket with a parenthesis
+                        value = ')'.join(value.rsplit('}', 1))
 
                     env_vars[var_name] = value
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mache
-version = 1.1.3
+version = 1.1.4
 author = Xylar Asay-Davis
 author_email = xylar@lanl.gov
 description = A package for providing configuration data relate to E3SM supported machines


### PR DESCRIPTION
Environment variables that include `$SHELL{}` were not being parsed correctly.