### PR TITLE
Add intel to pm-cpu

### DIFF
--- a/mache/cime_machine_config/config_machines.xml
+++ b/mache/cime_machine_config/config_machines.xml
@@ -148,7 +148,7 @@
     <DESC>Perlmutter CPU-only nodes at NERSC.  Phase2 only: Each node has 2 AMD EPYC 7713 64-Core (Milan) 512GB</DESC>
     <NODENAME_REGEX>$ENV{NERSC_HOST}:perlmutter</NODENAME_REGEX>
     <OS>Linux</OS>
-    <COMPILERS>gnu,nvidia,amdclang</COMPILERS>
+    <COMPILERS>gnu,intel,nvidia,amdclang</COMPILERS>
     <MPILIBS>mpich</MPILIBS>
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
@@ -167,7 +167,7 @@
     <BATCH_SYSTEM>nersc_slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>e3sm</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>srun</executable>
@@ -194,9 +194,12 @@
         <command name="unload">cray-netcdf-hdf5parallel</command>
         <command name="unload">cray-parallel-netcdf</command>
         <command name="unload">PrgEnv-gnu</command>
+        <command name="unload">PrgEnv-intel</command>
         <command name="unload">PrgEnv-nvidia</command>
         <command name="unload">PrgEnv-cray</command>
         <command name="unload">PrgEnv-aocc</command>
+        <command name="unload">intel</command>
+        <command name="unload">intel-oneapi</command>
         <command name="unload">cudatoolkit</command>
         <command name="unload">craype-accel-nvidia80</command>
         <command name="unload">craype-accel-host</command>
@@ -208,21 +211,28 @@
       <modules compiler="gnu">
         <command name="load">PrgEnv-gnu/8.3.3</command>
         <command name="load">gcc/11.2.0</command>
+        <command name="load">cray-libsci/23.02.1.1</command>
+      </modules>
+
+      <modules compiler="intel">
+        <command name="load">PrgEnv-intel/8.3.3</command>
+        <command name="load">intel/2023.0.0</command>
       </modules>
 
       <modules compiler="nvidia">
         <command name="load">PrgEnv-nvidia</command>
         <command name="load">nvidia/22.7</command>
+        <command name="load">cray-libsci/23.02.1.1</command>
       </modules>
 
       <modules compiler="amdclang">
         <command name="load">PrgEnv-aocc</command>
         <command name="load">aocc/3.2.0</command>
+        <command name="load">cray-libsci/23.02.1.1</command>
       </modules>
 
       <modules>
         <command name="load">craype-accel-host</command>
-        <command name="load">cray-libsci/23.02.1.1</command>
         <command name="load">craype/2.7.19</command>
         <command name="load">cray-mpich/8.1.24</command>
         <command name="load">cray-hdf5-parallel/1.12.2.3</command>
@@ -420,7 +430,7 @@
     <BATCH_SYSTEM>nersc_slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>e3sm</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>srun</executable>
@@ -586,19 +596,21 @@
     </environment_variables>
   </machine>
 
-  <machine MACH="crusher">
-    <DESC>Crusher. NCCS moderate-security system that contains similar hardware and software as the upcoming Frontier system at ORNL. 192 AMD EPYC 7A53 64C nodes, 128 hwthreads, 512GB DDR4, 4 MI250X GPUs</DESC>
-    <NODENAME_REGEX>.*crusher.*</NODENAME_REGEX>
+  <machine MACH="frontier">
+    <DESC>Frontier exascale supercomputer at ORNL. 9408 nodes, Node: 4 AMD MI250X GPUs (2 GCDs) ~ 8 GPUs, 512 GB HDB2E, AMD EPYC 64 cores, 512GB DDR4 </DESC>
+    <NODENAME_REGEX>.*frontier.*</NODENAME_REGEX>
     <OS>CNL</OS>
     <COMPILERS>gnu,crayclang,amdclang,gnugpu,crayclanggpu,amdclanggpu</COMPILERS>
     <MPILIBS>mpich</MPILIBS>
