### PR TITLE
Remove incorrect netcdf-fortran spec on pm-cpu

### DIFF
--- a/mache/spack/pm-cpu_gnu_mpich.yaml
+++ b/mache/spack/pm-cpu_gnu_mpich.yaml
@@ -128,8 +128,6 @@ spack:
       externals:
       - spec: netcdf-fortran@4.5.3 ^netcdf-c+mpi
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/GNU/9.1
-      - spec: netcdf-fortran@4.5.3 ^netcdf-c~mpi
-        prefix: /opt/cray/pe/netcdf/4.9.0.3/GNU/9.1
       buildable: false
 {% endif %}
 {% if system_hdf5_netcdf %}

--- a/mache/spack/pm-cpu_intel_mpich.yaml
+++ b/mache/spack/pm-cpu_intel_mpich.yaml
@@ -113,8 +113,6 @@ spack:
       externals:
       - spec: netcdf-fortran@4.5.3 ^netcdf-c+mpi
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/intel/19.0
-      - spec: netcdf-fortran@4.5.3 ^netcdf-c~mpi
-        prefix: /opt/cray/pe/netcdf/4.9.0.3/intel/19.0
       buildable: false
 {% endif %}
 {% if system_hdf5_netcdf %}


### PR DESCRIPTION
The version without MPI support should not be in the e3sm_hdf5_netcdf section.