### PR TITLE
Switch E3SM-Unified to intel and intel-mpi on Compy

### DIFF
--- a/mache/machines/compy.cfg
+++ b/mache/machines/compy.cfg
@@ -6,10 +6,10 @@
 group = users
 
 # the compiler set to use for system libraries and MPAS builds
-compiler = gnu
+compiler = intel
 
 # the system MPI library to use for intel18 compiler
-mpi = openmpi
+mpi = impi
 
 # the path to the directory where activation scripts, the base environment, and
 # system libraries will be deployed


### PR DESCRIPTION
We are seeing errors with `ESMF_RegridWeightGen` on Compy when testing with the same files that work fine on other machines.