-    <PROJECT>cli133_crusher</PROJECT>
-    <CIME_OUTPUT_ROOT>/gpfs/alpine/cli133/proj-shared/$ENV{USER}/e3sm_scratch/crusher</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/gpfs/alpine/cli115/world-shared/e3sm/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/gpfs/alpine/cli115/world-shared/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <PROJECT>cli115</PROJECT>
+    <SAVE_TIMING_DIR>/lustre/orion/cli115/world-shared/frontier</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
+    <CIME_OUTPUT_ROOT>/lustre/orion/$PROJECT/proj-shared/$ENV{USER}/e3sm_scratch</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/lustre/orion/cli115/world-shared/e3sm/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/lustre/orion/cli115/world-shared/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>/gpfs/alpine/cli133/world-shared/e3sm/baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/gpfs/alpine/cli133/world-shared/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
+    <BASELINE_ROOT>/lustre/orion/cli115/world-shared/e3sm/baselines/frontier/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/lustre/orion/cli115/world-shared/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>
     <NTEST_PARALLEL_JOBS>1</NTEST_PARALLEL_JOBS>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
@@ -630,7 +642,10 @@
       <modules compiler="crayclang.*">
         <command name="reset"></command>
         <command name="switch">PrgEnv-cray PrgEnv-cray/8.3.3</command>
-        <command name="switch">cce cce/14.0.2</command>
+        <command name="switch">cce cce/15.0.1</command>
+        <!-- craype module to address tcmalloc runtime errors at startup -->
+        <!-- tcmalloc.cc:647 Attempt to free invalid pointer -->
+        <command name="switch">craype craype/2.7.20</command>
       </modules>
       <modules compiler="crayclanggpu">
         <command name="load">craype-accel-amd-gfx90a</command>
@@ -647,6 +662,7 @@
       <modules compiler="gnu.*">
         <command name="reset"></command>
         <command name="switch">PrgEnv-cray PrgEnv-gnu/8.3.3</command>
+        <!-- TODO: gcc/12.2.0 is default, need to check -->
         <command name="switch">gcc gcc/11.2.0</command>
       </modules>
       <modules compiler="gnugpu">
@@ -654,13 +670,14 @@
         <command name="load">rocm/5.4.0</command>
       </modules>
       <modules>
-        <command name="load">cray-python/3.9.12.1</command>
+        <command name="load">cray-python/3.9.13.1</command>
         <command name="load">subversion/1.14.1</command>
         <command name="load">git/2.36.1</command>
         <command name="load">cmake/3.21.3</command>
