### PR TITLE
Add missing env variable for compy

### DIFF
--- a/mache/spack/compy_intel_impi.csh
+++ b/mache/spack/compy_intel_impi.csh
@@ -1,0 +1,1 @@
+setenv LD_LIBRARY_PATH "/share/apps/gcc/8.1.0/lib:/share/apps/gcc/8.1.0/lib64:${LD_LIBRARY_PATH}"

--- a/mache/spack/compy_intel_impi.sh
+++ b/mache/spack/compy_intel_impi.sh
@@ -1,0 +1,1 @@
+export LD_LIBRARY_PATH="/share/apps/gcc/8.1.0/lib:/share/apps/gcc/8.1.0/lib64:${LD_LIBRARY_PATH}"


### PR DESCRIPTION
This merge brings in two missing paths in the Intel module on Compy that E3SM also explicitly adds.