### PR TITLE
Use system python on pm-cpu

### DIFF
--- a/mache/spack/pm-cpu_gnu_mpich.yaml
+++ b/mache/spack/pm-cpu_gnu_mpich.yaml
@@ -57,6 +57,13 @@ spack:
       - spec: perl@5.26.1
         prefix: /usr
       buildable: false
+    python:
+      externals:
+      - spec: python@3.9.7
+        prefix: /global/common/software/nersc/pm-2022q3/sw/python/3.9-anaconda-2021.11
+        modules:
+        - python/3.9-anaconda-2021.11
+      buildable: false
     tar:
       externals:
       - spec: tar@1.34

--- a/mache/spack/pm-cpu_intel_mpich.yaml
+++ b/mache/spack/pm-cpu_intel_mpich.yaml
@@ -51,6 +51,13 @@ spack:
       - spec: perl@5.26.1
         prefix: /usr
       buildable: false
+    python:
+      externals:
+      - spec: python@3.9.7
+        prefix: /global/common/software/nersc/pm-2022q3/sw/python/3.9-anaconda-2021.11
+        modules:
+        - python/3.9-anaconda-2021.11
+      buildable: false
     tar:
       externals:
       - spec: tar@1.34


### PR DESCRIPTION
It doesn't seem to be possible (or necessary) to build python on Perlmutter form spack.