-        <command name="load">cray-hdf5-parallel/1.12.1.1</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.8.1.1</command>
-        <command name="load">cray-parallel-netcdf/1.12.1.7</command>
+        <command name="load">zlib/1.2.11</command>
+        <command name="load">cray-hdf5-parallel/1.12.2.1</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.1</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.1</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -691,6 +708,138 @@
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
+    </environment_variables>
+    <environment_variables compiler="gnu.*" mpilib="mpich">
+      <env name="ADIOS2_DIR">/lustre/orion/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/gcc-11.2.0</env>
+    </environment_variables>
+    <environment_variables compiler="crayclang.*" mpilib="mpich">
+      <env name="ADIOS2_DIR">/lustre/orion/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/crayclang-14.0.2</env>
+    </environment_variables>
+    <environment_variables compiler="amdclang.*" mpilib="mpich">
+      <env name="ADIOS2_DIR">/lustre/orion/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/amdclang-15.0.0</env>
+    </environment_variables>
+  </machine>
+
+  <machine MACH="crusher">
+    <DESC>Crusher. NCCS moderate-security system that contains similar hardware and software as the upcoming Frontier system at ORNL. 192 AMD EPYC 7A53 64C nodes, 128 hwthreads, 512GB DDR4, 4 MI250X GPUs</DESC>
+    <NODENAME_REGEX>.*crusher.*</NODENAME_REGEX>
+    <OS>CNL</OS>
+    <COMPILERS>gnu,crayclang,amdclang,gnugpu,crayclanggpu,amdclanggpu</COMPILERS>
+    <MPILIBS>mpich</MPILIBS>
+    <PROJECT>cli115</PROJECT>
+    <SAVE_TIMING_DIR>/lustre/orion/cli115/world-shared/crusher</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
+    <CIME_OUTPUT_ROOT>/lustre/orion/$PROJECT/proj-shared/$ENV{USER}/e3sm_scratch/crusher</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/lustre/orion/cli115/world-shared/e3sm/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/lustre/orion/cli115/world-shared/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/lustre/orion/cli115/world-shared/e3sm/baselines/crusher/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/lustre/orion/cli115/world-shared/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>8</GMAKE_J>
+    <NTEST_PARALLEL_JOBS>1</NTEST_PARALLEL_JOBS>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>e3sm</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>56</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>56</MAX_MPITASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE compiler="gnugpu">8</MAX_MPITASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE compiler="crayclanggpu">8</MAX_MPITASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE compiler="amdclanggpu">8</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+    <mpirun mpilib="default">
+      <executable>srun</executable>
+      <arguments>
+        <arg name="num_tasks"> -l -K -n {{ total_tasks }} -N {{ num_nodes }} </arg>
+        <arg name="thread_count">-c $ENV{OMP_NUM_THREADS}</arg>
+        <arg name="ntasks_per_gpu">$ENV{NTASKS_PER_GPU}</arg>
+        <arg name="gpu_bind">$ENV{GPU_BIND_ARGS}</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module" allow_error="true">
+      <init_path lang="sh">/usr/share/lmod/lmod/init/sh</init_path>
+      <init_path lang="csh">/usr/share/lmod/lmod/init/csh</init_path>
+      <init_path lang="perl">/usr/share/lmod/lmod/init/perl</init_path>
+      <init_path lang="python">/usr/share/lmod/lmod/init/env_modules_python.py</init_path>
+      <cmd_path lang="perl">/usr/share/lmod/lmod/libexec/lmod perl</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
+      <modules compiler="crayclang.*">
+        <command name="reset"></command>
+        <command name="switch">PrgEnv-cray PrgEnv-cray/8.3.3</command>
+        <command name="switch">cce cce/15.0.1</command>
+        <!-- craype module to address tcmalloc runtime errors at startup -->
+        <!-- tcmalloc.cc:647 Attempt to free invalid pointer -->
+        <command name="switch">craype craype/2.7.20</command>
+      </modules>
+      <modules compiler="crayclanggpu">
+        <command name="load">craype-accel-amd-gfx90a</command>
+        <command name="load">rocm/5.4.0</command>
+      </modules>
+      <modules compiler="amdclang.*">
+        <command name="reset"></command>
+        <command name="switch">PrgEnv-cray PrgEnv-amd/8.3.3</command>
+        <command name="switch">amd amd/5.4.0</command>
+      </modules>
+      <modules compiler="amdclanggpu">
+        <command name="load">craype-accel-amd-gfx90a</command>
+      </modules>
+      <modules compiler="gnu.*">
+        <command name="reset"></command>
+        <command name="switch">PrgEnv-cray PrgEnv-gnu/8.3.3</command>
+        <command name="switch">gcc gcc/11.2.0</command>
+      </modules>
+      <modules compiler="gnugpu">
+        <command name="load">craype-accel-amd-gfx90a</command>
+        <command name="load">rocm/5.4.0</command>
+      </modules>
+      <modules>
+        <command name="load">cray-python/3.9.13.1</command>
+        <command name="load">subversion/1.14.1</command>
+        <command name="load">git/2.36.1</command>
+        <command name="load">cmake/3.21.3</command>
+        <command name="load">zlib/1.2.11</command>
+        <command name="load">cray-hdf5-parallel/1.12.2.1</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.1</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.1</command>
+      </modules>
+    </module_system>
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+    <TEST_MEMLEAK_TOLERANCE>0.25</TEST_MEMLEAK_TOLERANCE>
+    <MAX_GB_OLD_TEST_DATA>0</MAX_GB_OLD_TEST_DATA>
+    <environment_variables>
+      <env name="NETCDF_PATH">$ENV{NETCDF_DIR}</env>
+      <env name="PNETCDF_PATH">$ENV{PNETCDF_DIR}</env>
+      <env name="NTASKS_PER_GPU"> </env>
+      <env name="GPU_BIND_ARGS"> </env>
+    </environment_variables>
+    <environment_variables compiler="amdclang">
+      <env name="LD_LIBRARY_PATH">$ENV{CRAY_LIBSCI_DIR}/amd/4.0/x86_64/lib:$ENV{LD_LIBRARY_PATH}</env>
+    </environment_variables>
+    <environment_variables compiler=".*gpu.*">
+      <env name="NTASKS_PER_GPU">--ntasks-per-gpu=$SHELL{echo "`./xmlquery --value MAX_MPITASKS_PER_NODE`/8"|bc}</env>
+      <env name="GPU_BIND_ARGS">--gpu-bind=closest</env>
+      <env name="PNETCDF_HINTS">romio_cb_read=disable</env>
+      <env name="MPICH_GPU_SUPPORT_ENABLED">0</env>
+    </environment_variables>
+    <environment_variables compiler=".*gpu.*" DEBUG="TRUE">
+      <env name="AMD_LOG_LEVEL">10</env>
+      <env name="CRAY_ACC_DEBUG">3</env>
+    </environment_variables>
+    <environment_variables SMP_PRESENT="TRUE">
+      <env name="OMP_STACKSIZE">128M</env>
+      <env name="OMP_PROC_BIND">spread</env>
+      <env name="OMP_PLACES">threads</env>
+    </environment_variables>
+    <environment_variables compiler="gnu.*" mpilib="mpich">
+      <env name="ADIOS2_DIR">/lustre/orion/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/gcc-11.2.0</env>
+    </environment_variables>
+    <environment_variables compiler="crayclang.*" mpilib="mpich">
+      <env name="ADIOS2_DIR">/lustre/orion/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/crayclang-14.0.2</env>
+    </environment_variables>
+    <environment_variables compiler="amdclang.*" mpilib="mpich">
+      <env name="ADIOS2_DIR">/lustre/orion/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/amdclang-15.0.0</env>
     </environment_variables>
   </machine>
 
