### PR TITLE
Fix Chrysalis OS and update to mache v1.4.1

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mache" %}
-{% set version = "1.4.0" %}
+{% set version = "1.4.1" %}
 
 package:
   name: {{ name|lower }}

--- a/mache/spack/chrysalis_gnu_openmpi.yaml
+++ b/mache/spack/chrysalis_gnu_openmpi.yaml
@@ -138,7 +138,7 @@ spack:
         f77: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/gcc-9.2.0-ugetvbp/bin/gfortran
         fc: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/gcc-9.2.0-ugetvbp/bin/gfortran
       flags: {}
-      operating_system: centos8
+      operating_system: rhel8
       target: x86_64
       modules: []
       environment: {}

--- a/mache/spack/chrysalis_intel_impi.yaml
+++ b/mache/spack/chrysalis_intel_impi.yaml
@@ -138,7 +138,7 @@ spack:
         f77: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/intel-20.0.4-kodw73g/compilers_and_libraries_2020.4.304/linux/bin/intel64/ifort
         fc: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/intel-20.0.4-kodw73g/compilers_and_libraries_2020.4.304/linux/bin/intel64/ifort
       flags: {}
-      operating_system: centos8
+      operating_system: rhel8
       target: x86_64
       modules: []
       environment: {}

--- a/mache/spack/chrysalis_intel_openmpi.yaml
+++ b/mache/spack/chrysalis_intel_openmpi.yaml
@@ -138,7 +138,7 @@ spack:
         f77: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/intel-20.0.4-kodw73g/compilers_and_libraries_2020.4.304/linux/bin/intel64/ifort
         fc: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/intel-20.0.4-kodw73g/compilers_and_libraries_2020.4.304/linux/bin/intel64/ifort
       flags: {}
-      operating_system: centos8
+      operating_system: rhel8
       target: x86_64
       modules: []
       environment: {}

--- a/mache/version.py
+++ b/mache/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (1, 4, 0)
+__version_info__ = (1, 4, 1)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mache
-version = 1.4.0
+version = 1.4.1
 author = Xylar Asay-Davis
 author_email = xylar@lanl.gov
 description = A package for providing configuration data relate to E3SM supported machines


### PR DESCRIPTION
The OS on Chrysalis seems to have changed from Centos 8 to RHEL 8 in the latest maintenance (or at least Spack thinks so).