### PR TITLE
Add command-line tools for syncing diagnostics data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,20 @@ not yet generated an SSH key for the destination macine, you will need to run:
 This is the same procedure as for creating an SSH key for GitHub so if you have
 already done that process, you will not need a new SSH key for LCRC.
 
+Setup on Andes
+~~~~~~~~~~~~~~
+Andes at OLCF requires special treatment.  You need to create or edit the
+file ``~/.ssh/config`` with the following:
+
+.. code-block:: none
+
+    Host blues.lcrc.anl.gov
+        User <ac.user>
+        PreferredAuthentications publickey
+        IdentityFile ~/.ssh/id_ed25519
+
+where, again ``<ac.user>`` is your username on LCRC.
+
 Syncing from LCRC
 ~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,88 @@ web_portal_base : str
 web_portal_url : str
     The base URL for the web portal
 
+Syncing Diagnostics
+-------------------
+
+``mache`` can be used to synchronize diagnostics data (observational data sets,
+testing data, mapping files, region masks, etc.) either directly on LCRC or
+from LCRC to other supported machines.
+
+E3SM maintains a set of public diagnostics data (those that we have permission
+to share with any users of our software) on LCRC machines (Anvil and Chrysalis)
+in the directory:
+
+.. code-block:: none
+
+    /lcrc/group/e3sm/public_html/diagnostics/
+
+A set of private diagnostics data (which we do not have permission to share
+outside the E3SM project) are stored at:
+
+.. code-block:: none
+
+    /lcrc/group/e3sm/diagnostics_private/
+
+The ``mache sync diags`` command can be used to synchronize both sets of data
+with a shared diagnostics directory on each supported machine.
+
+Whenever possible, we log on to the E3SM machine and download the data from
+LCRC because this allows the synchronization tool to also update permissions
+once the data has been synchronized.  This is the approach for all machines
+except for Los Alamos National Laboratory's Badger and Grizzly machines, which
+are behind a firewall taht prevents this approach.
+
+One-time Setup
+~~~~~~~~~~~~~~
+
+To synchronize data from LCRC to other machines, you must first provide your
+SSH keys by going to the `Argonne Accounts <https://accounts.cels.anl.gov/>`_
+page, logging in, and adding the public ssh key for each machine.  If you have
+not yet generated an SSH key for the destination macine, you will need to run:
+
+.. code-block:: bash
+
+    ssh-keygen -t ed25519 -C "your_email@example.com"
+
+This is the same procedure as for creating an SSH key for GitHub so if you have
+already done that process, you will not need a new SSH key for LCRC.
+
+Syncing from LCRC
+~~~~~~~~~~~~~~~~~
+
+To synchronize diagnostics data from LCRC, simply run:
+
+.. code-block:: bash
+
+    mache sync diags from anvil -u <ac.user>
+
+where ``<ac.user>`` is your account name on LCRC.
+
+Syncing on LCRC
+~~~~~~~~~~~~~~~
+
+To synchronize diagnostics on an LCRC machine, run:
+
+.. code-block:: bash
+
+    mache sync diags from anvil
+
+Make sure the machine after ``from`` is the same as the machine you are on,
+``anvil`` in this example.
+
+Syncing to Machines with Firewalls
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To synchronize diagnostics data to a machine with a firewall by using a tunnel,
+first log on to an LCRC machine, then run:
+
+.. code-block:: bash
+
+    mache sync diags to badger -u <username>
+
+where ``<username>`` is your account name on the non-LCRC machine (``badger``
+in this example).
+
 License
 -------
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - lxml
     - jinja2
     - pyyaml
+    - progressbar2
 
 test:
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -26,10 +26,13 @@ requirements:
     - rsync
 
 test:
-
+  requires:
+    - pip
   imports:
     - mache
-
+  commands:
+    - mache sync diags --help
+    - pip check
 
 about:
   home: https://github.com/E3SM-Project/mache

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - jinja2
     - pyyaml
     - progressbar2
+    - rsync
 
 test:
 

