### PR TITLE
Remove compilers for E3SM-Unified on Cori-KNL

### DIFF
--- a/mache/machines/cori-knl.cfg
+++ b/mache/machines/cori-knl.cfg
@@ -5,12 +5,6 @@
 # the unix group for permissions for the e3sm-unified conda environment
 group = e3sm
 
-# the compiler set to use for system libraries and MPAS builds
-compiler = intel
-
-# the system MPI library to use for intel18 compiler
-mpi = impi
-
 # the path to the directory where activation scripts, the base environment, and
 # system libraries will be deployed
 base_path = /global/common/software/e3sm/anaconda_envs


### PR DESCRIPTION
This is because we have not had any luck getting Spack to build the E3SM-Unified packages on Cori-KNL.