### PR TITLE
Fix libfabric on pm-cpu

### DIFF
--- a/mache/spack/pm-cpu_gnu_mpich.csh
+++ b/mache/spack/pm-cpu_gnu_mpich.csh
@@ -15,6 +15,7 @@ module load cray-libsci
 {% endif %}
 module load craype
 module rm cray-mpich
+moudle load libfabric/1.15.0.0
 module load cray-mpich/8.1.15
 {% if e3sm_hdf5_netcdf %}
 module rm cray-hdf5-parallel

--- a/mache/spack/pm-cpu_gnu_mpich.sh
+++ b/mache/spack/pm-cpu_gnu_mpich.sh
@@ -15,6 +15,7 @@ module load cray-libsci
 {% endif %}
 module load craype
 module rm cray-mpich
+moudle load libfabric/1.15.0.0
 module load cray-mpich/8.1.15
 {% if e3sm_hdf5_netcdf %}
 module rm cray-hdf5-parallel

--- a/mache/spack/pm-cpu_gnu_mpich.yaml
+++ b/mache/spack/pm-cpu_gnu_mpich.yaml
@@ -77,7 +77,15 @@ spack:
       - spec: mpich@8.1.15
         prefix: /opt/cray/pe/mpich/8.1.15/ofi/gnu/9.1
         modules:
+        - libfabric/1.15.0.0
         - cray-mpich/8.1.15
+      buildable: false
+    libfabric:
+      externals:
+      - spec: libfabric@1.15.0.0
+        prefix: /opt/cray/libfabric/1.15.0.0
+        modules:
+        - libfabric/1.15.0.0
       buildable: false
 {% if e3sm_lapack %}
     cray-libsci:
@@ -133,5 +141,3 @@ spack:
       target: x86_64
       modules: []
       environment: {}
-      extra_rpaths:
-      - /opt/cray/libfabric/1.15.0.0/lib64


### PR DESCRIPTION
This is its own module, and somehow I seem to have missed that.