--- a/mache/__main__.py
+++ b/mache/__main__.py
@@ -1,0 +1,42 @@
+import sys
+import argparse
+
+import mache.version
+from mache import sync
+
+
+def main():
+    """
+    Entry point for the main script ``mache``
+    """
+
+    parser = argparse.ArgumentParser(
+        description="Perform mache commands",
+        usage='''
+mache <command> [<args>]
+The available mache commands are:
+    sync    Sync files between supported machines
+ To get help on an individual command, run:
+    mache <command> --help
+    ''')
+
+    parser.add_argument('command', help='command to run')
+    parser.add_argument('-v', '--version',
+                        action='version',
+                        version='mache {}'.format(mache.version.__version__),
+                        help="Show version number and exit")
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(0)
+
+    args = parser.parse_args(sys.argv[1:2])
+
+    commands = {'sync': sync.main}
+
+    if args.command not in commands:
+        print('Unrecognized command {}'.format(args.command))
+        parser.print_help()
+        exit(1)
+
+    # call the function associated with the requested command
+    commands[args.command]()

--- a/mache/machines/acme1.cfg
+++ b/mache/machines/acme1.cfg
@@ -17,6 +17,8 @@ base_path = /usr/local/e3sm_unified/envs
 # The base path to the diagnostics directory
 base_path = /space2/diagnostics
 
+# the unix group for permissions for diagnostics
+group = climate
 
 # The parallel section describes options related to running jobs in parallel
 [parallel]
@@ -29,3 +31,10 @@ parallel_executable = mpirun
 
 # cores per node on the machine
 cores_per_node = 192
+
+
+# config options related to synchronizing files
+[sync]
+
+# the full hostname of the machine
+hostname = acme1.llnl.gov

--- a/mache/machines/andes.cfg
+++ b/mache/machines/andes.cfg
@@ -17,6 +17,9 @@ base_path = /gpfs/alpine/proj-shared/cli115/e3sm-unified
 # The base path to the diagnostics directory
 base_path = /gpfs/alpine/proj-shared/cli115/diagnostics/
 
+# the unix group for permissions for diagnostics
+group = cli115
+
 
 # The parallel section describes options related to running jobs in parallel
 [parallel]
@@ -35,3 +38,10 @@ account = cli115
 
 # available partition(s) (default is the first)
 partitions = batch
+
+
+# config options related to synchronizing files
+[sync]
+
+# the full hostname of the machine
+hostname = andes.olcf.ornl.gov

--- a/mache/machines/anvil.cfg
+++ b/mache/machines/anvil.cfg
@@ -23,6 +23,9 @@ base_path = /lcrc/soft/climate/e3sm-unified
 # The base path to the diagnostics directory
 base_path = /lcrc/group/e3sm/diagnostics
 
+# the unix group for permissions for diagnostics
+group = cels
+
 
 # config options associated with web portals
 [web_portal]
@@ -66,3 +69,16 @@ modules_before = False
 # whether to load modules from the spack yaml file after loading the spack
 # environment
 modules_after = True
+
+
+# config options related to synchronizing files
+[sync]
+
+# the full hostname of the machine
+hostname = blues.lcrc.anl.gov
+
+# public diagnostics directory
+public_diags = /lcrc/group/e3sm/public_html/diagnostics/
+
+# private diagnostics directory
+private_diags = /lcrc/group/e3sm/diagnostics_private/

--- a/mache/machines/badger.cfg
+++ b/mache/machines/badger.cfg
@@ -23,6 +23,9 @@ base_path = /usr/projects/climate/SHARED_CLIMATE/anaconda_envs
 # The base path to the diagnostics directory
 base_path = /usr/projects/climate/SHARED_CLIMATE/diagnostics
 
+# the unix group for permissions for diagnostics
+group = climate
+
 
 # The parallel section describes options related to running jobs in parallel
 [parallel]
@@ -53,3 +56,13 @@ modules_before = False
 # whether to load modules from the spack yaml file after loading the spack
 # environment
 modules_after = True
+
+
+# config options related to synchronizing files
+[sync]
+
+# the full hostname of the machine
+hostname = wtrw.lanl.gov
+
+# tunnel command
+tunnel_hostname = ba-fe

--- a/mache/machines/chrysalis.cfg
+++ b/mache/machines/chrysalis.cfg
@@ -23,6 +23,9 @@ base_path = /lcrc/soft/climate/e3sm-unified
 # The base path to the diagnostics directory
 base_path = /lcrc/group/e3sm/diagnostics
 
+# the unix group for permissions for diagnostics
+group = cels
+
 
 # config options associated with web portals
 [web_portal]
@@ -60,3 +63,16 @@ modules_before = False
 # whether to load modules from the spack yaml file after loading the spack
 # environment
 modules_after = True
