### PR TITLE
Make LAPACK from E3SM optional in Spack builds

### DIFF
--- a/mache/spack/anvil_gnu_mvapich.yaml
+++ b/mache/spack/anvil_gnu_mvapich.yaml
@@ -1,9 +1,11 @@
 spack:
-  specs: 
+  specs:
   - cmake
   - gcc
   - mvapich2
+{% if e3sm_lapack %}
   - intel-mkl
+{% endif %}
 {% if e3sm_hdf5_netcdf %}
   - netcdf-c
   - netcdf-fortran
@@ -16,7 +18,9 @@ spack:
       compiler: [gcc@8.2.0]
       providers:
         mpi: [mvapich2@4.1.1]
+{% if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
+{% endif %}
     bison:
       externals:
       - spec: bison@3.0.4

--- a/mache/spack/anvil_gnu_openmpi.yaml
+++ b/mache/spack/anvil_gnu_openmpi.yaml
@@ -1,9 +1,11 @@
 spack:
-  specs: 
+  specs:
   - cmake
   - gcc
   - openmpi
+{% if e3sm_lapack %}
   - intel-mkl
+{% endif %}
 {% if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
@@ -17,7 +19,9 @@ spack:
       compiler: [gcc@8.2.0]
       providers:
         mpi: [openmpi@4.1.1]
+{% if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
+{% endif %}
     bison:
       externals:
       - spec: bison@3.0.4

--- a/mache/spack/anvil_intel_impi.yaml
+++ b/mache/spack/anvil_intel_impi.yaml
@@ -3,7 +3,9 @@ spack:
   - cmake
   - intel
   - intel-mpi
+{% if e3sm_lapack %}
   - intel-mkl
+{% endif %}
 {% if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
@@ -17,7 +19,9 @@ spack:
       compiler: [intel@20.0.4]
       providers:
         mpi: [intel-mpi@2019.9.304]
+{% if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
+{% endif %}
     bison:
       externals:
       - spec: bison@3.0.4

--- a/mache/spack/anvil_intel_mvapich.yaml
+++ b/mache/spack/anvil_intel_mvapich.yaml
@@ -3,7 +3,9 @@ spack:
   - cmake
   - intel
   - mvapich2
+{% if e3sm_lapack %}
   - intel-mkl
+{% endif %}
 {% if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
@@ -17,7 +19,9 @@ spack:
       compiler: [intel@20.0.4]
       providers:
         mpi: [mvapich2@4.1.1]
+{% if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
+{% endif %}
     bison:
       externals:
       - spec: bison@3.0.4

--- a/mache/spack/anvil_intel_openmpi.yaml
+++ b/mache/spack/anvil_intel_openmpi.yaml
@@ -3,7 +3,9 @@ spack:
   - cmake
   - intel
   - openmpi
+{% if e3sm_lapack %}
   - intel-mkl
+{% endif %}
 {% if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
@@ -17,7 +19,9 @@ spack:
       compiler: [intel@20.0.4]
       providers:
         mpi: [openmpi@4.1.1]
+{% if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
+{% endif %}
     bison:
       externals:
       - spec: bison@3.0.4

--- a/mache/spack/badger_gnu_mvapich.yaml
+++ b/mache/spack/badger_gnu_mvapich.yaml
@@ -3,7 +3,9 @@ spack:
   - cmake
   - gcc
   - mvapich2
+{% if e3sm_lapack %}
   - intel-mkl
+{% endif %}
 {% if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
@@ -17,7 +19,9 @@ spack:
       compiler: [gcc@6.4.0]
       providers:
         mpi: [mvapich2@2.3]
+{% if e3sm_lapack %}
         lapack: [intel-mkl@2019.0.4]
+{% endif %}
     bzip2:
       externals:
       - spec: bzip2@1.0.6

--- a/mache/spack/badger_intel_impi.yaml
+++ b/mache/spack/badger_intel_impi.yaml
@@ -3,7 +3,9 @@ spack:
   - cmake
   - intel
   - intel-mpi
+{% if e3sm_lapack %}
   - intel-mkl
+{% endif %}
 {% if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
@@ -17,7 +19,9 @@ spack:
       compiler: [intel@19.0.4]
       providers:
         mpi: [intel-mpi@2019.4.243]
+{% if e3sm_lapack %}
         lapack: [intel-mkl@2019.0.4]
+{% endif %}
     bzip2:
       externals:
       - spec: bzip2@1.0.6

--- a/mache/spack/chrysalis_gnu_openmpi.yaml
+++ b/mache/spack/chrysalis_gnu_openmpi.yaml
@@ -3,7 +3,9 @@ spack:
   - cmake
   - gcc
   - openmpi
+{% if e3sm_lapack %}
   - intel-mkl
+{% endif %}
 {% if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
@@ -17,7 +19,9 @@ spack:
       compiler: [gcc@9.2.0]
       providers:
         mpi: [openmpi@4.1.3]
+{% if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
+{% endif %}
     bzip2:
       externals:
       - spec: bzip2@1.0.8

--- a/mache/spack/chrysalis_intel_impi.yaml
+++ b/mache/spack/chrysalis_intel_impi.yaml
@@ -1,9 +1,11 @@
 spack:
-  specs: 
+  specs:
   - cmake
   - intel
   - intel-mpi
+{% if e3sm_lapack %}
   - intel-mkl
+{% endif %}
 {% if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
@@ -17,7 +19,9 @@ spack:
       compiler: [intel@20.0.4]
       providers:
         mpi: [intel-mpi@2019.9.304]
+{% if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
+{% endif %}
     bzip2:
       externals:
       - spec: bzip2@1.0.8

--- a/mache/spack/chrysalis_intel_openmpi.yaml
+++ b/mache/spack/chrysalis_intel_openmpi.yaml
@@ -3,7 +3,9 @@ spack:
   - cmake
   - intel
   - openmpi
+{% if e3sm_lapack %}
   - intel-mkl
+{% endif %}
 {% if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
@@ -17,7 +19,9 @@ spack:
       compiler: [intel@20.0.4]
       providers:
         mpi: [openmpi@4.1.3]
+{% if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
+{% endif %}
     bzip2:
       externals:
       - spec: bzip2@1.0.8

--- a/mache/spack/compy_intel_impi.yaml
+++ b/mache/spack/compy_intel_impi.yaml
@@ -3,7 +3,9 @@ spack:
   - cmake
   - intel
   - intel-mpi
+{% if e3sm_lapack %}
   - intel-mkl
+{% endif %}
 {% if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
@@ -17,7 +19,9 @@ spack:
       compiler: [intel@20.0.0]
       providers:
         mpi: [intel-mpi@2020.0.166]
+{% if e3sm_lapack %}
         lapack: [intel-mkl@2020.0.166]
+{% endif %}
     bison:
       externals:
       - spec: bison@3.0.4

--- a/mache/spack/cori-haswell_gnu_mpt.csh
+++ b/mache/spack/cori-haswell_gnu_mpt.csh
@@ -34,7 +34,9 @@ module swap PrgEnv-intel PrgEnv-gnu/6.0.10
 module rm gcc
 module load gcc/10.3.0
 module rm cray-libsci
+{% if e3sm_lapack %}
 module load cray-libsci/20.09.1
+{% endif %}
 module swap craype craype/2.6.2
 module rm pmi
 module load pmi/5.0.14

--- a/mache/spack/cori-haswell_gnu_mpt.sh
+++ b/mache/spack/cori-haswell_gnu_mpt.sh
@@ -34,7 +34,9 @@ module swap PrgEnv-intel PrgEnv-gnu/6.0.10
 module rm gcc
 module load gcc/10.3.0
 module rm cray-libsci
+{% if e3sm_lapack %}
 module load cray-libsci/20.09.1
+{% endif %}
 module swap craype craype/2.6.2
 module rm pmi
 module load pmi/5.0.14

--- a/mache/spack/cori-haswell_gnu_mpt.yaml
+++ b/mache/spack/cori-haswell_gnu_mpt.yaml
@@ -3,7 +3,9 @@ spack:
   - cmake
   - gcc
   - mpich
+{% if e3sm_lapack %}
   - cray-libsci
+{% endif %}
 {% if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
@@ -19,7 +21,9 @@ spack:
       compiler: [gcc@10.3.0]
       providers:
         mpi: [mpich@7.7.10]
+{% if e3sm_lapack %}
         lapack: [cray-libsci@20.09.1]
+{% endif %}
       target:
       - haswell
     bzip2:

--- a/mache/spack/cori-haswell_intel_mpt.yaml
+++ b/mache/spack/cori-haswell_intel_mpt.yaml
@@ -3,7 +3,9 @@ spack:
   - cmake
   - intel
   - mpich
+{% if e3sm_lapack %}
   - cray-libsci
+{% endif %}
 {% if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
@@ -19,7 +21,9 @@ spack:
       compiler: [intel@19.0.3]
       providers:
         mpi: [mpich@7.7.10]
+{% if e3sm_lapack %}
         lapack: [cray-libsci@20.09.1]
+{% endif %}
       target:
       - haswell
     bzip2:


### PR DESCRIPTION
This is needed because MPAS standalone expects Netlib-LAPACK, which conflicts with other LAPACK installations in a given spack environment.