### PR TITLE
Fix pm-cpu yaml

### DIFF
--- a/mache/spack/pm-cpu_gnu_mpich.yaml
+++ b/mache/spack/pm-cpu_gnu_mpich.yaml
@@ -38,6 +38,11 @@ spack:
       - spec: gettext@0.20.2
         prefix: /usr
       buildable: false
+    libxml2:
+      externals:
+      - spec: libxml2@2.9.7
+        prefix: /usr
+      buildable: false
     openssl:
       externals:
       - spec: openssl@1.1.1d
@@ -68,9 +73,12 @@ spack:
     gcc:
       externals:
       - spec: gcc@11.2.0
-        prefix: /opt/cray/pe/gcc/11.2.0/
         modules:
+        - PrgEnv-gnu/8.3.3
         - gcc/11.2.0
+        - craype-accel-host
+        - craype
+        - libfabric/1.15.0.0
       buildable: false
     mpich:
       externals:
@@ -108,22 +116,16 @@ spack:
       externals:
       - spec: parallel-netcdf@1.12.2.5+cxx+fortran+pic+shared
         prefix: /opt/cray/pe/parallel-netcdf/1.12.2.1/GNU/9.1/
-        modules:
-        - cray-parallel-netcdf/1.12.2.5
       buildable: false
     netcdf-c:
       externals:
       - spec: netcdf-c@4.8.1.5+mpi+parallel-netcdf
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.8.1.5/GNU/9.1
-        modules:
-        - cray-netcdf-hdf5parallel/4.8.1.5
       buildable: false
     netcdf-fortran:
       externals:
       - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.8.1.5/GNU/9.1
-        modules:
-        - cray-netcdf-hdf5parallel/4.8.1.5
       buildable: false
 {% endif %}
   config:
@@ -139,5 +141,10 @@ spack:
       flags: {}
       operating_system: sles15
       target: x86_64
-      modules: []
+      modules:
+      - PrgEnv-gnu/8.3.3
+      - gcc/11.2.0
+      - craype-accel-host
+      - craype
+      - libfabric/1.15.0.0
       environment: {}


### PR DESCRIPTION
Since we rebased spack onto its 0.19.0 tag and updated modules in #71, we have run into some troubles building on Perlmutter-CPU.  The difficulties seem to be resolved if:
- we load more modules for `gcc`
- we include the pre-build libxml2 (which is otherwise complaining about not finding a `cray-xpmem` pkgconfig file)
- we do *not* load modules for netcdf-c and netcdf-fortran (and pnetcdf for good measure) because the path determined from the module includes all available compilers, not just gnu.

