### PR TITLE
Perlmutter and Chicoma fixes

### DIFF
--- a/mache/spack/chicoma-cpu_gnu_mpich.yaml
+++ b/mache/spack/chicoma-cpu_gnu_mpich.yaml
@@ -1,7 +1,7 @@
 spack:
   specs:
   - gcc
-  - mpich
+  - cray-mpich
 {% if e3sm_lapack %}
   - cray-libsci
 {% endif %}
@@ -18,7 +18,7 @@ spack:
     all:
       compiler: [gcc@12.1.0]
       providers:
-        mpi: [mpich@8.1.21]
+        mpi: [cray-mpich@8.1.21]
 {% if e3sm_lapack %}
         lapack: [cray-libsci@22.11.1.2]
 {% endif %}
@@ -99,9 +99,9 @@ spack:
         - craype
         - libfabric/1.15.0.0
       buildable: false
-    mpich:
+    cray-mpich:
       externals:
-      - spec: mpich@8.1.21
+      - spec: cray-mpich@8.1.21
         prefix: /opt/cray/pe/mpich/8.1.21/ofi/gnu/9.1
         modules:
         - libfabric/1.15.0.0

--- a/mache/spack/chicoma-cpu_gnu_mpich.yaml
+++ b/mache/spack/chicoma-cpu_gnu_mpich.yaml
@@ -138,7 +138,7 @@ spack:
       buildable: false
     netcdf-c:
       externals:
-      - spec: netcdf-c@4.9.0.1+mpi+parallel-netcdf
+      - spec: netcdf-c@4.9.0.1+mpi~parallel-netcdf
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/GNU/9.1
       buildable: false
     netcdf-fortran:

--- a/mache/spack/pm-cpu_gnu_mpich.csh
+++ b/mache/spack/pm-cpu_gnu_mpich.csh
@@ -41,9 +41,11 @@ setenv PNETCDF_PATH $CRAY_PARALLEL_NETCDF_PREFIX
 {% endif %}
 setenv MPICH_ENV_DISPLAY 1
 setenv MPICH_VERSION_DISPLAY 1
-setenv OMP_STACKSIZE 128M
-setenv OMP_PROC_BIND spread
-setenv OMP_PLACES threads
+## purposefully omitting OMP variables that cause trouble in ESMF
+# setenv OMP_STACKSIZE 128M
+# setenv OMP_PROC_BIND spread
+# setenv OMP_PLACES threads
 setenv HDF5_USE_FILE_LOCKING FALSE
-setenv PERL5LIB /global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
+## Not needed
+# setenv PERL5LIB /global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
 setenv FI_CXI_RX_MATCH_MODE software

--- a/mache/spack/pm-cpu_gnu_mpich.sh
+++ b/mache/spack/pm-cpu_gnu_mpich.sh
@@ -41,11 +41,13 @@ export PNETCDF_PATH=$CRAY_PARALLEL_NETCDF_PREFIX
 {% endif %}
 export MPICH_ENV_DISPLAY=1
 export MPICH_VERSION_DISPLAY=1
-export OMP_STACKSIZE=128M
-export OMP_PROC_BIND=spread
-export OMP_PLACES=threads
+## purposefully omitting OMP variables that cause trouble in ESMF
+# export OMP_STACKSIZE=128M
+# export OMP_PROC_BIND=spread
+# export OMP_PLACES=threads
 export HDF5_USE_FILE_LOCKING=FALSE
-export PERL5LIB=/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
+## Not needed
+# export PERL5LIB=/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
 export FI_CXI_RX_MATCH_MODE=software
 
 if [ -z "${NERSC_HOST:-}" ]; then

--- a/mache/spack/pm-cpu_gnu_mpich.sh
+++ b/mache/spack/pm-cpu_gnu_mpich.sh
@@ -47,3 +47,8 @@ export OMP_PLACES=threads
 export HDF5_USE_FILE_LOCKING=FALSE
 export PERL5LIB=/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
 export FI_CXI_RX_MATCH_MODE=software
+
+if [ -z "${NERSC_HOST:-}" ]; then
+  # happens when building spack environment
+  export NERSC_HOST="perlmutter"
+fi

--- a/mache/spack/pm-cpu_gnu_mpich.yaml
+++ b/mache/spack/pm-cpu_gnu_mpich.yaml
@@ -1,7 +1,7 @@
 spack:
   specs:
   - gcc
-  - mpich
+  - cray-mpich
 {% if e3sm_lapack %}
   - cray-libsci
 {% endif %}