+
+
+# config options related to synchronizing files
+[sync]
+
+# the full hostname of the machine
+hostname = chrysalis.lcrc.anl.gov
+
+# public diagnostics directory
+public_diags = /lcrc/group/e3sm/public_html/diagnostics/
+
+# private diagnostics directory
+private_diags = /lcrc/group/e3sm/diagnostics_private/

--- a/mache/machines/compy.cfg
+++ b/mache/machines/compy.cfg
@@ -23,6 +23,9 @@ base_path = /share/apps/E3SM/conda_envs
 # The base path to the diagnostics directory
 base_path = /compyfs/diagnostics
 
+# the unix group for permissions for diagnostics
+group = users
+
 
 # config options associated with web portals
 [web_portal]
@@ -66,3 +69,10 @@ modules_before = True
 # whether to load modules from the spack yaml file after loading the spack
 # environment
 modules_after = False
+
+
+# config options related to synchronizing files
+[sync]
+
+# the full hostname of the machine
+hostname = compy.pnl.gov

--- a/mache/machines/cooley.cfg
+++ b/mache/machines/cooley.cfg
@@ -17,6 +17,9 @@ base_path = /lus/theta-fs0/projects/ccsm/acme/tools/e3sm-unified
 # The base path to the diagnostics directory
 base_path = /lus/theta-fs0/projects/ClimateEnergy_4/diagnostics
 
+# the unix group for permissions for diagnostics
+group = ccsm
+
 
 # The parallel section describes options related to running jobs in parallel
 [parallel]
@@ -32,3 +35,10 @@ cores_per_node = 12
 
 # account for running diagnostics jobs
 account = ClimateEnergy_4
+
+
+# config options related to synchronizing files
+[sync]
+
+# the full hostname of the machine
+hostname = cooley.alcf.anl.gov

--- a/mache/machines/cori-haswell.cfg
+++ b/mache/machines/cori-haswell.cfg
@@ -23,6 +23,9 @@ base_path = /global/common/software/e3sm/anaconda_envs
 # The base path to the diagnostics directory
 base_path = /global/cfs/cdirs/e3sm/diagnostics
 
+# the unix group for permissions for diagnostics
+group = e3sm
+
 
 # config options associated with web portals
 [web_portal]
@@ -66,3 +69,10 @@ modules_before = False
 # whether to load modules from the spack yaml file after loading the spack
 # environment
 modules_after = False
+
+
+# config options related to synchronizing files
+[sync]
+
+# the full hostname of the machine
+hostname = cori.nersc.gov

--- a/mache/machines/cori-knl.cfg
+++ b/mache/machines/cori-knl.cfg
@@ -17,6 +17,9 @@ base_path = /global/common/software/e3sm/anaconda_envs
 # The base path to the diagnostics directory
 base_path = /global/cfs/cdirs/e3sm/diagnostics
 
+# the unix group for permissions for diagnostics
+group = e3sm
+
 
 # config options associated with web portals
 [web_portal]
@@ -48,3 +51,10 @@ configurations = knl
 
 # quality of service (default is the first)
 qos = regular, premium, debug
+
+
+# config options related to synchronizing files
+[sync]
+
+# the full hostname of the machine
+hostname = cori.nersc.gov

--- a/mache/machines/grizzly.cfg
+++ b/mache/machines/grizzly.cfg
@@ -23,6 +23,9 @@ base_path = /usr/projects/climate/SHARED_CLIMATE/anaconda_envs
 # The base path to the diagnostics directory
 base_path = /usr/projects/climate/SHARED_CLIMATE/diagnostics
 
+# the unix group for permissions for diagnostics
+group = climate
+
 
 # The parallel section describes options related to running jobs in parallel
 [parallel]
@@ -41,3 +44,13 @@ account = e3sm
 
 # quality of service (default is the first)
 qos = regular, interactive
+
+
+# config options related to synchronizing files
+[sync]
+
+# the full hostname of the machine
+hostname = wtrw.lanl.gov
+
+# tunnel command
+tunnel_hostname = gr-fe

