### PR TITLE
Add python to chicoma spack template

### DIFF
--- a/mache/spack/chicoma-cpu_gnu_mpich.yaml
+++ b/mache/spack/chicoma-cpu_gnu_mpich.yaml
@@ -70,6 +70,13 @@ spack:
         modules:
         - cmake/3.20.3
       buildable: false
+    python:
+      externals:
+      - spec: python@3.9.7
+        prefix: /usr/projects/hpcsoft/common/x86_64/anaconda/2021.11-python-3.9
+        modules:
+        - python/3.9-anaconda-2021.11
+      buildable: false
     gcc:
       externals:
       - spec: gcc@12.1.0


### PR DESCRIPTION
This is needed for building PETSc and building python in spack itself seems to take an inordinate amount of time and requires the mirror capability from #96.