### PR TITLE
Update Chrysalis Spack with new OpenMPI

### DIFF
--- a/mache/cime_machine_config/config_machines.xml
+++ b/mache/cime_machine_config/config_machines.xml
@@ -55,6 +55,113 @@
      This allows using a different mpirun command to launch unit tests
 
   -->
+
+
+
+  <machine MACH="miller">
+    <DESC> ORNL AF cluster 800-node AMD Epyc 2-sockets 64-cores per node</DESC>
+    <OS>CNL</OS>
+    <COMPILERS>gnu,cray,intel</COMPILERS>
+    <MPILIBS>mpt</MPILIBS>
+    <PROJECT>nwp501</PROJECT>
+    <SAVE_TIMING_DIR>/lustre/storm/nwp501/proj-shared/e3sm</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR_PROJECTS>e3sm,nwp501</SAVE_TIMING_DIR_PROJECTS>
+    <CIME_OUTPUT_ROOT>/lustre/storm/nwp501/proj-shared/e3sm/e3sm_scratch/</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/lustre/storm/nwp501/proj-shared/e3sm/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/lustre/storm/nwp501/proj-shared/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/lustre/storm/nwp501/proj-shared/e3sm/baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/lustre/storm/nwp501/proj-shared/e3sm/tools/cprnc</CCSM_CPRNC>
+    <GMAKE_J>8</GMAKE_J>
+    <TESTS>e3sm_developer</TESTS>
+    <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
+    <BATCH_SYSTEM>miller_slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>e3sm</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
+    <mpirun mpilib="default">
+      <executable>srun</executable>
+      <arguments>
+        <arg name="num_tasks">-n {{ total_tasks }} -N {{ num_nodes }} --kill-on-bad-exit </arg>
+        <arg name="thread_count">-c $SHELL{echo 128/ {{ tasks_per_node }} |bc}</arg>
+        <arg name="binding"> $SHELL{if [ 128 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
+        <arg name="placement">-m plane={{ tasks_per_node }}</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="perl">/opt/cray/pe/modules/default/init/perl.pm</init_path>
+      <init_path lang="python">/opt/cray/pe/modules/default/init/python.py</init_path>
+      <init_path lang="sh">/opt/cray/pe/modules/default/init/sh</init_path>
+      <init_path lang="csh">/opt/cray/pe/modules/default/init/csh</init_path>
+      <cmd_path lang="perl">/opt/cray/pe/modules/default/bin/modulecmd perl</cmd_path>
+      <cmd_path lang="python">/opt/cray/pe/modules/default/bin/modulecmd python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <modules>
+        <command name="unload">craype</command>
+        <command name="unload">cray-mpich</command>
+        <command name="unload">cray-parallel-netcdf</command>
+        <command name="unload">cray-hdf5-parallel</command>
+        <command name="unload">cray-hdf5</command>
+        <command name="unload">cray-netcdf</command>
+        <command name="unload">cray-netcdf-hdf5parallel</command>
+        <command name="load">craype/2.7.12</command>
+      </modules>
+      <modules compiler="intel">
+        <command name="rm">PrgEnv-gnu</command>
+        <command name="rm">PrgEnv-cray</command>
+        <command name="load">PrgEnv-intel/8.1.0</command>
+        <command name="swap">intel/19.1.0.166</command>
+      </modules>
+      <modules compiler="gnu">
+        <command name="unload">PrgEnv-cray</command>
+        <command name="load">PrgEnv-gnu/8.1.0</command>
+        <command name="swap">gcc/9.3.0</command>
+      </modules>
+      <modules compiler="cray">
+        <command name="unload">PrgEnv-intel</command>
+        <command name="unload">PrgEnv-gnu</command>
+        <command name="load">gcc/9.3.0</command>
+        <command name="load">PrgEnv-cray/8.1.0</command>
+        <command name="rm">darshan</command>
+      </modules>
+      <modules compiler="!intel">
+        <command name="swap">cray-libsci/21.06.1.1</command>
+      </modules>
+      <modules>
+        <command name="load">cray-mpich/8.1.11</command>
+        <command name="load">cray-hdf5-parallel/1.12.0.7</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.7.4.7</command>
+        <command name="load">cray-parallel-netcdf/1.12.1.7</command>
+      </modules>
+    </module_system>
+
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+    <MAX_GB_OLD_TEST_DATA>1000</MAX_GB_OLD_TEST_DATA>
+    <environment_variables>
+      <env name="PERL5LIB">/usr/lib/perl5/5.26.1</env>
+      <env name="NETCDF_C_PATH">opt/cray/pe/netcdf-hdf5parallel/4.7.4.4/gnu/9.1/</env>
+      <env name="NETCDF_FORTRAN_PATH">opt/cray/pe/netcdf-hdf5parallel/4.7.4.4/gnu/9.1/</env>
+      <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
+    </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE">
+      <env name="OMP_STACKSIZE">128M</env>
+    </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE" compiler="intel" MAX_TASKS_PER_NODE="!128">
+      <env name="KMP_AFFINITY">granularity=core,balanced</env>
+    </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE" compiler="intel" MAX_TASKS_PER_NODE="128">
+      <env name="KMP_AFFINITY">granularity=thread,balanced</env>
+    </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE" compiler="gnu">
+      <env name="OMP_PLACES">cores</env>
+    </environment_variables>
+  </machine>
+
+
   <machine MACH="perlmutter">
     <DESC>Perlmutter at NERSC.  Phase1 only: Each GPU node has single AMD EPYC 7713 64-Core (Milan) and 4 nvidia A100's.</DESC>
     <NODENAME_REGEX>$ENV{NERSC_HOST}:perlmutter</NODENAME_REGEX>
@@ -164,12 +271,17 @@
     <environment_variables>
       <env name="MPICH_ENV_DISPLAY">1</env>
       <env name="MPICH_VERSION_DISPLAY">1</env>
-      <!--env name="MPICH_GPU_SUPPORT_ENABLED">1</env-->
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
+    </environment_variables>
+    <environment_variables compiler="gnugpu">
+      <env name="MPICH_GPU_SUPPORT_ENABLED">1</env>
+    </environment_variables>
+    <environment_variables compiler="nvidiagpu">
+      <env name="MPICH_GPU_SUPPORT_ENABLED">1</env>
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>
@@ -1148,12 +1260,12 @@
     </environment_variables>
   </machine>
 
-  <machine MACH="anlgce">
-    <DESC>ANL CELS General Computing Environment (Linux) workstation</DESC>
-    <NODENAME_REGEX>compute-(240|386)-[0-9][0-9]</NODENAME_REGEX>
+  <machine MACH="anlgce-ub18">
+    <DESC>ANL CELS General Computing Environment (Linux) workstation (Ubuntu 18.04)</DESC>
+    <NODENAME_REGEX>compute-386-01|compute-386-02</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>gnu</COMPILERS>
-    <MPILIBS>mpich</MPILIBS>
+    <MPILIBS>mpich,openmpi</MPILIBS>
     <SAVE_TIMING_DIR>/scratch/$ENV{USER}/e3sm/timings</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
     <CIME_OUTPUT_ROOT>/scratch/$ENV{USER}/e3sm/scratch</CIME_OUTPUT_ROOT>
@@ -1173,6 +1285,12 @@
       <executable>mpirun</executable>
       <arguments>
         <arg name="num_tasks"> -l -np {{ total_tasks }}</arg>
+      </arguments>
+    </mpirun>
+    <mpirun mpilib="openmpi">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="num_tasks"> --oversubscribe -np {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1211,6 +1329,102 @@
       <env name="HDF5_PATH">/nfs/gce/projects/climate/software/hdf5/1.12.1/mpich-3.4.2/gcc-11.1.0</env>
       <env name="NETCDF_PATH">/nfs/gce/projects/climate/software/netcdf/4.8.0c-4.3.1cxx-4.5.3f-parallel/mpich-3.4.2/gcc-11.1.0</env>
       <env name="PNETCDF_PATH">/nfs/gce/projects/climate/software/pnetcdf/1.12.2/mpich-3.4.2/gcc-11.1.0</env>
+    </environment_variables>
+    <environment_variables mpilib="openmpi">
+      <!-- We currently don't have modules for HDF5, NetCDF & PnetCDF -->
+      <env name="LD_LIBRARY_PATH">/nfs/gce/projects/climate/software/openmpi/4.1.3/gcc-11.1.0/lib:$ENV{LD_LIBRARY_PATH}</env>
+      <env name="PATH">/nfs/gce/projects/climate/software/openmpi/4.1.3/gcc-11.1.0/bin:$ENV{PATH}</env>
+      <env name="ZLIB_PATH">/nfs/gce/software/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.11-smoyzzo</env>
+      <env name="HDF5_PATH">/nfs/gce/projects/climate/software/hdf5/1.12.1/openmpi-4.1.3/gcc-11.1.0</env>
+      <env name="NETCDF_PATH">/nfs/gce/projects/climate/software/netcdf/4.8.0c-4.3.1cxx-4.5.3f-parallel/openmpi-4.1.3/gcc-11.1.0</env>
+      <env name="PNETCDF_PATH">/nfs/gce/projects/climate/software/pnetcdf/1.12.2/openmpi-4.1.3/gcc-11.1.0</env>
+    </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE">
+      <env name="OMP_STACKSIZE">64M</env>
+    </environment_variables>
+    <environment_variables>
+      <env name="PERL5LIB">/nfs/gce/projects/climate/software/perl5/lib/perl5</env>
+    </environment_variables>
+  </machine>
+
+  <machine MACH="anlgce">
+    <DESC>ANL CELS General Computing Environment (Linux) workstation</DESC>
+    <NODENAME_REGEX>compute-(240|386)-[0-9][0-9]</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>gnu</COMPILERS>
+    <MPILIBS>mpich,openmpi</MPILIBS>
+    <SAVE_TIMING_DIR>/scratch/$ENV{USER}/e3sm/timings</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
+    <CIME_OUTPUT_ROOT>/scratch/$ENV{USER}/e3sm/scratch</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/nfs/gce/projects/climate/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>$DIN_LOC_ROOT/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/nfs/gce/projects/climate/e3sm/baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/nfs/gce/projects/climate/e3sm/cprnc/build/cprnc</CCSM_CPRNC>
+    <GMAKE>make</GMAKE>
+    <GMAKE_J>8</GMAKE_J>
+    <TESTS>e3sm_developer</TESTS>
+    <BATCH_SYSTEM>none</BATCH_SYSTEM>
+    <SUPPORTED_BY>jayesh at mcs dot anl dot gov</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
+    <mpirun mpilib="mpich">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="num_tasks"> -l -np {{ total_tasks }}</arg>
+      </arguments>
+    </mpirun>
+    <mpirun mpilib="openmpi">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="num_tasks"> --oversubscribe -np {{ total_tasks }}</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="python">/nfs/gce/software/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/lmod-8.3-6fjdtku/lmod/lmod/init/env_modules_python.py</init_path>
+      <init_path lang="perl">/nfs/gce/software/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/lmod-8.3-6fjdtku/lmod/lmod/init/perl</init_path>
+      <init_path lang="bash">/nfs/gce/software/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/lmod-8.3-6fjdtku/lmod/lmod/init/bash</init_path>
+      <init_path lang="sh">/nfs/gce/software/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/lmod-8.3-6fjdtku/lmod/lmod/init/sh</init_path>
+      <init_path lang="csh">/nfs/gce/software/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/lmod-8.3-6fjdtku/lmod/lmod/init/csh</init_path>
+      <cmd_path lang="python">/nfs/gce/software/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/lmod-8.3-6fjdtku/lmod/lmod/libexec/lmod python</cmd_path>
+      <cmd_path lang="perl">module</cmd_path>
+      <cmd_path lang="bash">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <modules>
+        <command name="purge"/>
+        <command name="load">autoconf/2.69-bmnwajj</command>
+        <command name="load">automake/1.16.3-r7w24o4</command>
+        <command name="load">libtool/2.4.6-uh3mpsu</command>
+        <command name="load">m4/1.4.19-7fztfyz</command>
+        <command name="load">cmake/3.20.5-zyz2eld</command>
+        <command name="load">gcc/11.1.0-qsjmpcg</command>
+        <command name="load">zlib/1.2.11-p7dmb5p</command>
+      </modules>
+    </module_system>
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <environment_variables mpilib="mpi-serial">
+      <!-- We currently don't have modules for serial NetCDF -->
+      <env name="NETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/netcdf/4.8.0c-4.3.1cxx-4.5.3f-serial/gcc-11.1.0</env>
+    </environment_variables>
+    <environment_variables mpilib="mpich">
+      <!-- We currently don't have modules for HDF5, NetCDF & PnetCDF -->
+      <env name="LD_LIBRARY_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/mpich/4.0/gcc-11.1.0/lib:$ENV{LD_LIBRARY_PATH}</env>
+      <env name="PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/mpich/4.0/gcc-11.1.0/bin:$ENV{PATH}</env>
+      <env name="ZLIB_PATH">/nfs/gce/software/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/zlib-1.2.11-p7dmb5p</env>
+      <env name="HDF5_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/hdf5/1.12.1/mpich-4.0/gcc-11.1.0</env>
+      <env name="NETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/netcdf/4.8.0c-4.3.1cxx-4.5.3f-parallel/mpich-4.0/gcc-11.1.0</env>
+      <env name="PNETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/pnetcdf/1.12.2/mpich-4.0/gcc-11.1.0</env>
+    </environment_variables>
+    <environment_variables mpilib="openmpi">
+      <!-- We currently don't have modules for HDF5, NetCDF & PnetCDF -->
+      <env name="LD_LIBRARY_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/openmpi/4.1.3/gcc-11.1.0/lib:$ENV{LD_LIBRARY_PATH}</env>
+      <env name="PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/openmpi/4.1.3/gcc-11.1.0/bin:$ENV{PATH}</env>
+      <env name="ZLIB_PATH">/nfs/gce/software/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/zlib-1.2.11-p7dmb5p</env>
+      <env name="HDF5_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/hdf5/1.12.1/openmpi-4.1.3/gcc-11.1.0</env>
+      <env name="NETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/netcdf/4.8.0c-4.3.1cxx-4.5.3f-parallel/openmpi-4.1.3/gcc-11.1.0</env>
+      <env name="PNETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/pnetcdf/1.12.2/openmpi-4.1.3/gcc-11.1.0</env>
     </environment_variables>
     <environment_variables SMP_PRESENT="TRUE">
       <env name="OMP_STACKSIZE">64M</env>
@@ -1549,12 +1763,12 @@
         <command name="load">intel-mkl/2020.4.304-g2qaxzf</command>
       </modules>
       <modules compiler="intel" mpilib="openmpi">
-        <command name="load">openmpi/4.1.2-k5epdq6</command>
-        <command name="load">hdf5/1.8.16-kyyksst</command>
-        <command name="load">netcdf-c/4.4.1-rrkbpws</command>
-        <command name="load">netcdf-cxx/4.2-2hotooj</command>
-        <command name="load">netcdf-fortran/4.4.4-znpfscr</command>
-        <command name="load">parallel-netcdf/1.11.0-c6fn7rw</command>
+        <command name="load">openmpi/4.1.3-pin4k7o</command>
+        <command name="load">hdf5/1.10.7-eewgp6v</command>
+        <command name="load">netcdf-c/4.4.1-ihoo4zq</command>
+        <command name="load">netcdf-cxx/4.2-soitsxm</command>
+        <command name="load">netcdf-fortran/4.4.4-tplolxh</command>
+        <command name="load">parallel-netcdf/1.11.0-gvcfihh</command>
       </modules>
       <modules compiler="intel" mpilib="impi">
         <command name="load">intel-mpi/2019.9.304-tkzvizk</command>
@@ -1569,12 +1783,12 @@
         <command name="load">intel-mkl/2020.4.304-n3b5fye</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi">
-        <command name="load">openmpi/4.1.2-zdskwit</command>
-        <command name="load">hdf5/1.8.16-oh66njw</command>
-        <command name="load">netcdf-c/4.4.1-54pwnbt</command>
-        <command name="load">netcdf-cxx/4.2-zgdnfys</command>
-        <command name="load">netcdf-fortran/4.4.4-fkyjosv</command>
-        <command name="load">parallel-netcdf/1.11.0-x6vnnuz</command>
+        <command name="load">openmpi/4.1.3-sxfyy4k</command>
+        <command name="load">hdf5/1.10.7-j3zxncu</command>
+        <command name="load">netcdf-c/4.4.1-7ohuiwq</command>
+        <command name="load">netcdf-cxx/4.2-tkg465k</command>
+        <command name="load">netcdf-fortran/4.4.4-k2zu3y5</command>
+        <command name="load">parallel-netcdf/1.11.0-mirrcz7</command>
       </modules>
       <modules compiler="gnu" mpilib="impi">
         <command name="load">intel-mpi/2019.9.304-jdih7h5</command>
@@ -3148,10 +3362,9 @@
         <command name="load">cmake/3.20.2</command>
         <command name="load">essl/6.3.0</command>
         <command name="load">netlib-lapack/3.8.0</command>
-        <command name="list"/>
       </modules>
       <modules compiler="pgi.*">
-        <command name="load">nvhpc/21.3</command>
+        <command name="load">nvhpc/21.11</command>
       </modules>
       <modules compiler="pgigpu">
         <command name="load">cuda/10.1.243</command>
@@ -3286,7 +3499,7 @@
         <command name="load">netlib-lapack/3.9.1</command>
       </modules>
       <modules compiler="pgi.*">
-        <command name="load">nvhpc/20.9</command>
+        <command name="load">nvhpc/21.11</command>
       </modules>
       <modules compiler="ibmgpu">
         <command name="load">cuda/10.1.243</command>
@@ -3311,6 +3524,7 @@
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+    <MAX_GB_OLD_TEST_DATA>9000</MAX_GB_OLD_TEST_DATA>
     <environment_variables>
       <env name="PATH">/gpfs/wolf/cli115/world-shared/e3sm/soft/perl/5.26.0/bin:$ENV{PATH}</env>
       <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
@@ -3574,6 +3788,82 @@
     <environment_variables SMP_PRESENT="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PLACES">threads</env>
+    </environment_variables>
+  </machine>
+
+  <machine MACH="fugaku">
+    <DESC>RIKEN-CCS Fugaku: Fujitsu A64FX 48 cores/node.</DESC>
+    <NODENAME_REGEX>fn01sv.*</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>gnu,fj</COMPILERS>
+    <MPILIBS>fujitsu</MPILIBS>
+    <PROJECT>hp210190</PROJECT>
+    <SAVE_TIMING_DIR>/data/hp210190/</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
+    <CIME_OUTPUT_ROOT>/data/hp210190/$USER/scratch</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/data/hp210190/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/data/hp210190/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>/data/hp210190/$USER/scratch/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/data/hp210190/baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/data/hp210190/tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>8</GMAKE_J>
+    <TESTS>e3sm_integration</TESTS>
+    <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
+    <BATCH_SYSTEM>moab</BATCH_SYSTEM>
+    <SUPPORTED_BY>E3SM</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>48</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>48</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
+    <mpirun mpilib="default">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="num_tasks">-n {{ total_tasks }} -std e3sm.log.$LID </arg>
+      </arguments>
+    </mpirun>
+    <module_system type="soft">
+      <init_path lang="sh">/vol0003/hp210190/data/soft/spack-v0.17.0/share/spack/setup-env.sh</init_path>
+      <init_path lang="csh">/vol0003/hp210190/data/soft/spack-v0.17.0/share/spack/setup-env.csh</init_path>
+      <cmd_path lang="csh">spack</cmd_path>
+      <cmd_path lang="sh">spack</cmd_path>
+      <modules compiler="gnu">
+        <command name="unload">--all</command>
+        <command name="load">gcc @11.2.0%gcc@8.4.1  arch=linux-rhel8-a64fx</command>
+        <command name="load">fujitsu-mpi @head%gcc@11.2.0  arch=linux-rhel8-a64fx</command>
+        <command name="find">--loaded;ln -sf /lib64/libhwloc.so.15 /tmp/libhwloc.so.5</command>
+      </modules>
+      <modules compiler="fj">
+        <command name="unload">--all</command>
+        <command name="load">netcdf-c       @4.8.1 %fj@4.7.0 arch=linux-rhel8-a64fx</command>
+        <command name="load">netcdf-cxx     @4.2   %fj@4.7.0 arch=linux-rhel8-a64fx</command>
+        <command name="load">netcdf-fortran @4.5.3 %fj@4.7.0 arch=linux-rhel8-a64fx</command>
+        <command name="load">parallel-netcdf@1.12.2%fj@4.7.0 arch=linux-rhel8-a64fx</command>
+        <command name="load">netlib-lapack  @3.9.1 %fj@4.7.0 arch=linux-rhel8-a64fx</command>
+        <command name="find">--loaded</command>
+      </modules>
+    </module_system>
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+    <MAX_GB_OLD_TEST_DATA>1000</MAX_GB_OLD_TEST_DATA>
+    <environment_variables>
+      <env name="PERL5LIB">/data/hp210190/soft/perl5/lib/perl5:/home/hp210190/u02380/perl5/lib/perl5</env>
+      <env name="OMPI_MCA_plm_ple_numanode_assign_policy">share_band</env>
+    </environment_variables>
+    <environment_variables compiler="gnu">
+      <env name="NETCDF_PATH">/data/hp210190/soft/netcdf/4.4.1c-4.2cxx-4.4.4f/gcc8.3.1</env>
+      <env name="LAPACK_PATH">/data/hp210190/soft/spack-v0.16/opt/spack/linux-rhel8-a64fx/gcc-8.3.1/netlib-lapack-3.8.0-jhmofiqoky6ajxmda5caawfhqnrirmm5</env>
+      <env name="LD_LIBRARY_PATH">/tmp:/data/hp210190/soft/spack-v0.16/opt/spack/linux-rhel8-a64fx/gcc-8.3.1/netlib-lapack-3.8.0-jhmofiqoky6ajxmda5caawfhqnrirmm5/lib64:$ENV{LD_LIBRARY_PATH}</env>
+    </environment_variables>
+    <environment_variables compiler="fj">
+      <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
+      <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
+      <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
+    </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE">
+      <env name="OMP_STACKSIZE">128M</env>
+    </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE" compiler="gnu">
+      <env name="OMP_PLACES">cores</env>
     </environment_variables>
   </machine>
 

--- a/mache/spack/chrysalis_gnu_openmpi.yaml
+++ b/mache/spack/chrysalis_gnu_openmpi.yaml
@@ -16,7 +16,7 @@ spack:
     all:
       compiler: [gcc@9.2.0]
       providers:
-        mpi: [openmpi@4.1.2]
+        mpi: [openmpi@4.1.3]
         lapack: [intel-mkl@2020.4.304]
     bzip2:
       externals:
@@ -81,10 +81,10 @@ spack:
       buildable: false
     openmpi:
       externals:
-      - spec: openmpi@4.1.2
-        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.2.0/openmpi-4.1.2-zdskwit
+      - spec: openmpi@4.1.3
+        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.2.0/openmpi-4.1.3-sxfyy4k
         modules:
-        - openmpi/4.1.2-zdskwit
+        - openmpi/4.1.3-sxfyy4k
       buildable: false
     intel-mkl:
       externals:
@@ -96,31 +96,31 @@ spack:
 {% if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
-      - spec: hdf5@1.8.16+cxx+fortran+hl+mpi
-        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.2.0/hdf5-1.8.16-oh66njw
+      - spec: hdf5@1.10.7+cxx+fortran+hl+mpi
+        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.2.0/hdf5-1.10.7-j3zxncu
         modules:
-        - hdf5/1.8.16-oh66njw
+        - hdf5/1.10.7-j3zxncu
       buildable: false
     netcdf-c:
       externals:
       - spec: netcdf-c@4.4.1+mpi~parallel-netcdf
-        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.2.0/netcdf-c-4.4.1-54pwnbt
+        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.2.0/netcdf-c-4.4.1-7ohuiwq
         modules:
-        - netcdf-c/4.4.1-54pwnbt
+        - netcdf-c/4.4.1-7ohuiwq
       buildable: false
     netcdf-fortran:
       externals:
       - spec: netcdf-fortran@4.4.4
-        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.2.0/netcdf-fortran-4.4.4-fkyjosv
+        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.2.0/netcdf-fortran-4.4.4-k2zu3y5
         modules:
-        - netcdf-fortran/4.4.4-fkyjosv
+        - netcdf-fortran/4.4.4-k2zu3y5
       buildable: false
     parallel-netcdf:
       externals:
       - spec: parallel-netcdf@1.11.0+cxx+fortran
-        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.2.0/parallel-netcdf-1.11.0-x6vnnuz
+        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.2.0/parallel-netcdf-1.11.0-mirrcz7
         modules:
-        - parallel-netcdf/1.11.0-x6vnnuz
+        - parallel-netcdf/1.11.0-mirrcz7
       buildable: false
 {% endif %}
   config:

--- a/mache/spack/chrysalis_intel_openmpi.yaml
+++ b/mache/spack/chrysalis_intel_openmpi.yaml
@@ -16,7 +16,7 @@ spack:
     all:
       compiler: [intel@20.0.4]
       providers:
-        mpi: [openmpi@4.1.2]
+        mpi: [openmpi@4.1.3]
         lapack: [intel-mkl@2020.4.304]
     bzip2:
       externals:
@@ -81,10 +81,10 @@ spack:
       buildable: false
     openmpi:
       externals:
-      - spec: openmpi@4.1.2
-        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/openmpi-4.1.2-k5epdq6
+      - spec: openmpi@4.1.3
+        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/openmpi-4.1.3-pin4k7o
         modules:
-        - openmpi/4.1.2-k5epdq6
+        - openmpi/4.1.3-pin4k7o
       buildable: false
     intel-mkl:
       externals:
@@ -96,31 +96,31 @@ spack:
 {% if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
-      - spec: hdf5@1.8.16+cxx+fortran+hl+mpi
-        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/hdf5-1.8.16-kyyksst
+      - spec: hdf5@1.10.7+cxx+fortran+hl+mpi
+        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/hdf5-1.10.7-eewgp6v
         modules:
-        - hdf5/1.8.16-kyyksst
+        - hdf5/1.10.7-eewgp6v
       buildable: false
     netcdf-c:
       externals:
       - spec: netcdf-c@4.4.1+mpi~parallel-netcdf
-        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/netcdf-c-4.4.1-rrkbpws
+        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/netcdf-c-4.4.1-ihoo4zq
         modules:
-        - netcdf-c/4.4.1-rrkbpws
+        - netcdf-c/4.4.1-ihoo4zq
       buildable: false
     netcdf-fortran:
       externals:
       - spec: netcdf-fortran@4.4.4
-        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/netcdf-fortran-4.4.4-znpfscr
+        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/netcdf-fortran-4.4.4-tplolxh
         modules:
-        - netcdf-fortran/4.4.4-znpfscr
+        - netcdf-fortran/4.4.4-tplolxh
       buildable: false
     parallel-netcdf:
       externals:
       - spec: parallel-netcdf@1.11.0+cxx+fortran
-        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/parallel-netcdf-1.11.0-c6fn7rw
+        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/parallel-netcdf-1.11.0-gvcfihh
         modules:
-        - parallel-netcdf/1.11.0-c6fn7rw
+        - parallel-netcdf/1.11.0-gvcfihh
       buildable: false
 {% endif %}
   config:


### PR DESCRIPTION
This merge updates `config_machines.xml` from `E3SM/master`, which changes the version of OpenMPI on Chrysalis (among other changes unrelated to `mache`).

This merge also updates the Spack templates for Chrysalis to use the new OpenMPI and related modules.

Related E3SM PR:
https://github.com/E3SM-Project/E3SM/pull/4890