### PR TITLE
Add modules for grizzly and cori-knl

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mache" %}
-{% set version = "1.3.0" %}
+{% set version = "1.3.1" %}
 
 package:
   name: {{ name|lower }}

--- a/mache/spack/__init__.py
+++ b/mache/spack/__init__.py
@@ -263,10 +263,13 @@ def get_modules_env_vars_and_mpi_compilers(machine, compiler, mpi, shell,
     machine_info = MachineInfo(machine)
 
     config = machine_info.config
-    section = config['spack']
+    if config.has_section('spack'):
+        section = config['spack']
 
-    with_modules = (section.getboolean('modules_before') or
-                    section.getboolean('modules_after'))
+        with_modules = (section.getboolean('modules_before') or
+                        section.getboolean('modules_after'))
+    else:
+        with_modules = False
 
     mod_env_commands = 'module purge\n'
     if with_modules:

--- a/mache/spack/chrysalis_intel_openmpi.yaml
+++ b/mache/spack/chrysalis_intel_openmpi.yaml
@@ -84,7 +84,7 @@ spack:
       - spec: openmpi@4.1.2
         prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/openmpi-4.1.2-k5epdq6
         modules:
-        - openmpi-4.1.2-k5epdq6
+        - openmpi/4.1.2-k5epdq6
       buildable: false
     intel-mkl:
       externals:

--- a/mache/spack/cori-knl_intel_impi.sh
+++ b/mache/spack/cori-knl_intel_impi.sh
@@ -1,0 +1,52 @@
+module rm craype
+module rm craype-mic-knl
+module rm craype-haswell
+module rm PrgEnv-intel
+module rm PrgEnv-cray
+module rm PrgEnv-gnu
+module rm intel
+module rm cce
+module rm gcc
+module rm cray-parallel-netcdf
+module rm cray-hdf5-parallel
+module rm pmi
+module rm cray-mpich2
+module rm cray-mpich
+module rm cray-netcdf
+module rm cray-hdf5
+module rm cray-netcdf-hdf5parallel
+module rm cray-libsci
+module rm papi
+module rm cmake
+module rm cray-petsc
+module rm esmf
+module rm zlib
+module rm craype-hugepages2M
+module rm darshan
+
+module load craype
+module load PrgEnv-intel
+module load cray-mpich
+module rm craype-haswell
+module load craype-mic-knl
+
+module swap cray-mpich impi/2020.up4
+
+module load PrgEnv-intel/6.0.10
+module rm intel
+module load intel/19.0.3.199
+
+module swap craype craype/2.6.2
+module rm pmi
+module load pmi/5.0.14
+module rm craype-haswell
+module load craype-mic-knl
+
+module rm cray-netcdf-hdf5parallel
+module load cray-netcdf-hdf5parallel/4.6.3.2
+module load cray-hdf5-parallel/1.10.5.2
+module load cray-parallel-netcdf/1.11.1.1
+
+module rm cmake
+module load cmake
+module load perl5-extras

--- a/mache/spack/grizzly_gnu_mvapich.sh
+++ b/mache/spack/grizzly_gnu_mvapich.sh
@@ -1,0 +1,16 @@
+export http_proxy=http://proxyout.lanl.gov:8080/
+export https_proxy=http://proxyout.lanl.gov:8080/
+export ftp_proxy=http://proxyout.lanl.gov:8080
+export HTTP_PROXY=http://proxyout.lanl.gov:8080
+export HTTPS_PROXY=http://proxyout.lanl.gov:8080
+export FTP_PROXY=http://proxyout.lanl.gov:8080
+
+module purge
+module load cmake/3.16.2
+module load gcc/6.4.0
+module load mvapich2/2.3
+module load friendly-testing
+module load hdf5-parallel/1.8.16
+module load pnetcdf/1.11.2
+module load netcdf-h5parallel/4.7.3
+module load mkl/2019.0.4

--- a/mache/spack/grizzly_intel_impi.sh
+++ b/mache/spack/grizzly_intel_impi.sh
@@ -1,0 +1,16 @@
+export http_proxy=http://proxyout.lanl.gov:8080/
+export https_proxy=http://proxyout.lanl.gov:8080/
+export ftp_proxy=http://proxyout.lanl.gov:8080
+export HTTP_PROXY=http://proxyout.lanl.gov:8080
+export HTTPS_PROXY=http://proxyout.lanl.gov:8080
+export FTP_PROXY=http://proxyout.lanl.gov:8080
+
+module purge
+module load cmake/3.16.2
+module load intel/19.0.4
+module load intel-mpi/2019.4
+module load friendly-testing
+module load hdf5-parallel/1.8.16
+module load pnetcdf/1.11.2
+module load netcdf-h5parallel/4.7.3
+module load mkl/2019.0.4

--- a/mache/version.py
+++ b/mache/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (1, 3, 0)
+__version_info__ = (1, 3, 1)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mache
-version = 1.3.0
+version = 1.3.1
 author = Xylar Asay-Davis
 author_email = xylar@lanl.gov
 description = A package for providing configuration data relate to E3SM supported machines


### PR DESCRIPTION
Although grizzly and cori-knl aren't supported under spack, this merge makes it possible to get compilers and module files in order to perform non-spack builds of libraries such as SCORPIO and ESMF.

This merge also fixes a typo in the yaml file for Chrysalis with Intel and OpenMPI.

The version of mache has been updated to 1.3.1 in anticipation of a bug-fix release.