### PR TITLE
Switch E3SM-Unified back to gnu on Compy

### DIFF
--- a/mache/machines/compy.cfg
+++ b/mache/machines/compy.cfg
@@ -6,10 +6,10 @@
 group = users
 
 # the compiler set to use for system libraries and MPAS builds
-compiler = intel
+compiler = gnu
 
 # the system MPI library to use for intel18 compiler
-mpi = impi
+mpi = openmpi
 
 # the path to the directory where activation scripts, the base environment, and
 # system libraries will be deployed


### PR DESCRIPTION
This reverts commit 58452e0af0e00eefe5f18adfe72543d39f6d86b7.