### PR TITLE
Update paths on Grizzly and Badger

### DIFF
--- a/mache/machines/badger.cfg
+++ b/mache/machines/badger.cfg
@@ -13,7 +13,7 @@ mpi = impi
 
 # the path to the directory where activation scripts, the base environment, and
 # system libraries will be deployed
-base_path = /turquoise/usr/projects/climate/SHARED_CLIMATE/anaconda_envs
+base_path = /usr/projects/climate/SHARED_CLIMATE/anaconda_envs
 
 
 # config options related to data needed by diagnostics software such as
@@ -21,7 +21,7 @@ base_path = /turquoise/usr/projects/climate/SHARED_CLIMATE/anaconda_envs
 [diagnostics]
 
 # The base path to the diagnostics directory
-base_path = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics
+base_path = /usr/projects/climate/SHARED_CLIMATE/diagnostics
 
 
 # The parallel section describes options related to running jobs in parallel

--- a/mache/machines/grizzly.cfg
+++ b/mache/machines/grizzly.cfg
@@ -13,7 +13,7 @@ mpi = impi
 
 # the path to the directory where activation scripts, the base environment, and
 # system libraries will be deployed
-base_path = /turquoise/usr/projects/climate/SHARED_CLIMATE/anaconda_envs
+base_path = /usr/projects/climate/SHARED_CLIMATE/anaconda_envs
 
 
 # config options related to data needed by diagnostics software such as
@@ -21,7 +21,7 @@ base_path = /turquoise/usr/projects/climate/SHARED_CLIMATE/anaconda_envs
 [diagnostics]
 
 # The base path to the diagnostics directory
-base_path = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics
+base_path = /usr/projects/climate/SHARED_CLIMATE/diagnostics
 
 
 # The parallel section describes options related to running jobs in parallel


### PR DESCRIPTION
Remove the unneeded `/turquoise` base path, which will not be available on the newer Chicoma machine.