@@ -791,6 +940,9 @@
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
     </environment_variables>
+    <environment_variables compiler="crayclang-scream" mpilib="mpich">
+      <env name="ADIOS2_DIR">/gpfs/alpine/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/crayclang-14.0.2</env>
+    </environment_variables>
   </machine>
 
 
@@ -875,6 +1027,9 @@
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
+    </environment_variables>
+    <environment_variables compiler="crayclang-scream" mpilib="mpich">
+      <env name="ADIOS2_DIR">/gpfs/alpine/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/crayclang-14.0.2</env>
     </environment_variables>
   </machine>
 
@@ -4655,7 +4810,7 @@
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>/home/baselines/$COMPILER</BASELINE_ROOT>
     <CCSM_CPRNC>/home/tools/cprnc/cprnc</CCSM_CPRNC>
-    <GMAKE_J>24</GMAKE_J>
+    <GMAKE_J>20</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>
     <NTEST_PARALLEL_JOBS>8</NTEST_PARALLEL_JOBS>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>

--- a/mache/spack/pm-cpu_gnu_mpich.csh
+++ b/mache/spack/pm-cpu_gnu_mpich.csh
@@ -1,11 +1,19 @@
-module rm PrgEnv-gnu
-module rm PrgEnv-nvidia
-module rm cudatoolkit
-module rm craype-accel-nvidia80
-module rm craype-accel-host
-module rm perftools-base
-module rm perftools
-module rm darshan
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module rm PrgEnv-gnu &> /dev/null
+module rm PrgEnv-intel &> /dev/null
+module rm PrgEnv-nvidia &> /dev/null
+module rm PrgEnv-cray &> /dev/null
+module rm PrgEnv-aocc &> /dev/null
+module rm intel &> /dev/null
+module rm intel-oneapi &> /dev/null
+module rm cudatoolkit &> /dev/null
+module rm craype-accel-nvidia80 &> /dev/null
+module rm craype-accel-host &> /dev/null
+module rm perftools-base &> /dev/null
+module rm perftools &> /dev/null
+module rm darshan &> /dev/null
 
 module load PrgEnv-gnu/8.3.3
 module load gcc/11.2.0