@@ -18,7 +18,7 @@ spack:
     all:
       compiler: [gcc@11.2.0]
       providers:
-        mpi: [mpich@8.1.24]
+        mpi: [cray-mpich@8.1.24]
 {% if e3sm_lapack %}
         lapack: [cray-libsci@23.02.1.1]
 {% endif %}
@@ -84,9 +84,9 @@ spack:
         - craype/2.7.19
         - libfabric/1.15.2.0
       buildable: false
-    mpich:
+    cray-mpich:
       externals:
-      - spec: mpich@8.1.24
+      - spec: cray-mpich@8.1.24
         prefix: /opt/cray/pe/mpich/8.1.24/ofi/gnu/9.1
         modules:
         - libfabric/1.15.2.0

--- a/mache/spack/pm-cpu_gnu_mpich.yaml
+++ b/mache/spack/pm-cpu_gnu_mpich.yaml
@@ -123,7 +123,7 @@ spack:
       buildable: false
     netcdf-c:
       externals:
-      - spec: netcdf-c@4.9.0.3+mpi+parallel-netcdf
+      - spec: netcdf-c@4.9.0.3+mpi~parallel-netcdf
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/GNU/9.1
       buildable: false
     netcdf-fortran:

--- a/mache/spack/pm-cpu_gnu_mpich.yaml
+++ b/mache/spack/pm-cpu_gnu_mpich.yaml
@@ -13,7 +13,7 @@ spack:
 {% endif %}
 {{ specs }}
   concretizer:
-    unify: true
+    unify: when_possible
   packages:
     all:
       compiler: [gcc@11.2.0]
@@ -113,8 +113,8 @@ spack:
       externals:
       - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared
         prefix: /opt/cray/pe/hdf5-parallel/1.12.2.3/GNU/9.1
-        modules:
-        - cray-hdf5-parallel/1.12.2.3
+      - spec: hdf5@1.12.2.3~cxx+fortran+hl~java~mpi+shared
+        prefix: /opt/cray/pe/hdf5/1.12.2.3/GNU/9.1
       buildable: false
     parallel-netcdf:
       externals:
@@ -125,11 +125,15 @@ spack:
       externals:
       - spec: netcdf-c@4.9.0.3+mpi~parallel-netcdf
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/GNU/9.1
+      - spec: netcdf-c@4.9.0.3~mpi~parallel-netcdf
+        prefix: /opt/cray/pe/netcdf/4.9.0.3/GNU/9.1
       buildable: false
     netcdf-fortran:
       externals:
-      - spec: netcdf-fortran@4.5.3
+      - spec: netcdf-fortran@4.5.3 ^netcdf-c+mpi
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/GNU/9.1
+      - spec: netcdf-fortran@4.5.3 ^netcdf-c~mpi
+        prefix: /opt/cray/pe/netcdf/4.9.0.3/GNU/9.1
       buildable: false
 {% endif %}
   config:

--- a/mache/spack/pm-cpu_intel_mpich.csh
+++ b/mache/spack/pm-cpu_intel_mpich.csh
@@ -38,9 +38,11 @@ setenv PNETCDF_PATH $CRAY_PARALLEL_NETCDF_PREFIX
 {% endif %}
 setenv MPICH_ENV_DISPLAY 1
 setenv MPICH_VERSION_DISPLAY 1
-setenv OMP_STACKSIZE 128M
-setenv OMP_PROC_BIND spread
-setenv OMP_PLACES threads
+## purposefully omitting OMP variables that cause trouble in ESMF
+# setenv OMP_STACKSIZE 128M
+# setenv OMP_PROC_BIND spread
+# setenv OMP_PLACES threads
 setenv HDF5_USE_FILE_LOCKING FALSE
-setenv PERL5LIB /global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
+## Not needed
+# setenv PERL5LIB /global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
 setenv FI_CXI_RX_MATCH_MODE software

--- a/mache/spack/pm-cpu_intel_mpich.sh
+++ b/mache/spack/pm-cpu_intel_mpich.sh
@@ -44,3 +44,8 @@ export OMP_PLACES=threads
 export HDF5_USE_FILE_LOCKING=FALSE
 export PERL5LIB=/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
 export FI_CXI_RX_MATCH_MODE=software
+
+if [ -z "${NERSC_HOST:-}" ]; then
+  # happens when building spack environment
+  export NERSC_HOST="perlmutter"
+fi

