### PR TITLE
Change `configuration` to `constraint` in Slurm

### DIFF
--- a/mache/machine_info.py
+++ b/mache/machine_info.py
@@ -176,9 +176,9 @@ class MachineInfo:
             The default partition on the machine, or ``None`` if no partition
             should be specified
 
-        configuration : str
-            The default configuration on the machine, or ``None`` if no
-            configuration should be specified
+        constraint : str
+            The default constraint on the machine, or ``None`` if no
+            constraint should be specified
 
         qos : str
             The default quality of service on the machine, or ``None`` if no
@@ -197,12 +197,12 @@ class MachineInfo:
         else:
             partition = None
 
-        if config.has_option('parallel', 'configurations'):
-            configuration = config.get('parallel', 'configurations')
+        if config.has_option('parallel', 'constraints'):
+            constraint = config.get('parallel', 'constraints')
             # take the first entry
-            configuration = configuration.split(',')[0].strip()
+            constraint = constraint.split(',')[0].strip()
         else:
-            configuration = None
+            constraint = None
 
         if config.has_option('parallel', 'qos'):
             qos = config.get('parallel', 'qos')
@@ -211,7 +211,7 @@ class MachineInfo:
         else:
             qos = None
 
-        return account, partition, configuration, qos
+        return account, partition, constraint, qos
 
     def _get_config(self):
         """ get a parser for config options """

--- a/mache/machines/cori-haswell.cfg
+++ b/mache/machines/cori-haswell.cfg
@@ -49,8 +49,8 @@ cores_per_node = 32
 # account for running diagnostics jobs
 account = e3sm
 
-# available configurations(s) (default is the first)
-configurations = haswell
+# available constraint(s) (default is the first)
+constraints = haswell
 
 # quality of service (default is the first)
 qos = regular, premium, debug

--- a/mache/machines/cori-knl.cfg
+++ b/mache/machines/cori-knl.cfg
@@ -43,8 +43,8 @@ cores_per_node = 68
 # account for running diagnostics jobs
 account = e3sm
 
-# available configurations(s) (default is the first)
-configurations = knl
+# available constraint(s) (default is the first)
+constraints = knl
 
 # quality of service (default is the first)
 qos = regular, premium, debug


### PR DESCRIPTION
It should have been `constraint` in the first place because this is the term used in Slurm.