@@ -14,22 +22,22 @@ module load craype-accel-host
 module load cray-libsci/23.02.1.1
 {% endif %}
 module load craype/2.7.19
-module rm cray-mpich
+module rm cray-mpich &> /dev/null
 module load libfabric/1.15.2.0
 module load cray-mpich/8.1.24
 {% if e3sm_hdf5_netcdf %}
-module rm cray-hdf5-parallel
-module rm cray-netcdf-hdf5parallel
-module rm cray-parallel-netcdf
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
 module load cray-hdf5-parallel/1.12.2.3
 module load cray-netcdf-hdf5parallel/4.9.0.3
 module load cray-parallel-netcdf/1.12.3.3
 {% endif %}
 
 {% if e3sm_hdf5_netcdf %}
-setenv NETCDF_C_PATH $(dirname $(dirname $(which nc-config)))
-setenv NETCDF_FORTRAN_PATH $(dirname $(dirname $(which nf-config)))
-setenv PNETCDF_PATH $(dirname $(dirname $(which pnetcdf_version)))
+setenv NETCDF_C_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
+setenv NETCDF_FORTRAN_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
+setenv PNETCDF_PATH $CRAY_PARALLEL_NETCDF_PREFIX
 {% endif %}
 setenv MPICH_ENV_DISPLAY 1
 setenv MPICH_VERSION_DISPLAY 1

--- a/mache/spack/pm-cpu_gnu_mpich.sh
+++ b/mache/spack/pm-cpu_gnu_mpich.sh
@@ -1,11 +1,19 @@
-module rm PrgEnv-gnu
-module rm PrgEnv-nvidia
-module rm cudatoolkit
-module rm craype-accel-nvidia80
-module rm craype-accel-host
-module rm perftools-base
-module rm perftools
-module rm darshan
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module rm PrgEnv-gnu &> /dev/null
+module rm PrgEnv-intel &> /dev/null
+module rm PrgEnv-nvidia &> /dev/null
+module rm PrgEnv-cray &> /dev/null
+module rm PrgEnv-aocc &> /dev/null
+module rm intel &> /dev/null
+module rm intel-oneapi &> /dev/null
+module rm cudatoolkit &> /dev/null
+module rm craype-accel-nvidia80 &> /dev/null
+module rm craype-accel-host &> /dev/null
+module rm perftools-base &> /dev/null
+module rm perftools &> /dev/null
+module rm darshan &> /dev/null
 
 module load PrgEnv-gnu/8.3.3
 module load gcc/11.2.0
@@ -14,22 +22,22 @@ module load craype-accel-host
 module load cray-libsci/23.02.1.1
 {% endif %}
 module load craype/2.7.19
-module rm cray-mpich
+module rm cray-mpich &> /dev/null
 module load libfabric/1.15.2.0
 module load cray-mpich/8.1.24
 {% if e3sm_hdf5_netcdf %}
-module rm cray-hdf5-parallel
-module rm cray-netcdf-hdf5parallel
-module rm cray-parallel-netcdf
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
 module load cray-hdf5-parallel/1.12.2.3
 module load cray-netcdf-hdf5parallel/4.9.0.3
 module load cray-parallel-netcdf/1.12.3.3
 {% endif %}
 
 {% if e3sm_hdf5_netcdf %}
-export NETCDF_C_PATH=$(dirname $(dirname $(which nc-config)))
-export NETCDF_FORTRAN_PATH=$(dirname $(dirname $(which nf-config)))
-export PNETCDF_PATH=$(dirname $(dirname $(which pnetcdf_version)))
+export NETCDF_C_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
+export NETCDF_FORTRAN_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
+export PNETCDF_PATH=$CRAY_PARALLEL_NETCDF_PREFIX
 {% endif %}
 export MPICH_ENV_DISPLAY=1
 export MPICH_VERSION_DISPLAY=1

