### PR TITLE
Various fixes needed for E3SM-Unified

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include mache/machines/*.cfg
 include mache/spack/*.yaml
 include mache/spack/*.template
 include mache/spack/*.sh
+include mache/spack/*.csh

--- a/mache/machines/anvil.cfg
+++ b/mache/machines/anvil.cfg
@@ -6,10 +6,10 @@
 group = cels
 
 # the compiler set to use for system libraries and MPAS builds
-compiler = intel
+compiler = gnu
 
 # the system MPI library to use for intel18 compiler
-mpi = impi
+mpi = openmpi
 
 # the path to the directory where activation scripts, the base environment, and
 # system libraries will be deployed

--- a/mache/machines/anvil.cfg
+++ b/mache/machines/anvil.cfg
@@ -17,7 +17,7 @@ base_path = /lcrc/soft/climate/e3sm-unified
 
 # whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
 # pnetcdf as E3SM (spack modules are used otherwise)
-use_e3sm_hdf5_netcdf = True
+use_e3sm_hdf5_netcdf = False
 
 
 # config options related to data needed by diagnostics software such as

--- a/mache/machines/anvil.cfg
+++ b/mache/machines/anvil.cfg
@@ -15,6 +15,10 @@ mpi = impi
 # system libraries will be deployed
 base_path = /lcrc/soft/climate/e3sm-unified
 
+# whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
+# pnetcdf as E3SM (spack modules are used otherwise)
+use_e3sm_hdf5_netcdf = True
+
 
 # config options related to data needed by diagnostics software such as
 # e3sm_diags and MPAS-Analysis

--- a/mache/machines/anvil.cfg
+++ b/mache/machines/anvil.cfg
@@ -15,9 +15,9 @@ mpi = openmpi
 # system libraries will be deployed
 base_path = /lcrc/soft/climate/e3sm-unified
 
-# whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
-# pnetcdf as E3SM (spack modules are used otherwise)
-use_e3sm_hdf5_netcdf = False
+# whether to use system modules for hdf5, netcdf-c, netcdf-fortran and pnetcdf
+# (spack modules are used otherwise)
+use_system_hdf5_netcdf = False
 
 
 # config options related to data needed by diagnostics software such as

--- a/mache/machines/chicoma-cpu.cfg
+++ b/mache/machines/chicoma-cpu.cfg
@@ -15,9 +15,9 @@ mpi = mpich
 # system libraries will be deployed
 base_path = /usr/projects/e3sm/e3sm-unified
 
-# whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
-# pnetcdf as E3SM (spack modules are used otherwise)
-use_e3sm_hdf5_netcdf = True
+# whether to use system modules for hdf5, netcdf-c, netcdf-fortran and pnetcdf
+# (spack modules are used otherwise)
+use_system_hdf5_netcdf = True
 
 
 # config options related to data needed by diagnostics software such as

--- a/mache/machines/chicoma-cpu.cfg
+++ b/mache/machines/chicoma-cpu.cfg
@@ -15,6 +15,10 @@ mpi = mpich
 # system libraries will be deployed
 base_path = /usr/projects/e3sm/e3sm-unified
 
+# whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
+# pnetcdf as E3SM (spack modules are used otherwise)
+use_e3sm_hdf5_netcdf = True
+
 
 # config options related to data needed by diagnostics software such as
 # e3sm_diags and MPAS-Analysis

--- a/mache/machines/chrysalis.cfg
+++ b/mache/machines/chrysalis.cfg
@@ -15,6 +15,10 @@ mpi = openmpi
 # system libraries will be deployed
 base_path = /lcrc/soft/climate/e3sm-unified
 
+# whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
+# pnetcdf as E3SM (spack modules are used otherwise)
+use_e3sm_hdf5_netcdf = True
+
 
 # config options related to data needed by diagnostics software such as
 # e3sm_diags and MPAS-Analysis

--- a/mache/machines/chrysalis.cfg
+++ b/mache/machines/chrysalis.cfg
@@ -17,7 +17,7 @@ base_path = /lcrc/soft/climate/e3sm-unified
 
 # whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
 # pnetcdf as E3SM (spack modules are used otherwise)
-use_e3sm_hdf5_netcdf = True
+use_e3sm_hdf5_netcdf = False
 
 
 # config options related to data needed by diagnostics software such as

--- a/mache/machines/chrysalis.cfg
+++ b/mache/machines/chrysalis.cfg
@@ -15,9 +15,9 @@ mpi = openmpi
 # system libraries will be deployed
 base_path = /lcrc/soft/climate/e3sm-unified
 
-# whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
-# pnetcdf as E3SM (spack modules are used otherwise)
-use_e3sm_hdf5_netcdf = False
+# whether to use system modules for hdf5, netcdf-c, netcdf-fortran and pnetcdf
+# (spack modules are used otherwise)
+use_system_hdf5_netcdf = False
 
 
 # config options related to data needed by diagnostics software such as

--- a/mache/machines/compy.cfg
+++ b/mache/machines/compy.cfg
@@ -15,6 +15,10 @@ mpi = impi
 # system libraries will be deployed
 base_path = /share/apps/E3SM/conda_envs
 
+# whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
+# pnetcdf as E3SM (spack modules are used otherwise)
+use_e3sm_hdf5_netcdf = False
+
 
 # config options related to data needed by diagnostics software such as
 # e3sm_diags and MPAS-Analysis

--- a/mache/machines/compy.cfg
+++ b/mache/machines/compy.cfg
@@ -17,7 +17,7 @@ base_path = /share/apps/E3SM/conda_envs
 
 # whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
 # pnetcdf as E3SM (spack modules are used otherwise)
-use_e3sm_hdf5_netcdf = False
+use_system_hdf5_netcdf = False
 
 
 # config options related to data needed by diagnostics software such as

--- a/mache/machines/compy.cfg
+++ b/mache/machines/compy.cfg
@@ -6,10 +6,10 @@
 group = users
 
 # the compiler set to use for system libraries and MPAS builds
-compiler = intel
+compiler = gnu
 
 # the system MPI library to use for intel18 compiler
-mpi = impi
+mpi = openmpi
 
 # the path to the directory where activation scripts, the base environment, and
 # system libraries will be deployed

--- a/mache/machines/pm-cpu.cfg
+++ b/mache/machines/pm-cpu.cfg
@@ -15,9 +15,9 @@ mpi = mpich
 # system libraries will be deployed
 base_path = /global/common/software/e3sm/anaconda_envs
 
-# whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
-# pnetcdf as E3SM (spack modules are used otherwise)
-use_e3sm_hdf5_netcdf = True
+# whether to use system modules for hdf5, netcdf-c, netcdf-fortran and pnetcdf
+# (spack modules are used otherwise)
+use_system_hdf5_netcdf = True
 
 
 # config options related to data needed by diagnostics software such as

--- a/mache/machines/pm-cpu.cfg
+++ b/mache/machines/pm-cpu.cfg
@@ -15,6 +15,10 @@ mpi = mpich
 # system libraries will be deployed
 base_path = /global/common/software/e3sm/anaconda_envs
 
+# whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
+# pnetcdf as E3SM (spack modules are used otherwise)
+use_e3sm_hdf5_netcdf = True
+
 
 # config options related to data needed by diagnostics software such as
 # e3sm_diags and MPAS-Analysis

--- a/mache/spack/pm-cpu_gnu_mpich.yaml
+++ b/mache/spack/pm-cpu_gnu_mpich.yaml
@@ -113,6 +113,30 @@ spack:
       externals:
       - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared
         prefix: /opt/cray/pe/hdf5-parallel/1.12.2.3/GNU/9.1
+      buildable: false
+    parallel-netcdf:
+      externals:
+      - spec: parallel-netcdf@1.12.3.3+cxx+fortran+pic+shared
+        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.3/GNU/9.1/
+      buildable: false
+    netcdf-c:
+      externals:
+      - spec: netcdf-c@4.9.0.3+mpi~parallel-netcdf
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/GNU/9.1
+      buildable: false
+    netcdf-fortran:
+      externals:
+      - spec: netcdf-fortran@4.5.3 ^netcdf-c+mpi
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/GNU/9.1
+      - spec: netcdf-fortran@4.5.3 ^netcdf-c~mpi
+        prefix: /opt/cray/pe/netcdf/4.9.0.3/GNU/9.1
+      buildable: false
+{% endif %}
+{% if system_hdf5_netcdf %}
+    hdf5:
+      externals:
+      - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared
+        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.3/GNU/9.1
       - spec: hdf5@1.12.2.3~cxx+fortran+hl~java~mpi+shared
         prefix: /opt/cray/pe/hdf5/1.12.2.3/GNU/9.1
       buildable: false

--- a/mache/spack/pm-cpu_intel_mpich.yaml
+++ b/mache/spack/pm-cpu_intel_mpich.yaml
@@ -98,6 +98,30 @@ spack:
       externals:
       - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared
         prefix: /opt/cray/pe/hdf5-parallel/1.12.2.3/intel/19.0
+      buildable: false
+    parallel-netcdf:
+      externals:
+      - spec: parallel-netcdf@1.12.3.3+cxx+fortran+pic+shared
+        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.3/intel/19.0/
+      buildable: false
+    netcdf-c:
+      externals:
+      - spec: netcdf-c@4.9.0.3+mpi~parallel-netcdf
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/intel/19.0
+      buildable: false
+    netcdf-fortran:
+      externals:
+      - spec: netcdf-fortran@4.5.3 ^netcdf-c+mpi
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/intel/19.0
+      - spec: netcdf-fortran@4.5.3 ^netcdf-c~mpi
+        prefix: /opt/cray/pe/netcdf/4.9.0.3/intel/19.0
+      buildable: false
+{% endif %}
+{% if system_hdf5_netcdf %}
+    hdf5:
+      externals:
+      - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared
+        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.3/intel/19.0
       - spec: hdf5@1.12.2.3~cxx+fortran+hl~java~mpi+shared
         prefix: /opt/cray/pe/hdf5/1.12.2.3/intel/19.0
       buildable: false


### PR DESCRIPTION
This merge includes the following fixes:
* Add `use_e3sm_hdf5_netcdf` config options to the `e3sm_unified` section of machine config files
* In E3SM-U, don't use E3SM HDF5, NetCDF or PNetCDF except for Cray machines
* Build with gnu on anvil and compy
* Add "system" rather than "e3sm" hdf5, netcdf, pnetcdf.  For E3SM-Unified, it doesn't seem to be possible to use the same HDF5 and NetCDF as E3SM because ESMF needs to use the non-parallel version.  This also means that we can't load the parallel modules at runtime (because ESMF will use them instead and will fail).
* Add missing csh files in mache.spack to the manifest