--- a/mache/sync/__init__.py
+++ b/mache/sync/__init__.py
@@ -1,0 +1,36 @@
+import sys
+import argparse
+
+from mache.sync import diags
+
+def main():
+    """
+    Defines the ``mache sync`` command
+    """
+
+    parser = argparse.ArgumentParser(
+        description="Perform synchronization between supported machines",
+        usage='''
+    mache sync <command> [<args>]
+    The available mache commands are:
+        diags    Synchronize diagnostics files between supported machines
+     To get help on an individual command, run:
+        mache sync <command> --help
+        ''')
+
+    parser.add_argument('command', help='command to run')
+    if len(sys.argv) == 2:
+        parser.print_help()
+        sys.exit(0)
+
+    args = parser.parse_args(sys.argv[2:3])
+
+    commands = {'diags': diags.main}
+
+    if args.command not in commands:
+        print('Unrecognized command {}'.format(args.command))
+        parser.print_help()
+        exit(1)
+
+    # call the function associated with the requested command
+    commands[args.command]()

--- a/mache/sync/diags.py
+++ b/mache/sync/diags.py
@@ -51,7 +51,7 @@ def sync_diags(other, direction='to', machine=None, username=None):
             'machine with a tunnel.  Other machines should only use \n'
             '"mache sync diags from ..." so permissions can be updated.')
 
-    if machine in lcrc_machines:
+    if machine in lcrc_machines and tunnel is None:
         if machine != other:
             raise ValueError(f'You should sync {machine} with itself since '
                              f'files are local')
@@ -93,7 +93,7 @@ def sync_diags(other, direction='to', machine=None, username=None):
             '--exclude=observations/Atm', '--no-perms', '--omit-dir-times']
 
     if tunnel:
-        args.append(f'--rsync-path="ssh {tunnel} rsync"')
+        args.append(f'--rsync-path=ssh {tunnel} rsync')
 
     public_args = args + [public_diags, dest_diags]
     private_args = args + [private_diags, dest_diags]

--- a/mache/sync/diags.py
+++ b/mache/sync/diags.py
@@ -99,9 +99,18 @@ def sync_diags(other, direction='to', machine=None, username=None):
     private_args = args + [private_diags, dest_diags]
 
     print(f'running: {" ".join(public_args)}')
-    subprocess.check_call(public_args)
+    try:
+        subprocess.check_call(public_args)
+    except subprocess.CalledProcessError:
+        print('Warning: Some transfer operations failed for public '
+              'diagnostics.')
+    print('')
     print(f'running: {" ".join(private_args)}')
-    subprocess.check_call(private_args)
+    try:
+        subprocess.check_call(private_args)
+    except subprocess.CalledProcessError:
+        print('Warning: Some transfer operations failed for private '
+              'diagnostics.')
 
     if direction == 'from':
         group = machine_config.get('diagnostics', 'group')