--- a/mache/spack/pm-cpu_intel_mpich.csh
+++ b/mache/spack/pm-cpu_intel_mpich.csh
@@ -1,0 +1,46 @@
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module rm PrgEnv-gnu &> /dev/null
+module rm PrgEnv-intel &> /dev/null
+module rm PrgEnv-nvidia &> /dev/null
+module rm PrgEnv-cray &> /dev/null
+module rm PrgEnv-aocc &> /dev/null
+module rm intel &> /dev/null
+module rm intel-oneapi &> /dev/null
+module rm cudatoolkit &> /dev/null
+module rm craype-accel-nvidia80 &> /dev/null
+module rm craype-accel-host &> /dev/null
+module rm perftools-base &> /dev/null
+module rm perftools &> /dev/null
+module rm darshan &> /dev/null
+
+module load PrgEnv-intel/8.3.3
+module load intel/2023.0.0
+module load craype-accel-host
+module load craype/2.7.19
+module rm cray-mpich &> /dev/null
+module load libfabric/1.15.2.0
+module load cray-mpich/8.1.24
+{% if e3sm_hdf5_netcdf %}
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module load cray-hdf5-parallel/1.12.2.3
+module load cray-netcdf-hdf5parallel/4.9.0.3
+module load cray-parallel-netcdf/1.12.3.3
+{% endif %}
+
+{% if e3sm_hdf5_netcdf %}
+setenv NETCDF_C_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
+setenv NETCDF_FORTRAN_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
+setenv PNETCDF_PATH $CRAY_PARALLEL_NETCDF_PREFIX
+{% endif %}
+setenv MPICH_ENV_DISPLAY 1
+setenv MPICH_VERSION_DISPLAY 1
+setenv OMP_STACKSIZE 128M
+setenv OMP_PROC_BIND spread
+setenv OMP_PLACES threads
+setenv HDF5_USE_FILE_LOCKING FALSE
+setenv PERL5LIB /global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
+setenv FI_CXI_RX_MATCH_MODE software

--- a/mache/spack/pm-cpu_intel_mpich.sh
+++ b/mache/spack/pm-cpu_intel_mpich.sh
@@ -1,0 +1,46 @@
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module rm PrgEnv-gnu &> /dev/null
+module rm PrgEnv-intel &> /dev/null
+module rm PrgEnv-nvidia &> /dev/null
+module rm PrgEnv-cray &> /dev/null
+module rm PrgEnv-aocc &> /dev/null
+module rm intel &> /dev/null
+module rm intel-oneapi &> /dev/null
+module rm cudatoolkit &> /dev/null
+module rm craype-accel-nvidia80 &> /dev/null
+module rm craype-accel-host &> /dev/null
+module rm perftools-base &> /dev/null
+module rm perftools &> /dev/null
+module rm darshan &> /dev/null
+
+module load PrgEnv-intel/8.3.3
+module load intel/2023.0.0
+module load craype-accel-host
+module load craype/2.7.19
+module rm cray-mpich &> /dev/null
+module load libfabric/1.15.2.0
+module load cray-mpich/8.1.24
+{% if e3sm_hdf5_netcdf %}
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module load cray-hdf5-parallel/1.12.2.3
+module load cray-netcdf-hdf5parallel/4.9.0.3
+module load cray-parallel-netcdf/1.12.3.3
+{% endif %}
+
+{% if e3sm_hdf5_netcdf %}
+export NETCDF_C_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
+export NETCDF_FORTRAN_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
+export PNETCDF_PATH=$CRAY_PARALLEL_NETCDF_PREFIX
+{% endif %}
+export MPICH_ENV_DISPLAY=1
+export MPICH_VERSION_DISPLAY=1
+export OMP_STACKSIZE=128M
+export OMP_PROC_BIND=spread
+export OMP_PLACES=threads
+export HDF5_USE_FILE_LOCKING=FALSE
+export PERL5LIB=/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
+export FI_CXI_RX_MATCH_MODE=software

