### PR TITLE
Update Cori base_url

### DIFF
--- a/mache/machines/andes.cfg
+++ b/mache/machines/andes.cfg
@@ -15,7 +15,7 @@ base_path = /gpfs/alpine/proj-shared/cli115/e3sm-unified
 [diagnostics]
 
 # The base path to the diagnostics directory
-base_path = /gpfs/alpine/proj-shared/cli115/diagnostics/
+base_path = /gpfs/alpine/proj-shared/cli115/diagnostics
 
 # the unix group for permissions for diagnostics
 group = cli115

--- a/mache/machines/anvil.cfg
+++ b/mache/machines/anvil.cfg
@@ -78,7 +78,7 @@ modules_after = True
 hostname = blues.lcrc.anl.gov
 
 # public diagnostics directory
-public_diags = /lcrc/group/e3sm/public_html/diagnostics/
+public_diags = /lcrc/group/e3sm/public_html/diagnostics
 
 # private diagnostics directory
-private_diags = /lcrc/group/e3sm/diagnostics_private/
+private_diags = /lcrc/group/e3sm/diagnostics_private

--- a/mache/machines/chrysalis.cfg
+++ b/mache/machines/chrysalis.cfg
@@ -72,7 +72,7 @@ modules_after = True
 hostname = chrysalis.lcrc.anl.gov
 
 # public diagnostics directory
-public_diags = /lcrc/group/e3sm/public_html/diagnostics/
+public_diags = /lcrc/group/e3sm/public_html/diagnostics
 
 # private diagnostics directory
-private_diags = /lcrc/group/e3sm/diagnostics_private/
+private_diags = /lcrc/group/e3sm/diagnostics_private

--- a/mache/machines/compy.cfg
+++ b/mache/machines/compy.cfg
@@ -31,10 +31,10 @@ group = users
 [web_portal]
 
 # The path to the base of the web portals
-base_path = /compyfs/www/
+base_path = /compyfs/www
 
 # The base URL that corresponds to the base path
-base_url = https://compy-dtn.pnl.gov/
+base_url = https://compy-dtn.pnl.gov
 
 
 # The parallel section describes options related to running jobs in parallel

--- a/mache/machines/cori-haswell.cfg
+++ b/mache/machines/cori-haswell.cfg
@@ -34,7 +34,7 @@ group = e3sm
 base_path = /global/cfs/cdirs/e3sm/www
 
 # The base URL that corresponds to the base path
-base_url = https://portal.nersc.gov/project/e3sm/
+base_url = https://portal.nersc.gov/cfs/e3sm
 
 
 # The parallel section describes options related to running jobs in parallel

--- a/mache/machines/cori-knl.cfg
+++ b/mache/machines/cori-knl.cfg
@@ -28,7 +28,7 @@ group = e3sm
 base_path = /global/cfs/cdirs/e3sm/www
 
 # The base URL that corresponds to the base path
-base_url = https://portal.nersc.gov/project/e3sm/
+base_url = https://portal.nersc.gov/cfs/e3sm
 
 
 # The parallel section describes options related to running jobs in parallel


### PR DESCRIPTION
Update Cori `base_url` to use `/cfs/` rather than `/project/`. Resolves #52.