### PR TITLE
Add load gcc module before intel on Anvil and Compy

### DIFF
--- a/mache/spack/anvil_intel_impi.yaml
+++ b/mache/spack/anvil_intel_impi.yaml
@@ -1,5 +1,5 @@
 spack:
-  specs: 
+  specs:
   - cmake
   - intel
   - intel-mpi
@@ -102,6 +102,7 @@ spack:
       - spec: intel@20.0.4
         prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/intel-20.0.4-lednsve
         modules:
+        - gcc/7.4.0
         - intel/20.0.4-lednsve
       buildable: false
     intel-mpi:

--- a/mache/spack/anvil_intel_mvapich.yaml
+++ b/mache/spack/anvil_intel_mvapich.yaml
@@ -1,5 +1,5 @@
 spack:
-  specs: 
+  specs:
   - cmake
   - intel
   - mvapich2
@@ -102,6 +102,7 @@ spack:
       - spec: intel@20.0.4
         prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/intel-20.0.4-lednsve
         modules:
+        - gcc/7.4.0
         - intel/20.0.4-lednsve
       buildable: false
     mvapich2:

--- a/mache/spack/anvil_intel_openmpi.yaml
+++ b/mache/spack/anvil_intel_openmpi.yaml
@@ -1,5 +1,5 @@
 spack:
-  specs: 
+  specs:
   - cmake
   - intel
   - openmpi
@@ -102,6 +102,7 @@ spack:
       - spec: intel@20.0.4
         prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/intel-20.0.4-lednsve
         modules:
+        - gcc/7.4.0
         - intel/20.0.4-lednsve
       buildable: false
     openmpi:

--- a/mache/spack/compy_intel_impi.yaml
+++ b/mache/spack/compy_intel_impi.yaml
@@ -1,5 +1,5 @@
 spack:
-  specs: 
+  specs:
   - cmake
   - intel
   - intel-mpi
@@ -85,6 +85,7 @@ spack:
       - spec: intel@20.0.0
         prefix: /share/apps/intel/2020/compilers_and_libraries_2020.0.166
         modules:
+        - gcc/8.1.0
         - intel/20.0.0
       buildable: false
     intel-mpi:


### PR DESCRIPTION
This is necessary to get proper support for C++14.