### PR TITLE
Add more system packages to chicoma-cpu spack template

### DIFF
--- a/mache/spack/chicoma-cpu_gnu_mpich.yaml
+++ b/mache/spack/chicoma-cpu_gnu_mpich.yaml
@@ -42,6 +42,11 @@ spack:
       - spec: gmake@4.2.1
         prefix: /usr
       buildable: false
+    libiconv:
+      externals:
+      - spec: libiconv@2.31
+        prefix: /usr
+      buildable: false
     libxml2:
       externals:
       - spec: libxml2@2.9.7

--- a/mache/spack/chicoma-cpu_gnu_mpich.yaml
+++ b/mache/spack/chicoma-cpu_gnu_mpich.yaml
@@ -32,6 +32,11 @@ spack:
       - spec: curl@7.60.0
         prefix: /usr
       buildable: false
+    diffutils:
+      externals:
+      - spec: diffutils@3.6
+        prefix: /usr
+      buildable: false
     gettext:
       externals:
       - spec: gettext@0.19.8.1


### PR DESCRIPTION
Chicoma's firewall doesn't allow us to download the code for this one.