### PR TITLE
Switch E3SM-Unified compiler on Chrysalis to Gnu

### DIFF
--- a/mache/machines/chrysalis.cfg
+++ b/mache/machines/chrysalis.cfg
@@ -6,7 +6,7 @@
 group = cels
 
 # the compiler set to use for system libraries and MPAS builds
-compiler = intel
+compiler = gnu
 
 # the system MPI library to use for intel18 compiler
 mpi = openmpi


### PR DESCRIPTION
We're having trouble with NCO compiled with Intel on this particular machine.  `ncremap` is producing strange results.