--- a/mache/sync/diags.py
+++ b/mache/sync/diags.py
@@ -1,0 +1,128 @@
+import sys
+import argparse
+import subprocess
+
+from mache.machine_info import MachineInfo
+from mache.permissions import update_permissions
+
+
+def sync_diags(other, direction='to', machine=None, username=None):
+    """
+    Synchronize diagnostics files between supported machines
+
+    Parameters
+    ----------
+    other : str
+        The other machine to sync to or from
+    direction : {'to', 'from'}, optional
+        The direction to sync (to or from the other machine).
+    machine : str, optional
+        The name of this machine.  If not provided, it will be detected
+        automatically
+    username : str, optional
+        The username to use on the other machine, if not from ``.ssh/config``
+    """
+    if direction not in ['to', 'from']:
+        raise ValueError('The direction must be one of "to" or "from"')
+
+    machine_info = MachineInfo(machine=machine)
+    machine = machine_info.machine
+
+    lcrc_machines = ['anvil', 'chrysalis']
+    if direction == 'to' and machine not in lcrc_machines:
+        raise ValueError(f'You can only sync diagnostics to another machine '
+                         f'from an LCRC machine: {", ".join(lcrc_machines)}')
+    if direction == 'from' and other not in lcrc_machines:
+        raise ValueError(f'You can only sync diagnostics from an LCRC '
+                         f'machine: {", ".join(lcrc_machines)}')
+    machine_config = machine_info.config
+    other_info = MachineInfo(machine=other)
+    other_config = other_info.config
+
+    hostname = other_config.get('sync', 'hostname')
+    if other_config.has_option('sync', 'tunnel_hostname'):
+        tunnel = other_config.get('sync', 'tunnel_hostname')
+    else:
+        tunnel = None
+
+    if direction == 'to' and (machine != other or tunnel is None):
+        raise ValueError('You can only use "mache sync diags to ..." to '
+                         'sync diags between directories on an LCRC machine\n'
+                         'or to a machine with a tunnel.  Other machines '
+                         'should only use "mache sync diags from ..." so\n'
+                         'permissions can be updated.')
+
+    if direction == 'from':
+        source_config = other_config
+        dest_config = machine_config
+    else:
+        source_config = machine_config
+        dest_config = other_config
+
+    public_diags = source_config.get('sync', 'public_diags')
+    private_diags = source_config.get('sync', 'private_diags')
+    dest_diags = dest_config.get('diagnostics', 'base_path')
+
+    if machine == other:
+        prefix = ''
+    else:
+        if username is not None:
+            prefix = f'{username}@{hostname}:'
+        else:
+            prefix = f'{hostname}:'
+
+    if direction == 'from':
+        public_diags = f'{prefix}{public_diags}'
+        private_diags = f'{prefix}{private_diags}'
+    else:
+        dest_diags = f'{prefix}{dest_diags}'
+
+    args = ['rsync', '--verbose', '--recursive', '--times', '--links',
+            '--compress', '--progress', '--update',
+            '--exclude=observations/Atm', '--no-perms', '--omit-dir-times']
+
+    if tunnel:
+        args.append(f'--rsync-path="ssh {tunnel} rsync"')
+
+    public_args = args + [public_diags, dest_diags]
+    private_args = args + [private_diags, dest_diags]
+
+    print(f'running: {" ".join(public_args)}')
+    subprocess.check_call(public_args)
+    print(f'running: {" ".join(private_args)}')
+    subprocess.check_call(private_args)
+
+    if direction == 'from':
+        group = machine_config.get('diagnostics', 'group')
+        print(f'Updating permissions on {dest_diags}:')
+        update_permissions(base_paths=dest_diags, group=group,
+                           show_progress=True, group_writable=True,
+                           other_readable=True)
+        print('Done.')
+
+
+def main():
+    """
+    Defines the ``mache sync diags`` command
+    """
+    parser = argparse.ArgumentParser(
+        description="Synchronize diagnostics files between supported machines",
+        usage='''
+    mache sync diags to <other> [<args>]
+        or
+    mache sync diags from <other> [<args>]
+
+    To get help on an individual command, run:
+        mache sync <command> --help
+        ''')
+    parser.add_argument('direction', help='whether to sync "to" or "from" the '
+                                          'other machine')
+    parser.add_argument("other", help="The other machine to sync to or from")
+    parser.add_argument("-m", "--machine", dest="machine",
+                        help="The name of this machine.  If not provided, it "
+                             "will be detected automatically")
+    parser.add_argument("-u", "--username", dest="username",
+                        help="The username to use on the other machine, if "
+                             "not from .ssh/config")
+    args = parser.parse_args(sys.argv[3:])
+    sync_diags(args.other, args.direction, args.machine, args.username)

--- a/mache/sync/diags.py
+++ b/mache/sync/diags.py
@@ -121,8 +121,7 @@ def main():
     parser.add_argument("-m", "--machine", dest="machine",
                         help="The name of this machine.  If not provided, it "
                              "will be detected automatically")
-    parser.add_argument("-u", "--username", dest="username",
-                        help="The username to use on the other machine, if "
-                             "not from .ssh/config")
+    parser.add_argument("-u", "--username", dest="username", required=True,
+                        help="The username to use on the other machine")
     args = parser.parse_args(sys.argv[3:])
     sync_diags(args.other, args.direction, args.machine, args.username)

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,8 @@ install_requires =
    lxml
    jinja2
    pyyaml
+   progressbar2
+
+[options.entry_points]
+console_scripts =
+    mache = mache.__main__:main

--- a/spec-file.txt
+++ b/spec-file.txt
@@ -2,3 +2,4 @@ python >=3.6
 lxml
 jinja2
 pyyaml
+progressbar2

--- a/spec-file.txt
+++ b/spec-file.txt
@@ -3,3 +3,4 @@ lxml
 jinja2
 pyyaml
 progressbar2
+rsync


### PR DESCRIPTION
This tool can be used to update diagnostics on any supported machine without a firewall with a command like:
```
mache sync diags from anvil -u <ac.user>
```
The LCRC username `<ac.user>` is needed on all machines except Anvil and Chrysalis.  For this to work, the user needs to have their public SSH key for non-LCRC supported machine registered to their LCRC account.  See the README for details.

There is an alternative procedure:
```
mache sync diags to badger -u <username>
```
for syncing diagnostics to a machine with a firewall (`badger` in this example).