### PR TITLE
Upute chrysalis cores per node to 128

### DIFF
--- a/mache/machines/chrysalis.cfg
+++ b/mache/machines/chrysalis.cfg
@@ -44,7 +44,7 @@ system = slurm
 parallel_executable = srun
 
 # cores per node on the machine
-cores_per_node = 64
+cores_per_node = 128
 
 # available partition(s) (default is the first)
 partitions = debug, compute, high


### PR DESCRIPTION
For the purposes of any code running on Chrysalis, it looks like it has 128 CPUs per node because of hyperthreading.