--- a/mache/spack/pm-cpu_intel_mpich.sh
+++ b/mache/spack/pm-cpu_intel_mpich.sh
@@ -38,11 +38,13 @@ export PNETCDF_PATH=$CRAY_PARALLEL_NETCDF_PREFIX
 {% endif %}
 export MPICH_ENV_DISPLAY=1
 export MPICH_VERSION_DISPLAY=1
-export OMP_STACKSIZE=128M
-export OMP_PROC_BIND=spread
-export OMP_PLACES=threads
+## purposefully omitting OMP variables that cause trouble in ESMF
+# export OMP_STACKSIZE=128M
+# export OMP_PROC_BIND=spread
+# export OMP_PLACES=threads
 export HDF5_USE_FILE_LOCKING=FALSE
-export PERL5LIB=/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
+## Not needed
+# export PERL5LIB=/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
 export FI_CXI_RX_MATCH_MODE=software
 
 if [ -z "${NERSC_HOST:-}" ]; then

--- a/mache/spack/pm-cpu_intel_mpich.yaml
+++ b/mache/spack/pm-cpu_intel_mpich.yaml
@@ -1,7 +1,7 @@
 spack:
   specs:
   - intel
-  - mpich
+  - cray-mpich
 {% if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
@@ -15,7 +15,7 @@ spack:
     all:
       compiler: [intel@2023.1.0]
       providers:
-        mpi: [mpich@8.1.24]
+        mpi: [cray-mpich@8.1.24]
     bzip2:
       externals:
       - spec: bzip2@1.0.6
@@ -78,9 +78,9 @@ spack:
         - craype/2.7.19
         - libfabric/1.15.2.0
       buildable: false
-    mpich:
+    cray-mpich:
       externals:
-      - spec: mpich@8.1.24
+      - spec: cray-mpich@8.1.24
         prefix: /opt/cray/pe/mpich/8.1.24/ofi/intel/19.0
         modules:
         - libfabric/1.15.2.0

--- a/mache/spack/pm-cpu_intel_mpich.yaml
+++ b/mache/spack/pm-cpu_intel_mpich.yaml
@@ -108,7 +108,7 @@ spack:
       buildable: false
     netcdf-c:
       externals:
-      - spec: netcdf-c@4.9.0.3+mpi+parallel-netcdf
+      - spec: netcdf-c@4.9.0.3+mpi~parallel-netcdf
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/intel/19.0
       buildable: false
     netcdf-fortran:

--- a/mache/spack/pm-cpu_intel_mpich.yaml
+++ b/mache/spack/pm-cpu_intel_mpich.yaml
@@ -10,7 +10,7 @@ spack:
 {% endif %}
 {{ specs }}
   concretizer:
-    unify: true
+    unify: when_possible
   packages:
     all:
       compiler: [intel@2023.1.0]
@@ -98,8 +98,8 @@ spack:
       externals:
       - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared
         prefix: /opt/cray/pe/hdf5-parallel/1.12.2.3/intel/19.0
-        modules:
-        - cray-hdf5-parallel/1.12.2.3
+      - spec: hdf5@1.12.2.3~cxx+fortran+hl~java~mpi+shared
+        prefix: /opt/cray/pe/hdf5/1.12.2.3/intel/19.0
       buildable: false
     parallel-netcdf:
       externals:
@@ -110,11 +110,15 @@ spack:
       externals:
       - spec: netcdf-c@4.9.0.3+mpi~parallel-netcdf
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/intel/19.0
+      - spec: netcdf-c@4.9.0.3~mpi~parallel-netcdf
+        prefix: /opt/cray/pe/netcdf/4.9.0.3/intel/19.0
       buildable: false
     netcdf-fortran:
       externals:
-      - spec: netcdf-fortran@4.5.3
+      - spec: netcdf-fortran@4.5.3 ^netcdf-c+mpi
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/intel/19.0
+      - spec: netcdf-fortran@4.5.3 ^netcdf-c~mpi
+        prefix: /opt/cray/pe/netcdf/4.9.0.3/intel/19.0
       buildable: false
 {% endif %}
   config:


### PR DESCRIPTION
This merge brings in a variety of fixes to spack builds on Perlmutter and Chicoma, including:
* making sure the `NERSC_HOST` variable is defined on PM
* fixing the specification for netcdf-c
* switching from `mpich` to `cray-mpich`
* Adding `netcdf-c`, `netcdf-fortran` and `hdf5` without MPI on PM
* Commenting out some OMP environment variables on PM that seem to cause issues with ESMF