--- a/mache/spack/pm-cpu_intel_mpich.yaml
+++ b/mache/spack/pm-cpu_intel_mpich.yaml
@@ -1,0 +1,134 @@
+spack:
+  specs:
+  - intel
+  - mpich
+{% if e3sm_hdf5_netcdf %}
+  - hdf5
+  - netcdf-c
+  - netcdf-fortran
+  - parallel-netcdf
+{% endif %}
+{{ specs }}
+  concretizer:
+    unify: true
+  packages:
+    all:
+      compiler: [intel@2023.0.0]
+      providers:
+        mpi: [mpich@8.1.24]
+    bzip2:
+      externals:
+      - spec: bzip2@1.0.6
+        prefix: /usr
+      buildable: false
+    curl:
+      externals:
+      - spec: curl@7.66.0
+        prefix: /usr
+      buildable: false
+    gettext:
+      externals:
+      - spec: gettext@0.20.2
+        prefix: /usr
+      buildable: false
+    libxml2:
+      externals:
+      - spec: libxml2@2.9.7
+        prefix: /usr
+      buildable: false
+    ncurses:
+      externals:
+      - spec: ncurses@6.1.20180317
+        prefix: /usr
+      buildable: false
+    openssl:
+      externals:
+      - spec: openssl@1.1.1d
+        prefix: /usr
+      buildable: false
+    perl:
+      externals:
+      - spec: perl@5.26.1
+        prefix: /usr
+      buildable: false
+    tar:
+      externals:
+      - spec: tar@1.34
+        prefix: /usr
+      buildable: false
+    xz:
+      externals:
+      - spec: xz@5.2.3
+        prefix: /usr
+      buildable: false
+    intel:
+      externals:
+      - spec: intel@2023.0.0
+        modules:
+        - PrgEnv-intel/8.3.3
+        - intel/2023.0.0
+        - craype-accel-host
+        - craype/2.7.19
+        - libfabric/1.15.2.0
+      buildable: false
+    mpich:
+      externals:
+      - spec: mpich@8.1.24
+        prefix: /opt/cray/pe/mpich/8.1.24/ofi/intel/19.0
+        modules:
+        - libfabric/1.15.2.0
+        - cray-mpich/8.1.24
+      buildable: false
+    libfabric:
+      externals:
+      - spec: libfabric@1.15.2.0
+        prefix: /opt/cray/libfabric/1.15.2.0
+        modules:
+        - libfabric/1.15.2.0
+      buildable: false
+{% if e3sm_hdf5_netcdf %}
+    hdf5:
+      externals:
+      - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared
+        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.3/intel/19.0
+        modules:
+        - cray-hdf5-parallel/1.12.2.3
+      buildable: false
+    parallel-netcdf:
+      externals:
+      - spec: parallel-netcdf@1.12.3.3+cxx+fortran+pic+shared
+        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.3/intel/19.0/
+      buildable: false
+    netcdf-c:
+      externals:
+      - spec: netcdf-c@4.9.0.3+mpi+parallel-netcdf
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/intel/19.0
+      buildable: false
+    netcdf-fortran:
+      externals:
+      - spec: netcdf-fortran@4.5.3
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/intel/19.0
+      buildable: false
+{% endif %}
+  config:
+    install_missing_compilers: false
+  compilers:
+  - compiler:
+      spec: intel@2023.0.0
+      paths:
+        cc: cc
+        cxx: CC
+        f77: ftn
+        fc: ftn
+      flags: {}
+      operating_system: sles15
+      target: x86_64
+      modules:
+      - PrgEnv-intel/8.3.3
+      - intel/2023.0.0
+      - craype-accel-host
+      - craype/2.7.19
+      - libfabric/1.15.2.0
+      environment:
+        prepend_path:
+          PKG_CONFIG_PATH: "/opt/cray/xpmem/2.5.2-2.4_3.30__gd0f7936.shasta/lib64/pkgconfig"


### PR DESCRIPTION
This merge updates `config_machines.xml` to match E3SM/master, now at E3SM commit fed770a9dd

It also updates pm-cpu gnu modules and environment variables to match E3SM.

Finally, it adds support for Intel compilers on pm-cpu.