### PR TITLE
Get machine name from file

### DIFF
--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+$PYTHON -m pip install -vv --no-deps .
+
+mkdir -p "$PREFIX"/bin
+POST_LINK="$PREFIX"/bin/.mache-post-link.sh
+cp "$SRC_DIR"/conda/post-link.sh "$POST_LINK"
+chmod +x "$POST_LINK"

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -10,7 +10,6 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
   noarch: python
 
 requirements:

--- a/conda/post-link.sh
+++ b/conda/post-link.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+machine=$("${PREFIX}/bin/python" -c "from mache import discover_machine; print(discover_machine(quiet=True))")
+if [[ "${machine}" != "None" ]]; then
+  mkdir -p "${PREFIX}/share/mache"
+  echo "${machine}" > "${PREFIX}/share/mache/machine.txt"
+fi

--- a/mache/machine_info.py
+++ b/mache/machine_info.py
@@ -59,7 +59,7 @@ class MachineInfo:
         the ``config`` attribute.
     """
 
-    def __init__(self, machine=None):
+    def __init__(self, machine=None, quiet=False):
         """
         Create an object with information about the E3SM supported machine
 
@@ -68,9 +68,13 @@ class MachineInfo:
         machine : str, optional
             The name of an E3SM supported machine.  By default, the machine
             will be inferred from the host name
+
+        quiet : bool, optional
+            Whether to print warnings if the machine name is ambiguous
+
         """
         if machine is None:
-            machine = discover_machine()
+            machine = discover_machine(quiet=quiet)
             if machine is None:
                 raise ValueError('Unable to discover machine from host name')
         self.machine = machine


### PR DESCRIPTION
If the machine name cannot be discovered at runtime from the host name or an environment variable, get it from a file created at install time.

closes #83 