### PR TITLE
Add `system_hdf5_netcdf` to chicoma spack template

### DIFF
--- a/mache/spack/chicoma-cpu_gnu_mpich.yaml
+++ b/mache/spack/chicoma-cpu_gnu_mpich.yaml
@@ -123,7 +123,7 @@ spack:
         - cray-libsci/22.11.1.2
       buildable: false
 {% endif %}
-{% if e3sm_hdf5_netcdf %}
+{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.1~cxx+fortran+hl~java+mpi+shared


### PR DESCRIPTION
E3SM-Unified is not installing properly without this.