### PR TITLE
Fix importlib.resources constraints

### DIFF
--- a/mache/machine_info.py
+++ b/mache/machine_info.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from lxml import etree
 
-if TYPE_CHECKING or sys.version_info > (3, 8, 0):
+if TYPE_CHECKING or sys.version_info >= (3, 9, 0):
     from importlib import resources as importlib_resources
 else:
     # python <= 3.8

--- a/mache/spack/__init__.py
+++ b/mache/spack/__init__.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from jinja2 import Template
 
-if TYPE_CHECKING or sys.version_info > (3, 8, 0):
+if TYPE_CHECKING or sys.version_info >= (3, 9, 0):
     from importlib import resources as importlib_resources
 else:
     # python <= 3.8


### PR DESCRIPTION
The python version was not being constrained correctly, leading to using the python > 3.8 imports for python 3.8