### PR TITLE
Many updates to supported Perlmutter compilers

### DIFF
--- a/mache/cime_machine_config/config_machines.xml
+++ b/mache/cime_machine_config/config_machines.xml
@@ -136,10 +136,10 @@
       <env name="NETCDF_FORTRAN_PATH">/opt/cray/pe/netcdf-hdf5parallel/4.8.1.3/gnu/9.1/</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="gnu">
+    <environment_variables BUILD_THREADED="TRUE" compiler="gnu">
       <env name="OMP_PLACES">cores</env>
     </environment_variables>
   </machine>
@@ -148,7 +148,7 @@
     <DESC>Perlmutter CPU-only nodes at NERSC.  Phase2 only: Each node has 2 AMD EPYC 7713 64-Core (Milan) 512GB</DESC>
     <NODENAME_REGEX>$ENV{NERSC_HOST}:perlmutter</NODENAME_REGEX>
     <OS>Linux</OS>
-    <COMPILERS>gnu,intel,nvidia,amdclang</COMPILERS>
+    <COMPILERS>intel,gnu,nvidia,amdclang</COMPILERS>
     <MPILIBS>mpich</MPILIBS>
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
@@ -160,7 +160,7 @@
     <DIN_LOC_ROOT_CLMFORC>/global/cfs/cdirs/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>/global/cfs/cdirs/e3sm/baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc.cori/cprnc</CCSM_CPRNC>
+    <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>10</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>
     <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
@@ -193,6 +193,8 @@
         <command name="unload">cray-hdf5-parallel</command>
         <command name="unload">cray-netcdf-hdf5parallel</command>
         <command name="unload">cray-parallel-netcdf</command>
+        <command name="unload">cray-netcdf</command>
+        <command name="unload">cray-hdf5</command>
         <command name="unload">PrgEnv-gnu</command>
         <command name="unload">PrgEnv-intel</command>
         <command name="unload">PrgEnv-nvidia</command>
@@ -200,7 +202,10 @@
         <command name="unload">PrgEnv-aocc</command>
         <command name="unload">intel</command>
         <command name="unload">intel-oneapi</command>
+        <command name="unload">nvidia</command>
+        <command name="unload">aocc</command>
         <command name="unload">cudatoolkit</command>
+        <command name="unload">climate-utils</command>
         <command name="unload">craype-accel-nvidia80</command>
         <command name="unload">craype-accel-host</command>
         <command name="unload">perftools-base</command>
@@ -227,14 +232,14 @@
 
       <modules compiler="amdclang">
         <command name="load">PrgEnv-aocc</command>
-        <command name="load">aocc/3.2.0</command>
+        <command name="load">aocc/4.0.0</command>
         <command name="load">cray-libsci/23.02.1.1</command>
       </modules>
 
       <modules>
         <command name="load">craype-accel-host</command>
-        <command name="load">craype/2.7.19</command>
-        <command name="load">cray-mpich/8.1.24</command>
+        <command name="load">craype/2.7.20</command>
+        <command name="load">cray-mpich/8.1.25</command>
         <command name="load">cray-hdf5-parallel/1.12.2.3</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
         <command name="load">cray-parallel-netcdf/1.12.3.3</command>
@@ -257,15 +262,31 @@
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
       <env name="FI_CXI_RX_MATCH_MODE">software</env>
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
+      <env name="Albany_ROOT">$SHELL{if [ -z "$Albany_ROOT" ]; then echo /global/common/software/e3sm/mali_tpls/albany-e3sm-serial-release-gcc; else echo "$Albany_ROOT"; fi}</env>
+      <env name="Trilinos_ROOT">$SHELL{if [ -z "$Trilinos_ROOT" ]; then echo /global/common/software/e3sm/mali_tpls/trilinos-e3sm-serial-release-gcc; else echo "$Trilinos_ROOT"; fi}</env>
+      <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
+      <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
+    </environment_variables>
+    <environment_variables compiler="intel" mpilib="mpich">
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/adios2/2.9.1/cray-mpich-8.1.25/intel-2023.1.0; else echo "$ADIOS2_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="gnu" mpilib="mpich">
-      <env name="ADIOS2_DIR">/global/cfs/cdirs/e3sm/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.15/gcc-11.2.0</env>
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/adios2/2.9.1/cray-mpich-8.1.25/gcc-11.2.0; else echo "$ADIOS2_ROOT"; fi}</env>
+      <env name="BLA_VENDOR">Generic</env>
     </environment_variables>
     <environment_variables compiler="nvidia" mpilib="mpich">
-      <env name="ADIOS2_DIR">/global/cfs/cdirs/e3sm/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.15/nvidia-21.11</env>
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/adios2/2.9.1/cray-mpich-8.1.25/nvidia-22.7; else echo "$ADIOS2_ROOT"; fi}</env>
+    </environment_variables>
+    <environment_variables compiler="nvidia">
+      <env name="BLAS_ROOT">$SHELL{if [ -z "$BLAS_ROOT" ]; then echo /opt/nvidia/hpc_sdk/Linux_x86_64/22.7/compilers; else echo "$BLAS_ROOT"; fi}</env>
+      <env name="LAPACK_ROOT">$SHELL{if [ -z "$LAPACK_ROOT" ]; then echo /opt/nvidia/hpc_sdk/Linux_x86_64/22.7/compilers; else echo "$LAPACK_ROOT"; fi}</env>
+      <env name="BLA_VENDOR">NVHPC</env>
+    </environment_variables>
+    <environment_variables compiler="intel">
+      <env name="BLA_VENDOR">Intel10_64_dyn</env>
     </environment_variables>
     <environment_variables compiler="amdclang" mpilib="mpich">
-      <env name="ADIOS2_DIR">/global/cfs/cdirs/e3sm/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.15/aocc-3.2.0</env>
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/adios2/2.9.1/cray-mpich-8.1.25/aocc-4.0.0; else echo "$ADIOS2_ROOT"; fi}</env>
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>
@@ -288,7 +309,7 @@
     <DIN_LOC_ROOT_CLMFORC>/global/cfs/cdirs/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>/global/cfs/cdirs/e3sm/baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc.cori/cprnc</CCSM_CPRNC>
+    <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>10</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>
     <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
@@ -325,11 +346,19 @@
         <command name="unload">cray-hdf5-parallel</command>
         <command name="unload">cray-netcdf-hdf5parallel</command>
         <command name="unload">cray-parallel-netcdf</command>
+        <command name="unload">cray-netcdf</command>
+        <command name="unload">cray-hdf5</command>
         <command name="unload">PrgEnv-gnu</command>
+        <command name="unload">PrgEnv-intel</command>
         <command name="unload">PrgEnv-nvidia</command>
         <command name="unload">PrgEnv-cray</command>
         <command name="unload">PrgEnv-aocc</command>
+        <command name="unload">intel</command>
+        <command name="unload">intel-oneapi</command>
+        <command name="unload">nvidia</command>
+        <command name="unload">aocc</command>
         <command name="unload">cudatoolkit</command>
+        <command name="unload">climate-utils</command>
         <command name="unload">craype-accel-nvidia80</command>
         <command name="unload">craype-accel-host</command>
         <command name="unload">perftools-base</command>
@@ -348,12 +377,12 @@
       </modules>
 
       <modules compiler="gnugpu">
-        <command name="load">cudatoolkit/11.5</command>
+        <command name="load">cudatoolkit/11.7</command>
         <command name="load">craype-accel-nvidia80</command>
       </modules>
 
       <modules compiler="nvidiagpu">
-        <command name="load">cudatoolkit/11.5</command>
+        <command name="load">cudatoolkit/11.7</command>
         <command name="load">craype-accel-nvidia80</command>
       </modules>
 
@@ -367,8 +396,8 @@
 
       <modules>
         <command name="load">cray-libsci/23.02.1.1</command>
-        <command name="load">craype/2.7.19</command>
-        <command name="load">cray-mpich/8.1.24</command>
+        <command name="load">craype/2.7.20</command>
+        <command name="load">cray-mpich/8.1.25</command>
         <command name="load">cray-hdf5-parallel/1.12.2.3</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
         <command name="load">cray-parallel-netcdf/1.12.3.3</command>
@@ -389,6 +418,8 @@
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
+      <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
+      <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
     </environment_variables>
     <environment_variables compiler="gnugpu">
       <env name="MPICH_GPU_SUPPORT_ENABLED">1</env>
@@ -397,10 +428,155 @@
       <env name="MPICH_GPU_SUPPORT_ENABLED">1</env>
     </environment_variables>
     <environment_variables compiler="gnu.*" mpilib="mpich">
-      <env name="ADIOS2_DIR">/global/cfs/cdirs/e3sm/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.15/gcc-11.2.0</env>
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/adios2/2.9.1/cray-mpich-8.1.25/gcc-11.2.0; else echo "$ADIOS2_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="nvidia.*" mpilib="mpich">
-      <env name="ADIOS2_DIR">/global/cfs/cdirs/e3sm/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.15/nvidia-21.11</env>
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/adios2/2.9.1/cray-mpich-8.1.25/nvidia-22.7; else echo "$ADIOS2_ROOT"; fi}</env>
+    </environment_variables>
+    <resource_limits>
+      <resource name="RLIMIT_STACK">-1</resource>
+    </resource_limits>
+  </machine>
+
+  <machine MACH="muller">
+    <DESC>Muller small internal machine at NERSC with GPU nodes similar to pm-gpu </DESC>
+    <NODENAME_REGEX>$ENV{NERSC_HOST}:muller</NODENAME_REGEX>
+    <OS>Linux</OS>
+    <COMPILERS>gnugpu,gnu,nvidiagpu,nvidia</COMPILERS>
+    <MPILIBS>mpich</MPILIBS>
+    <PROJECT>e3sm_g</PROJECT>
+    <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
+    <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/e3sm_scratch/muller</CIME_OUTPUT_ROOT>
+    <CIME_HTML_ROOT>/global/cfs/cdirs/e3sm/www/$ENV{USER}</CIME_HTML_ROOT>
+    <CIME_URL_ROOT>http://portal.nersc.gov/project/e3sm/$ENV{USER}</CIME_URL_ROOT>
+    <DIN_LOC_ROOT>/global/cfs/cdirs/e3sm/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/global/cfs/cdirs/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/global/cfs/cdirs/e3sm/baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>10</GMAKE_J>
+    <TESTS>e3sm_developer</TESTS>
+    <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
+    <BATCH_SYSTEM>nersc_slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>e3sm</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE compiler="gnu">256</MAX_TASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE compiler="nvidia">256</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>4</MAX_MPITASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE compiler="gnu">64</MAX_MPITASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE compiler="nvidia">64</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+    <mpirun mpilib="default">
+      <executable>srun</executable>
+      <arguments>
+        <arg name="label"> --label</arg>
+        <arg name="num_tasks"> -n {{ total_tasks }} -N {{ num_nodes }}</arg>
+        <arg name="thread_count">-c $SHELL{echo 128/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc}</arg>
+        <arg name="binding"> $SHELL{if [ 64 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu_bind=cores"; else echo "--cpu_bind=threads";fi;} </arg>
+        <arg name="placement"> -m plane=$SHELL{echo `./xmlquery --value MAX_MPITASKS_PER_NODE`}</arg>
+    </arguments>
+    </mpirun>
+    <module_system type="module" allow_error="true">
+      <init_path lang="perl">/usr/share/lmod/8.3.1/init/perl</init_path>
+      <init_path lang="python">/usr/share/lmod/8.3.1/init/python</init_path>
+      <init_path lang="sh">/usr/share/lmod/8.3.1/init/sh</init_path>
+      <init_path lang="csh">/usr/share/lmod/8.3.1/init/csh</init_path>
+      <cmd_path lang="perl">/usr/share/lmod/lmod/libexec/lmod perl</cmd_path>
+      <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+
+      <modules>
+        <command name="unload">cray-hdf5-parallel</command>
+        <command name="unload">cray-netcdf-hdf5parallel</command>
+        <command name="unload">cray-parallel-netcdf</command>
+        <command name="unload">cray-netcdf</command>
+        <command name="unload">cray-hdf5</command>
+        <command name="unload">PrgEnv-gnu</command>
+        <command name="unload">PrgEnv-intel</command>
+        <command name="unload">PrgEnv-nvidia</command>
+        <command name="unload">PrgEnv-cray</command>
+        <command name="unload">PrgEnv-aocc</command>
+        <command name="unload">intel</command>
+        <command name="unload">intel-oneapi</command>
+        <command name="unload">nvidia</command>
+        <command name="unload">aocc</command>
+        <command name="unload">cudatoolkit</command>
+        <command name="unload">climate-utils</command>
+        <command name="unload">craype-accel-nvidia80</command>
+        <command name="unload">craype-accel-host</command>
+        <command name="unload">perftools-base</command>
+        <command name="unload">perftools</command>
+        <command name="unload">darshan</command>
+      </modules>
+
+      <modules compiler="gnu.*">
+        <command name="load">PrgEnv-gnu/8.3.3</command>
+        <command name="load">gcc/11.2.0</command>
+      </modules>
+
+      <modules compiler="nvidia.*">
+        <command name="load">PrgEnv-nvidia</command>
+        <command name="load">nvidia/22.7</command>
+      </modules>
+
+      <modules compiler="gnugpu">
+        <command name="load">cudatoolkit/11.7</command>
+        <command name="load">craype-accel-nvidia80</command>
+      </modules>
+
+      <modules compiler="nvidiagpu">
+        <command name="load">cudatoolkit/11.7</command>
+        <command name="load">craype-accel-nvidia80</command>
+      </modules>
+
+      <modules compiler="gnu">
+        <command name="load">craype-accel-host</command>
+      </modules>
+
+      <modules compiler="nvidia">
+        <command name="load">craype-accel-host</command>
+      </modules>
+
+      <modules>
+        <command name="load">cray-libsci/23.02.1.1</command>
+        <command name="load">craype/2.7.20</command>
+        <command name="load">cray-mpich/8.1.25</command>
+        <command name="load">cray-hdf5-parallel/1.12.2.3</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.3</command>
+        <command name="load">cmake/3.24.3</command>
+      </modules>
+    </module_system>
+
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+
+    <environment_variables>
+      <env name="MPICH_ENV_DISPLAY">1</env>
+      <env name="MPICH_VERSION_DISPLAY">1</env>
+      <env name="OMP_STACKSIZE">128M</env>
+      <env name="OMP_PROC_BIND">spread</env>
+      <env name="OMP_PLACES">threads</env>
+      <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
+      <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
+      <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
+      <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
+      <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
+    </environment_variables>
+    <environment_variables compiler="gnugpu">
+      <env name="MPICH_GPU_SUPPORT_ENABLED">1</env>
+    </environment_variables>
+    <environment_variables compiler="nvidiagpu">
+      <env name="MPICH_GPU_SUPPORT_ENABLED">1</env>
+    </environment_variables>
+    <environment_variables compiler="gnu.*" mpilib="mpich">
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/adios2/2.9.1/cray-mpich-8.1.25/gcc-11.2.0; else echo "$ADIOS2_ROOT"; fi}</env>
+    </environment_variables>
+    <environment_variables compiler="nvidia.*" mpilib="mpich">
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/adios2/2.9.1/cray-mpich-8.1.25/nvidia-22.7; else echo "$ADIOS2_ROOT"; fi}</env>
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>
@@ -411,19 +587,19 @@
     <DESC>test machine at NERSC, very similar to pm-cpu. each node has 2 AMD EPYC 7713 64-Core (Milan) 512GB</DESC>
     <NODENAME_REGEX>$ENV{NERSC_HOST}:alvarez</NODENAME_REGEX>
     <OS>Linux</OS>
-    <COMPILERS>gnu,nvidia,amdclang</COMPILERS>
+    <COMPILERS>intel,gnu,nvidia,amdclang</COMPILERS>
     <MPILIBS>mpich</MPILIBS>
     <PROJECT>e3sm</PROJECT>
     <SAVE_TIMING_DIR>/global/cfs/cdirs/e3sm</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>e3sm,m3411,m3412</SAVE_TIMING_DIR_PROJECTS>
-    <CIME_OUTPUT_ROOT>$ENV{PSCRATCH}/e3sm_scratch/alvarez</CIME_OUTPUT_ROOT>
+    <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/e3sm_scratch/alvarez</CIME_OUTPUT_ROOT>
     <CIME_HTML_ROOT>/global/cfs/cdirs/e3sm/www/$ENV{USER}</CIME_HTML_ROOT>
     <CIME_URL_ROOT>http://portal.nersc.gov/project/e3sm/$ENV{USER}</CIME_URL_ROOT>
     <DIN_LOC_ROOT>/global/cfs/cdirs/e3sm/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/global/cfs/cdirs/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>/global/cfs/cdirs/e3sm/baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc.cori/cprnc</CCSM_CPRNC>
+    <CCSM_CPRNC>/global/cfs/cdirs/e3sm/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>10</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>
     <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
@@ -443,12 +619,12 @@
     </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
-      <init_path lang="perl">/usr/share/lmod/8.3.1/init/perl</init_path>
-      <init_path lang="python">/usr/share/lmod/8.3.1/init/python</init_path>
-      <init_path lang="sh">/usr/share/lmod/8.3.1/init/sh</init_path>
-      <init_path lang="csh">/usr/share/lmod/8.3.1/init/csh</init_path>
-      <cmd_path lang="perl">/usr/share/lmod/lmod/libexec/lmod perl</cmd_path>
-      <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
+      <init_path lang="perl">/opt/cray/pe/lmod/8.7.19/init/perl</init_path>
+      <init_path lang="python">/opt/cray/pe/lmod/8.7.19/init/python</init_path>
+      <init_path lang="sh">/opt/cray/pe/lmod/8.7.19/init/sh</init_path>
+      <init_path lang="csh">/opt/cray/pe/lmod/8.7.19/init/csh</init_path>
+      <cmd_path lang="perl">/opt/cray/pe/lmod/lmod/libexec/lmod perl</cmd_path>
+      <cmd_path lang="python">/opt/cray/pe/lmod/lmod/libexec/lmod python</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
 
@@ -456,11 +632,19 @@
         <command name="unload">cray-hdf5-parallel</command>
         <command name="unload">cray-netcdf-hdf5parallel</command>
         <command name="unload">cray-parallel-netcdf</command>
+        <command name="unload">cray-netcdf</command>
+        <command name="unload">cray-hdf5</command>
         <command name="unload">PrgEnv-gnu</command>
+        <command name="unload">PrgEnv-intel</command>
         <command name="unload">PrgEnv-nvidia</command>
         <command name="unload">PrgEnv-cray</command>
         <command name="unload">PrgEnv-aocc</command>
+        <command name="unload">intel</command>
+        <command name="unload">intel-oneapi</command>
+        <command name="unload">nvidia</command>
+        <command name="unload">aocc</command>
         <command name="unload">cudatoolkit</command>
+        <command name="unload">climate-utils</command>
         <command name="unload">craype-accel-nvidia80</command>
         <command name="unload">craype-accel-host</command>
         <command name="unload">perftools-base</command>
@@ -469,25 +653,33 @@
       </modules>
 
       <modules compiler="gnu">
-        <command name="load">PrgEnv-gnu/8.3.3</command>
-        <command name="load">gcc/12.1.0</command>
+        <command name="load">PrgEnv-gnu</command>
+        <command name="load">gcc</command>
+        <command name="load">cray-libsci</command>
+      </modules>
+
+      <modules compiler="intel">
+        <command name="load">PrgEnv-intel</command>
+        <command name="load">intel</command>
       </modules>
 
       <modules compiler="nvidia">
         <command name="load">PrgEnv-nvidia</command>
         <command name="load">nvidia/22.7</command>
+        <command name="load">cray-libsci</command>
       </modules>
 
       <modules compiler="amdclang">
         <command name="load">PrgEnv-aocc</command>
-        <command name="load">aocc/3.2.0</command>
+        <command name="load">aocc/4.0.0</command>
+        <command name="load">cray-libsci</command>
       </modules>
 
       <modules>
         <command name="load">craype-accel-host</command>
-        <command name="load">cray-libsci/23.02.1.1</command>
-        <command name="load">craype/2.7.19</command>
-        <command name="load">cray-mpich/8.1.24</command>
+        <command name="load">cray-libsci</command>
+        <command name="load">craype/2.7.21</command>
+        <command name="load">cray-mpich/8.1.26</command>
         <command name="load">cray-hdf5-parallel/1.12.2.3</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
         <command name="load">cray-parallel-netcdf/1.12.3.3</command>
@@ -509,6 +701,8 @@
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
       <env name="FI_CXI_RX_MATCH_MODE">software</env>
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
+      <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
+      <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>
@@ -589,7 +783,7 @@
       <env name="NETCDF_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
@@ -704,19 +898,19 @@
       <env name="AMD_LOG_LEVEL">10</env>
       <env name="CRAY_ACC_DEBUG">3</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
     </environment_variables>
     <environment_variables compiler="gnu.*" mpilib="mpich">
-      <env name="ADIOS2_DIR">/lustre/orion/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/gcc-11.2.0</env>
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /lustre/orion/cli115/world-shared/frontier/3rdparty/adios2/2.9.1/cray-mpich-8.1.23/gcc-11.2.0; else echo "$ADIOS2_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="crayclang.*" mpilib="mpich">
-      <env name="ADIOS2_DIR">/lustre/orion/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/crayclang-14.0.2</env>
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /lustre/orion/cli115/world-shared/frontier/3rdparty/adios2/2.9.1/cray-mpich-8.1.23/crayclang-15.0.1; else echo "$ADIOS2_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="amdclang.*" mpilib="mpich">
-      <env name="ADIOS2_DIR">/lustre/orion/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/amdclang-15.0.0</env>
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /lustre/orion/cli115/world-shared/frontier/3rdparty/adios2/2.9.1/cray-mpich-8.1.23/amdclang-15.0.0; else echo "$ADIOS2_ROOT"; fi}</env>
     </environment_variables>
   </machine>
 
@@ -827,19 +1021,10 @@
       <env name="AMD_LOG_LEVEL">10</env>
       <env name="CRAY_ACC_DEBUG">3</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
-    </environment_variables>
-    <environment_variables compiler="gnu.*" mpilib="mpich">
-      <env name="ADIOS2_DIR">/lustre/orion/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/gcc-11.2.0</env>
-    </environment_variables>
-    <environment_variables compiler="crayclang.*" mpilib="mpich">
-      <env name="ADIOS2_DIR">/lustre/orion/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/crayclang-14.0.2</env>
-    </environment_variables>
-    <environment_variables compiler="amdclang.*" mpilib="mpich">
-      <env name="ADIOS2_DIR">/lustre/orion/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/amdclang-15.0.0</env>
     </environment_variables>
   </machine>
 
@@ -932,13 +1117,10 @@
       <env name="MPICH_GPU_SUPPORT_ENABLED">0</env>
     </environment_variables>
 
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
-    </environment_variables>
-    <environment_variables compiler="crayclang-scream" mpilib="mpich">
-      <env name="ADIOS2_DIR">/lustre/orion/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/crayclang-14.0.2</env>
     </environment_variables>
   </machine>
 
@@ -1018,13 +1200,10 @@
       <env name="PNETCDF_HINTS">romio_cb_read=disable</env>
     </environment_variables>
 
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
-    </environment_variables>
-    <environment_variables compiler="crayclang-scream" mpilib="mpich">
-      <env name="ADIOS2_DIR">/lustre/orion/cli133/world-shared/3rdparty/adios2/2.8.3.patch/cray-mpich-8.1.17/crayclang-14.0.2</env>
     </environment_variables>
   </machine>
 
@@ -1042,7 +1221,7 @@
     <DIN_LOC_ROOT_CLMFORC>$ENV{SCRATCH}/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>$ENV{SCRATCH}/baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>$ENV{SCRATCH}/tools/cprnc.cori/cprnc</CCSM_CPRNC>
+    <CCSM_CPRNC>$ENV{SCRATCH}/tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
@@ -1111,6 +1290,8 @@
       <env name="OMP_PLACES">threads</env>
       <env name="I_MPI_PIN">1</env>
       <env name="MY_MPIRUN_OPTIONS">-l</env>
+      <env name="NETCDF_PATH">$ENV{TACC_NETCDF_DIR}</env>
+      <env name="PNETCDF_PATH">$ENV{TACC_PNETCDF_DIR}</env>
     </environment_variables>
   </machine>
 
@@ -1202,6 +1383,9 @@
     <module_system type="none"/>
     <RUNDIR>$ENV{HOME}/e3sm_scratch/$CASE/run</RUNDIR>
     <EXEROOT>$ENV{HOME}/e3sm_scratch/$CASE/bld</EXEROOT>
+    <environment_variables>
+      <env name="LAPACK_ROOT">$ENV{BLASLAPACK_LIBDIR}</env>
+    </environment_variables>
   </machine>
 
   <machine MACH="singularity">
@@ -1243,7 +1427,7 @@
     <environment_variables mpilib="!mpi-serial">
       <env name="NETCDF_PATH">/usr/local/packages/netcdf-parallel</env>
       <env name="PNETCDF_PATH">/usr/local/packages/pnetcdf</env>
-      <env name="HDF5_PATH">/usr/local/packages/hdf5-parallel</env>
+      <env name="HDF5_ROOT">/usr/local/packages/hdf5-parallel</env>
       <env name="PATH">/usr/local/packages/cmake/bin:/usr/local/packages/mpich/bin:/usr/local/packages/hdf5-parallel/bin:/usr/local/packages/netcdf-parallel/bin:/usr/local/packages/pnetcdf/bin:$ENV{PATH}</env>
       <env name="LD_LIBRARY_PATH">/usr/local/packages/mpich/lib:/usr/local/packages/szip/lib:/usr/local/packages/hdf5-parallel/lib:/usr/local/packages/netcdf-parallel/lib:/usr/local/packages/pnetcdf/lib</env>
     </environment_variables>
@@ -1393,10 +1577,11 @@
     <MAX_GB_OLD_TEST_DATA>0</MAX_GB_OLD_TEST_DATA>
     <!--    <GMAKE>make</GMAKE> <- this doesn't actually work! -->
     <environment_variables>
-      <env name="NETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
+      <env name="NETCDF_PATH">$ENV{SEMS_NETCDF_ROOT}</env>
       <env name="OMP_STACKSIZE">64M</env>
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
+      <env name="BLA_VENDOR">Generic</env>
     </environment_variables>
   </machine>
 
@@ -1451,6 +1636,9 @@
       <env name="PATH">/ascldap/users/projects/e3sm/scream/libs/gcc/install/weaver/gcc/8.5.0/bin:/ascldap/users/projects/e3sm/scream/libs/gcc/install/weaver/gcc/8.5.0/libexec/gcc/powerpc64le-unknown-linux-gnu/8.5.0:/ascldap/users/projects/e3sm/scream/libs/openmpi/install/weaver/gcc/8.5.0/cuda/10.1.105/bin:/ascldap/users/projects/e3sm/scream/libs/pnetcdf/install/weaver/gcc/8.5.0/cuda/10.1.105/bin:/ascldap/users/projects/e3sm/scream/libs/netcdf-c/install/weaver/gcc/8.5.0/cuda/10.1.105/bin:/ascldap/users/projects/e3sm/scream/libs/netcdf-fortran/install/weaver/gcc/8.5.0/cuda/10.1.105/bin:/ascldap/users/projects/e3sm/scream/libs/wget/bin:/ascldap/users/jgfouca/perl5/bin:$ENV{PATH}</env>
       <env name="PERL5LIB">/ascldap/users/jgfouca/perl5/lib/perl5</env>
       <env name="PERL_LOCAL_LIB_ROOT">/ascldap/users/jgfouca/perl5</env>
+      <env name="NETCDF_C_PATH">/ascldap/users/projects/e3sm/scream/libs/netcdf-c/install/weaver/gcc/8.5.0/cuda/10.1.105</env>
+      <env name="NETCDF_FORTRAN_PATH">/ascldap/users/projects/e3sm/scream/libs/netcdf-fortran/install/weaver/gcc/8.5.0/cuda/10.1.105</env>
+      <env name="PNETCDF_PATH">/ascldap/users/projects/e3sm/scream/libs/pnetcdf/install/weaver/gcc/8.5.0/cuda/10.1.105</env>
     </environment_variables>
   </machine>
 
@@ -1592,7 +1780,7 @@
       <!-- We currently don't have a soft env for mpich 3.3.2 built with gcc 8.2.0 -->
       <env name="PATH">/soft/apps/packages/climate/mpich/3.3.2/gcc-8.2.0/bin:/soft/apps/packages/climate/cmake/3.18.4/bin:/soft/apps/packages/climate/gmake/bin:$ENV{PATH}</env>
       <!-- We currently don't have a soft env for parallel hdf5 built with mpich 3.3.2 and gcc 8.2.0 -->
-      <env name="HDF5_PATH">/soft/apps/packages/climate/hdf5/1.8.16-parallel/mpich-3.3.2/gcc-8.2.0</env>
+      <env name="HDF5_ROOT">/soft/apps/packages/climate/hdf5/1.8.16-parallel/mpich-3.3.2/gcc-8.2.0</env>
       <!-- We currently don't have a soft env for netcdf parallel built with mpich 3.3.2 and gcc 8.2.0 -->
       <env name="NETCDF_PATH">/soft/apps/packages/climate/netcdf/4.4.1c-4.2cxx-4.4.4f-parallel/mpich-3.3.2/gcc-8.2.0</env>
       <!-- We currently don't have a soft env for pnetcdf built with mpich 3.3.2 and gcc 8.2.0 -->
@@ -1601,28 +1789,22 @@
     <environment_variables mpilib="openmpi">
       <!-- We currently don't have a soft env for openmpi 2.1.5, zlib, szip, hdf5, NetCDF and PnetCDF libraries -->
       <env name="PATH">/soft/apps/packages/climate/openmpi/2.1.5/gcc-8.2.0/bin:/soft/apps/packages/climate/cmake/3.18.4/bin:/soft/apps/packages/climate/gmake/bin:$ENV{PATH}</env>
-      <env name="ZLIB_PATH">/soft/apps/packages/climate/zlib/1.2.11/gcc-8.2.0-static</env>
-      <env name="SZIP_PATH">/soft/apps/packages/climate/szip/2.1/gcc-8.2.0-static</env>
-      <env name="HDF5_PATH">/soft/apps/packages/climate/hdf5/1.8.12-parallel/openmpi-2.1.5/gcc-8.2.0-static</env>
+      <env name="ZLIB_ROOT">/soft/apps/packages/climate/zlib/1.2.11/gcc-8.2.0-static</env>
+      <env name="SZIP_ROOT">/soft/apps/packages/climate/szip/2.1/gcc-8.2.0-static</env>
+      <env name="HDF5_ROOT">/soft/apps/packages/climate/hdf5/1.8.12-parallel/openmpi-2.1.5/gcc-8.2.0-static</env>
       <env name="NETCDF_PATH">/soft/apps/packages/climate/netcdf/4.7.4c-4.3.1cxx-4.4.4f-parallel/openmpi-2.1.5/gcc-8.2.0-static-hdf5-1.8.12-pnetcdf-1.12.0</env>
       <env name="PNETCDF_PATH">/soft/apps/packages/climate/pnetcdf/1.12.0/openmpi-2.1.5/gcc-8.2.0</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
     <environment_variables>
       <env name="PERL5LIB">/soft/apps/packages/climate/perl5/lib/perl5</env>
     </environment_variables>
-    <environment_variables compiler="gnu" mpilib="mpich">
-      <env name="ADIOS2_DIR">/soft/apps/packages/climate/adios2/2.7.0/mpich-3.3.2/gcc-8.2.0</env>
-    </environment_variables>
-    <environment_variables compiler="gnu" mpilib="openmpi">
-      <env name="ADIOS2_DIR">/soft/apps/packages/climate/adios2/2.7.0/openmpi-2.1.5/gcc-8.2.0</env>
-    </environment_variables>
   </machine>
 
-  <machine MACH="anlgce-ub18">
-    <DESC>ANL CELS General Computing Environment (Linux) workstation (Ubuntu 18.04)</DESC>
+  <machine MACH="anlgce-ub22">
+    <DESC>ANL CELS General Computing Environment (Linux) workstation (Ubuntu 22.04)</DESC>
     <NODENAME_REGEX>compute-386-01|compute-386-02</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>gnu</COMPILERS>
@@ -1655,59 +1837,53 @@
       </arguments>
     </mpirun>
     <module_system type="module">
-      <init_path lang="python">/nfs/gce/software/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.3.0/lmod-7.7.29-zg24dcc/lmod/lmod/init/env_modules_python.py</init_path>
-      <init_path lang="perl">/nfs/gce/software/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.3.0/lmod-7.7.29-zg24dcc/lmod/lmod/init/perl</init_path>
-      <init_path lang="bash">/nfs/gce/software/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.3.0/lmod-7.7.29-zg24dcc/lmod/lmod/init/bash</init_path>
-      <init_path lang="sh">/nfs/gce/software/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.3.0/lmod-7.7.29-zg24dcc/lmod/lmod/init/sh</init_path>
-      <init_path lang="csh">/nfs/gce/software/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.3.0/lmod-7.7.29-zg24dcc/lmod/lmod/init/csh</init_path>
-      <cmd_path lang="python">/nfs/gce/software/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.3.0/lmod-7.7.29-zg24dcc/lmod/lmod/libexec/lmod python</cmd_path>
+      <init_path lang="python">/nfs/gce/software/custom/linux-ubuntu22.04-x86_64/spack/opt/spack/linux-ubuntu22.04-x86_64/gcc-11.2.0/lmod-8.5.6-hkjjxhp/lmod/8.5.6/init/env_modules_python.py</init_path>
+      <init_path lang="perl">/nfs/gce/software/custom/linux-ubuntu22.04-x86_64/spack/opt/spack/linux-ubuntu22.04-x86_64/gcc-11.2.0/lmod-8.5.6-hkjjxhp/lmod/lmod/init/perl</init_path>
+      <init_path lang="bash">/nfs/gce/software/custom/linux-ubuntu22.04-x86_64/spack/opt/spack/linux-ubuntu22.04-x86_64/gcc-11.2.0/lmod-8.5.6-hkjjxhp/lmod/lmod/init/bash</init_path>
+      <init_path lang="sh">/nfs/gce/software/custom/linux-ubuntu22.04-x86_64/spack/opt/spack/linux-ubuntu22.04-x86_64/gcc-11.2.0/lmod-8.5.6-hkjjxhp/lmod/lmod/init/sh</init_path>
+      <init_path lang="csh">/nfs/gce/software/custom/linux-ubuntu22.04-x86_64/spack/opt/spack/linux-ubuntu22.04-x86_64/gcc-11.2.0/lmod-8.5.6-hkjjxhp/lmod/lmod/init/csh</init_path>
+      <cmd_path lang="python">/nfs/gce/software/custom/linux-ubuntu22.04-x86_64/spack/opt/spack/linux-ubuntu22.04-x86_64/gcc-11.2.0/lmod-8.5.6-hkjjxhp/lmod/lmod/libexec/lmod python</cmd_path>
       <cmd_path lang="perl">module</cmd_path>
       <cmd_path lang="bash">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
         <command name="purge"/>
-        <command name="load">autoconf/2.69-tz6eue5</command>
-        <command name="load">automake/1.16.3-fm5m6qc</command>
-        <command name="load">libtool/2.4.6-jdxbjft</command>
-        <command name="load">m4/1.4.19-wq3bm42</command>
-        <command name="load">cmake/3.20.5-yjp2hz6</command>
-        <command name="load">gcc/11.1.0-5ikoznk</command>
-        <command name="load">zlib/1.2.11-smoyzzo</command>
+        <command name="load">gcc/12.1.0</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <environment_variables mpilib="mpi-serial">
       <!-- We currently don't have modules for serial NetCDF -->
-      <env name="NETCDF_PATH">/nfs/gce/projects/climate/software/netcdf/4.8.0c-4.3.1cxx-4.5.3f-serial/gcc-11.1.0</env>
+      <env name="NETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/netcdf/4.8.0c-4.3.1cxx-4.5.3f-serial/gcc-12.1.0</env>
     </environment_variables>
     <environment_variables mpilib="mpich">
       <!-- We currently don't have modules for HDF5, NetCDF & PnetCDF -->
-      <env name="LD_LIBRARY_PATH">/nfs/gce/projects/climate/software/mpich/3.4.2/gcc-11.1.0/lib:$ENV{LD_LIBRARY_PATH}</env>
-      <env name="PATH">/nfs/gce/projects/climate/software/mpich/3.4.2/gcc-11.1.0/bin:$ENV{PATH}</env>
-      <env name="ZLIB_PATH">/nfs/gce/software/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.11-smoyzzo</env>
-      <env name="HDF5_PATH">/nfs/gce/projects/climate/software/hdf5/1.12.1/mpich-3.4.2/gcc-11.1.0</env>
-      <env name="NETCDF_PATH">/nfs/gce/projects/climate/software/netcdf/4.8.0c-4.3.1cxx-4.5.3f-parallel/mpich-3.4.2/gcc-11.1.0</env>
-      <env name="PNETCDF_PATH">/nfs/gce/projects/climate/software/pnetcdf/1.12.2/mpich-3.4.2/gcc-11.1.0</env>
+      <env name="LD_LIBRARY_PATH">/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/mpich/4.1.2/gcc-12.1.0/lib:$ENV{LD_LIBRARY_PATH}</env>
+      <env name="PATH">/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/mpich/4.1.2/gcc-12.1.0/bin:$ENV{PATH}</env>
+      <env name="ZLIB_ROOT">/nfs/gce/software/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/zlib-1.2.11-p7dmb5p</env>
+      <env name="HDF5_ROOT">/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/hdf5/1.12.2/mpich-4.1.2/gcc-12.1.0</env>
+      <env name="NETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/netcdf/4.8.0c-4.3.1cxx-4.5.3f-parallel/mpich-4.1.2/gcc-12.1.0</env>
+      <env name="PNETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/pnetcdf/1.12.3/mpich-4.1.2/gcc-12.1.0</env>
     </environment_variables>
     <environment_variables mpilib="openmpi">
       <!-- We currently don't have modules for HDF5, NetCDF & PnetCDF -->
-      <env name="LD_LIBRARY_PATH">/nfs/gce/projects/climate/software/openmpi/4.1.3/gcc-11.1.0/lib:$ENV{LD_LIBRARY_PATH}</env>
-      <env name="PATH">/nfs/gce/projects/climate/software/openmpi/4.1.3/gcc-11.1.0/bin:$ENV{PATH}</env>
-      <env name="ZLIB_PATH">/nfs/gce/software/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.11-smoyzzo</env>
-      <env name="HDF5_PATH">/nfs/gce/projects/climate/software/hdf5/1.12.1/openmpi-4.1.3/gcc-11.1.0</env>
-      <env name="NETCDF_PATH">/nfs/gce/projects/climate/software/netcdf/4.8.0c-4.3.1cxx-4.5.3f-parallel/openmpi-4.1.3/gcc-11.1.0</env>
-      <env name="PNETCDF_PATH">/nfs/gce/projects/climate/software/pnetcdf/1.12.2/openmpi-4.1.3/gcc-11.1.0</env>
+      <env name="LD_LIBRARY_PATH">/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/openmpi/4.1.6/gcc-12.1.0/lib:$ENV{LD_LIBRARY_PATH}</env>
+      <env name="PATH">/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/openmpi/4.1.6/gcc-12.1.0/bin:$ENV{PATH}</env>
+      <env name="ZLIB_ROOT">/nfs/gce/software/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/zlib-1.2.11-p7dmb5p</env>
+      <env name="HDF5_ROOT">/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/hdf5/1.12.2/openmpi-4.1.6/gcc-12.1.0</env>
+      <env name="NETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/netcdf/4.8.0c-4.3.1cxx-4.5.3f-parallel/openmpi-4.1.6/gcc-12.1.0</env>
+      <env name="PNETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/pnetcdf/1.12.3/openmpi-4.1.6/gcc-12.1.0</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
     <environment_variables>
       <env name="PERL5LIB">/nfs/gce/projects/climate/software/perl5/lib/perl5</env>
     </environment_variables>
     <environment_variables compiler="gnu" mpilib="mpich">
-      <env name="ADIOS2_DIR">/nfs/gce/projects/climate/software/adios2/2.8.3.patch/mpich-3.4.2/gcc-11.1.0</env>
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/adios2/2.9.1/mpich-4.1.2/gcc-12.1.0; else echo "$ADIOS2_ROOT"; fi}</env>
     </environment_variables>
   </machine>
 
@@ -1776,28 +1952,30 @@
       <!-- We currently don't have modules for HDF5, NetCDF & PnetCDF -->
       <env name="LD_LIBRARY_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/mpich/4.0/gcc-11.1.0/lib:$ENV{LD_LIBRARY_PATH}</env>
       <env name="PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/mpich/4.0/gcc-11.1.0/bin:$ENV{PATH}</env>
-      <env name="ZLIB_PATH">/nfs/gce/software/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/zlib-1.2.11-p7dmb5p</env>
-      <env name="HDF5_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/hdf5/1.12.1/mpich-4.0/gcc-11.1.0</env>
+      <env name="ZLIB_ROOT">/nfs/gce/software/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/zlib-1.2.11-p7dmb5p</env>
+      <env name="HDF5_ROOT">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/hdf5/1.12.1/mpich-4.0/gcc-11.1.0</env>
       <env name="NETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/netcdf/4.8.0c-4.3.1cxx-4.5.3f-parallel/mpich-4.0/gcc-11.1.0</env>
       <env name="PNETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/pnetcdf/1.12.2/mpich-4.0/gcc-11.1.0</env>
+      <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /nfs/gce/projects/climate/software/moab/devel/mpich-4.0/gcc-11.1.0; else echo "$MOAB_ROOT"; fi}</env>
+      <env name="MOAB_PATH">/nfs/gce/projects/climate/software/moab/devel/mpich-4.0/gcc-11.1.0</env>
     </environment_variables>
     <environment_variables mpilib="openmpi">
       <!-- We currently don't have modules for HDF5, NetCDF & PnetCDF -->
       <env name="LD_LIBRARY_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/openmpi/4.1.3/gcc-11.1.0/lib:$ENV{LD_LIBRARY_PATH}</env>
       <env name="PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/openmpi/4.1.3/gcc-11.1.0/bin:$ENV{PATH}</env>
-      <env name="ZLIB_PATH">/nfs/gce/software/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/zlib-1.2.11-p7dmb5p</env>
-      <env name="HDF5_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/hdf5/1.12.1/openmpi-4.1.3/gcc-11.1.0</env>
+      <env name="ZLIB_ROOT">/nfs/gce/software/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/zlib-1.2.11-p7dmb5p</env>
+      <env name="HDF5_ROOT">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/hdf5/1.12.1/openmpi-4.1.3/gcc-11.1.0</env>
       <env name="NETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/netcdf/4.8.0c-4.3.1cxx-4.5.3f-parallel/openmpi-4.1.3/gcc-11.1.0</env>
       <env name="PNETCDF_PATH">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/pnetcdf/1.12.2/openmpi-4.1.3/gcc-11.1.0</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
     <environment_variables>
       <env name="PERL5LIB">/nfs/gce/projects/climate/software/perl5/lib/perl5</env>
     </environment_variables>
     <environment_variables compiler="gnu" mpilib="mpich">
-      <env name="ADIOS2_DIR">/nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/adios2/2.8.3.patch/mpich-4.0/gcc-11.1.0</env>
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /nfs/gce/projects/climate/software/linux-ubuntu20.04-x86_64/adios2/2.9.1/mpich-4.0/gcc-11.1.0; else echo "$ADIOS2_ROOT"; fi}</env>
     </environment_variables>
   </machine>
 
@@ -1867,13 +2045,11 @@
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
 
     <environment_variables>
-      <env name="NETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
-      <env name="NETCDF_INCLUDES">$ENV{SEMS_NETCDF_ROOT}/include</env>
-      <env name="NETCDF_LIBS">$ENV{SEMS_NETCDF_ROOT}/lib</env>
+      <env name="NETCDF_PATH">$ENV{SEMS_NETCDF_ROOT}</env>
       <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
     <environment_variables mpilib="!mpi-serial">
-      <env name="PNETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
+      <env name="PNETCDF_PATH">$ENV{SEMS_NETCDF_ROOT}</env>
     </environment_variables>
   </machine>
 
@@ -1938,13 +2114,11 @@
     <!-- complete path to a short term archiving directory -->
     <!-- path to the cprnc tool used to compare netcdf history files in testing -->
     <environment_variables>
-      <env name="NETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
-      <env name="NETCDF_INCLUDES">$ENV{SEMS_NETCDF_ROOT}/include</env>
-      <env name="NETCDF_LIBS">$ENV{SEMS_NETCDF_ROOT}/lib</env>
+      <env name="NETCDF_PATH">$ENV{SEMS_NETCDF_ROOT}</env>
       <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
     <environment_variables mpilib="!mpi-serial">
-      <env name="PNETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
+      <env name="PNETCDF_PATH">$ENV{SEMS_NETCDF_ROOT}</env>
     </environment_variables>
   </machine>
 
@@ -1990,7 +2164,7 @@
       <cmd_path lang="csh">module</cmd_path>
       <modules>
         <command name="purge"/>
-        <command name="load">cmake/3.20.3-vedypwm</command>
+        <command name="load">cmake/3.26.3-nszudya</command>
       </modules>
       <modules compiler="intel">
         <command name="load">gcc/7.4.0</command>
@@ -2047,7 +2221,7 @@
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
-    <MAX_GB_OLD_TEST_DATA>1000</MAX_GB_OLD_TEST_DATA>
+    <MAX_GB_OLD_TEST_DATA>0</MAX_GB_OLD_TEST_DATA>
     <environment_variables>
       <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
@@ -2066,33 +2240,15 @@
     <environment_variables mpilib="impi" DEBUG="TRUE">
       <env name="I_MPI_DEBUG">10</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="intel">
+    <environment_variables BUILD_THREADED="TRUE" compiler="intel">
       <env name="KMP_AFFINITY">granularity=core,balanced</env>
       <env name="KMP_HOT_TEAMS_MODE">1</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="gnu">
+    <environment_variables BUILD_THREADED="TRUE" compiler="gnu">
       <env name="OMP_PLACES">cores</env>
-    </environment_variables>
-    <environment_variables compiler="intel" mpilib="impi">
-      <env name="ADIOS2_DIR">/lcrc/group/e3sm/3rdparty/anvil/adios2/2.8.3.patch/intel-mpi-2019.9.304/intel-20.0.4</env>
-    </environment_variables>
-    <environment_variables compiler="gnu" mpilib="impi">
-      <env name="ADIOS2_DIR">/lcrc/group/e3sm/3rdparty/anvil/adios2/2.8.3.patch/intel-mpi-2019.9.304/gcc-8.2.0</env>
-    </environment_variables>
-    <environment_variables compiler="intel" mpilib="openmpi">
-      <env name="ADIOS2_DIR">/lcrc/group/e3sm/3rdparty/anvil/adios2/2.8.3.patch/openmpi-4.1.1/intel-20.0.4</env>
-    </environment_variables>
-    <environment_variables compiler="gnu" mpilib="openmpi">
-      <env name="ADIOS2_DIR">/lcrc/group/e3sm/3rdparty/anvil/adios2/2.8.3.patch/openmpi-4.1.1/gcc-8.2.0</env>
-    </environment_variables>
-    <environment_variables compiler="intel" mpilib="mvapich">
-      <env name="ADIOS2_DIR">/lcrc/group/e3sm/3rdparty/anvil/adios2/2.8.3.patch/mvapich2-2.3.6/intel-20.0.4</env>
-    </environment_variables>
-    <environment_variables compiler="gnu" mpilib="mvapich">
-      <env name="ADIOS2_DIR">/lcrc/group/e3sm/3rdparty/anvil/adios2/2.8.3.patch/mvapich2-2.2/gcc-8.2.0</env>
     </environment_variables>
   </machine>
 
@@ -2206,29 +2362,23 @@
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="intel" MAX_TASKS_PER_NODE="!128">
+    <environment_variables BUILD_THREADED="TRUE" compiler="intel" MAX_TASKS_PER_NODE="!128">
       <env name="KMP_AFFINITY">granularity=core,balanced</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="intel" MAX_TASKS_PER_NODE="128">
+    <environment_variables BUILD_THREADED="TRUE" compiler="intel" MAX_TASKS_PER_NODE="128">
       <env name="KMP_AFFINITY">granularity=thread,balanced</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="gnu">
+    <environment_variables BUILD_THREADED="TRUE" compiler="gnu">
       <env name="OMP_PLACES">cores</env>
     </environment_variables>
     <environment_variables compiler="intel" mpilib="openmpi">
-      <env name="ADIOS2_DIR">/lcrc/group/e3sm/3rdparty/chrysalis/adios2/2.8.3.patch/openmpi-4.1.3/intel-20.0.4</env>
+      <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /lcrc/soft/climate/moab/chrysalis/intel; else echo "$MOAB_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="gnu" mpilib="openmpi">
-      <env name="ADIOS2_DIR">/lcrc/group/e3sm/3rdparty/chrysalis/adios2/2.8.3.patch/openmpi-4.1.3/gcc-9.2.0</env>
-    </environment_variables>
-    <environment_variables compiler="intel" mpilib="impi">
-      <env name="ADIOS2_DIR">/lcrc/group/e3sm/3rdparty/chrysalis/adios2/2.8.3.patch/intel-mpi-2019.9.304/intel-20.0.4</env>
-    </environment_variables>
-    <environment_variables compiler="gnu" mpilib="impi">
-      <env name="ADIOS2_DIR">/lcrc/group/e3sm/3rdparty/chrysalis/adios2/2.8.3.patch/intel-mpi-2019.9.304/gcc-9.2.0</env>
+      <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /lcrc/soft/climate/moab/chrysalis/gnu; else echo "$MOAB_ROOT"; fi}</env>
     </environment_variables>
   </machine>
 
@@ -2302,7 +2452,7 @@
       <env name="MV2_DEBUG_SHOW_BACKTRACE">1</env>
       <env name="MV2_SHOW_ENV_INFO">2</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">64M</env>
       <env name="OMP_PLACES">cores</env>
     </environment_variables>
@@ -2373,7 +2523,7 @@
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
       <env name="PATH">/lcrc/group/e3sm/soft/perl/5.26.0/bin:$ENV{PATH}</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">64M</env>
       <env name="OMP_PLACES">cores</env>
     </environment_variables>
@@ -2464,6 +2614,7 @@
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
+    <MAX_GB_OLD_TEST_DATA>0</MAX_GB_OLD_TEST_DATA>
     <environment_variables>
       <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
@@ -2473,80 +2624,15 @@
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
     </environment_variables>
     <environment_variables compiler="gnu">
-      <env name="HDF5_PATH">$SHELL{which h5dump | xargs dirname | xargs dirname}</env>
+      <env name="HDF5_ROOT">$SHELL{which h5dump | xargs dirname | xargs dirname}</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
     </environment_variables>
     <environment_variables mpilib="impi">
       <env name="I_MPI_FABRICS">shm:tmi</env>
-    </environment_variables>
-    <environment_variables compiler="intel" mpilib="impi">
-      <env name="ADIOS2_DIR">/lcrc/group/e3sm/3rdparty/bebop/adios2/2.8.3.patch/intel-mpi-2018.4.274/intel-18.0.4</env>
-    </environment_variables>
-    <environment_variables compiler="gnu" mpilib="impi">
-      <env name="ADIOS2_DIR">/lcrc/group/e3sm/3rdparty/bebop/adios2/2.8.3.patch/intel-mpi-2018.4.274/gcc-8.2.0</env>
-    </environment_variables>
-    <environment_variables compiler="intel" mpilib="mvapich">
-      <env name="ADIOS2_DIR">/lcrc/group/e3sm/3rdparty/bebop/adios2/2.8.3.patch/mvapich2-2.3.1/intel-18.0.4</env>
-    </environment_variables>
-    <environment_variables compiler="gnu" mpilib="mvapich">
-      <env name="ADIOS2_DIR">/lcrc/group/e3sm/3rdparty/bebop/adios2/2.8.3.patch/mvapich2-2.3/gcc-8.2.0</env>
-    </environment_variables>
-  </machine>
-
-  <machine MACH="syrah">
-    <DESC>LLNL Linux Cluster, Linux (pgi), 16 pes/node, batch system is Slurm</DESC>
-    <OS>LINUX</OS>
-    <COMPILERS>intel</COMPILERS>
-    <MPILIBS>mpich</MPILIBS>
-    <PROJECT>cbronze</PROJECT>
-    <CIME_OUTPUT_ROOT>/p/lustre2/$USER/e3sm_scratch/syrah</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/usr/gdata/climdat/ccsm3data/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/usr/gdata/climdat/ccsm3data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-    <DOUT_S_ROOT>/p/lustre2/$USER/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>/p/lustre2/$USER/ccsm_baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/usr/gdata/climdat/tools/cprnc</CCSM_CPRNC>
-    <GMAKE_J>8</GMAKE_J>
-    <BATCH_SYSTEM>lc_slurm</BATCH_SYSTEM>
-    <SUPPORTED_BY>donahue5 -at- llnl.gov</SUPPORTED_BY>
-    <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
-    <mpirun mpilib="mpi-serial">
-      <executable/>
-    </mpirun>
-    <mpirun mpilib="default">
-      <executable>srun</executable>
-    </mpirun>
-    <module_system type="module">
-      <init_path lang="python">/usr/share/lmod/lmod/init/env_modules_python.py</init_path>
-      <init_path lang="perl">/usr/share/lmod/lmod/init/perl</init_path>
-      <init_path lang="sh">/usr/share/lmod/lmod/init/sh</init_path>
-      <init_path lang="csh">/usr/share/lmod/lmod/init/csh</init_path>
-      <cmd_path lang="csh">module</cmd_path>
-      <cmd_path lang="sh">module</cmd_path>
-      <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
-      <cmd_path lang="perl">/usr/share/lmod/lmod/libexec/lmod perl</cmd_path>
-      <modules compiler="intel">
-        <command name="load">python</command>
-        <command name="load">git</command>
-        <command name="load">intel/19.0.4</command>
-        <command name="load">mvapich2/2.3</command>
-        <command name="load">cmake/3.18.0</command>
-        <command name="load">netcdf-fortran/4.4.4</command>
-        <command name="load">pnetcdf/1.9.0</command>
-      </modules>
-    </module_system>
-    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
-    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
-    <environment_variables compiler="intel">
-      <env name="NETCDFROOT">/usr/tce/packages/netcdf-fortran/netcdf-fortran-4.4.4-intel-19.0.4/</env>
-      <env name="NETCDF_PATH">/usr/tce/packages/netcdf-fortran/netcdf-fortran-4.4.4-intel-19.0.4/</env>
-    </environment_variables>
-    <environment_variables compiler="intel" mpilib="!mpi-serial">
-      <env name="PNETCDFROOT">/usr/tce/packages/pnetcdf/pnetcdf-1.9.0-intel-19.0.4-mvapich2-2.3/</env>
     </environment_variables>
   </machine>
 
@@ -2583,24 +2669,23 @@
       <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
       <cmd_path lang="perl">/usr/share/lmod/lmod/libexec/lmod perl</cmd_path>
       <modules compiler="intel">
-        <command name="load">python/3.8.2</command>
+        <command name="load">python/3.9.12</command>
         <command name="load">git</command>
-        <command name="load">intel/19.0.4</command>
-        <command name="load">mvapich2/2.3</command>
-        <command name="load">cmake/3.18.0</command>
-        <command name="load">netcdf-fortran/4.4.4</command>
-        <command name="load">pnetcdf/1.9.0</command>
+        <command name="load">mkl/2022.1.0</command>
+        <command name="load">intel-classic/2021.6.0-magic</command>
+        <command name="load">mvapich2/2.3.7</command>
+        <command name="load">cmake/3.19.2</command>
+        <command name="load">netcdf-fortran-parallel/4.6.0</command>
+        <command name="load">netcdf-c-parallel/4.9.0</command>
+        <command name="load">parallel-netcdf/1.12.3</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <environment_variables compiler="intel">
-      <env name="NETCDFROOT">/usr/tce/packages/netcdf-fortran/netcdf-fortran-4.4.4-intel-19.0.4/</env>
-      <env name="NETCDF_PATH">/usr/tce/packages/netcdf-fortran/netcdf-fortran-4.4.4-intel-19.0.4/</env>
-    </environment_variables>
-    <environment_variables compiler="intel" mpilib="!mpi-serial">
-      <env name="PNETCDFROOT">/usr/tce/packages/pnetcdf/pnetcdf-1.9.0-intel-19.0.4-mvapich2-2.3/</env>
-    </environment_variables>
+      <env name="NETCDF_PATH">/usr/tce/packages/netcdf-fortran/netcdf-fortran-4.6.0-mvapich2-2.3.7-intel-classic-2021.6.0/</env>
+      <env name="PNETCDF_PATH">/usr/tce/packages/parallel-netcdf/parallel-netcdf-1.12.3-mvapich2-2.3.7-intel-classic-2021.6.0/</env>
+      </environment_variables>
   </machine>
 
   <machine MACH="quartz">
@@ -2640,17 +2725,21 @@
         <command name="load">git</command>
         <command name="load">mkl/2022.1.0</command>
         <command name="load">intel-classic/2021.6.0-magic</command>
-        <command name="load">mvapich2/2.3.6</command>
+        <command name="load">mvapich2/2.3.7</command>
         <command name="load">cmake/3.19.2</command>
-        <command name="load">netcdf-fortran-parallel/4.6.0</command>
-        <command name="load">netcdf-c-parallel/4.9.0</command>
+        <command name="use --append">/usr/gdata/climdat/install/quartz/modulefiles</command>
+        <command name="load">hdf5/1.12.2</command>
+        <command name="load">netcdf-c/4.9.0</command>
+        <command name="load">netcdf-fortran/4.6.0</command>
+        <command name="load">parallel-netcdf/1.12.3</command>
+        <command name="load">screamML-venv/0.0.1</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <environment_variables compiler="intel">
-      <env name="NETCDFROOT">/usr/tce/packages/netcdf-fortran/netcdf-fortran-4.6.0-mvapich2-2.3.6-intel-classic-2021.6.0/</env>
-      <env name="NETCDF_PATH">/usr/tce/packages/netcdf-fortran/netcdf-fortran-4.6.0-mvapich2-2.3.6-intel-classic-2021.6.0/</env>
+      <env name="NETCDF_PATH">/usr/gdata/climdat/install/quartz/netcdf-fortran/</env>
+      <env name="PNETCDF_PATH">/usr/tce/packages/parallel-netcdf/parallel-netcdf-1.12.3-mvapich2-2.3.7-intel-classic-2021.6.0</env>
     </environment_variables>
   </machine>
 
@@ -2744,18 +2833,13 @@
       <env name="HDF5_DISABLE_VERSION_CHECK">1</env>
       <env name="labeling">-e PMI_LABEL_ERROUT=1</env>
       <env name="SMP_VARS"> </env>
+      <env name="NETCDF_PATH">$ENV{NETCDF_DIR}</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="intel">
+    <environment_variables BUILD_THREADED="TRUE" compiler="intel">
       <env name="SMP_VARS">-e OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS} -e OMP_STACKSIZE=128M -e KMP_AFFINITY=granularity=thread,scatter</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="!intel">
+    <environment_variables BUILD_THREADED="TRUE" compiler="!intel">
       <env name="SMP_VARS">-e OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS} -e OMP_STACKSIZE=128M -e OMP_PROC_BIND=spread -e OMP_PLACES=threads</env>
-    </environment_variables>
-    <environment_variables compiler="intel" mpilib="mpt">
-      <env name="ADIOS2_DIR">/projects/ClimateEnergy_4/3rdparty/adios2/2.7.0/cray-mpich-7.7.14/intel-19.1.0</env>
-    </environment_variables>
-    <environment_variables compiler="gnu" mpilib="mpt">
-      <env name="ADIOS2_DIR">/projects/ClimateEnergy_4/3rdparty/adios2/2.7.0/cray-mpich-7.7.14/gcc-9.3.0</env>
     </environment_variables>
   </machine>
 
@@ -2763,7 +2847,7 @@
     <DESC>ANL experimental/evaluation cluster, batch system is cobalt</DESC>
     <NODENAME_REGEX>jlse.*</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <COMPILERS>oneapi-ifx,oneapi-ifxgpu,oneapi-ifort,gnu</COMPILERS>
+    <COMPILERS>oneapi-ifx,oneapi-ifxgpu,gnu</COMPILERS>
     <MPILIBS>mpich,impi,openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>/gpfs/jlse-fs0/projects/climate/$USER/scratch</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/gpfs/jlse-fs0/projects/climate/inputdata</DIN_LOC_ROOT>
@@ -2823,6 +2907,7 @@
       <env name="PATH">/home/azamat/soft/perl/5.32.0/bin:$ENV{PATH}</env>
       <env name="NETCDF_PATH">/home/azamat/soft/netcdf/4.4.1c-4.2cxx-4.4.4f/oneapi-2020.12.15.004-intel_mpi-2019.4.243</env>
       <env name="PNETCDF_PATH">/home/azamat/soft/pnetcdf/1.12.1/oneapi-2020.12.15.004-intel_mpi-2019.4.243</env>
+      <env name="LAPACK_ROOT">/home/azamat/soft/libs</env>
     </environment_variables>
     <environment_variables mpilib="mpich" DEBUG="TRUE">
       <env name="HYDRA_TOPO_DEBUG">1</env>
@@ -2865,11 +2950,11 @@
       <env name="LIBOMPTARGET_DEBUG">0</env><!--default 0, max 5 -->
       <env name="OMP_TARGET_OFFLOAD">DISABLED</env><!--default OMP_TARGET_OFFLOAD=MANDATORY-->
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="!gnu">
+    <environment_variables BUILD_THREADED="TRUE" compiler="!gnu">
       <env name="KMP_AFFINITY">verbose,granularity=thread,balanced</env>
       <env name="OMP_STACKSIZE">128M</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="gnu">
+    <environment_variables BUILD_THREADED="TRUE" compiler="gnu">
       <env name="OMP_PLACES">threads</env>
       <env name="OMP_STACKSIZE">128M</env>
     </environment_variables>
@@ -2882,7 +2967,7 @@
     <DESC>ANL Sunspot Test and Development System (TDS), batch system is pbspro</DESC>
     <NODENAME_REGEX>uan-.*</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <COMPILERS>oneapi-ifx,oneapi-ifxgpu,oneapi-ifort,gnu</COMPILERS>
+    <COMPILERS>oneapi-ifx,oneapi-ifxgpu,gnu</COMPILERS>
     <MPILIBS>mpich,impi,openmpi</MPILIBS>
     <CHARGE_ACCOUNT>CSC249ADSE15_CNDA</CHARGE_ACCOUNT>
     <SAVE_TIMING_DIR>/gila/CSC249ADSE15_CNDA/performance_archive</SAVE_TIMING_DIR>
@@ -2933,26 +3018,16 @@
        <modules>
           <command name="purge"></command>
           <command name="use">/soft/modulefiles</command>
-          <command name="load">spack cmake</command>
-          <command name="use">/soft/restricted/CNDA/updates/modulefiles</command>
+          <command name="load">spack cmake/3.26.3-gcc-11.2.0-vnn7ncx</command>
+          <command name="load">prepend-deps/default</command>
         </modules>
         <modules compiler="!gnu">
-          <command name="load">oneapi/eng-compiler/2022.12.30.003</command>
-          <command name="load">mpich/52.2/icc-all-pmix-gpu</command>
-          <!--command name="load">oneapi/eng-compiler/.2023.05.15.002-rc02</command-->
-          <!--command name="load">oneapi/eng-compiler/.2023.05.15.003-rc08</command-->
-          <!--command name="load">oneapi/eng-compiler/2022.10.15.006</command-->
-          <!--command name="load">mpich/50.2/icc-all-pmix-gpu</command-->
-          <!--command name="load">intel_compute_runtime/release/22.43.24595.30</command-->
+          <command name="unload">gcc</command>
+          <command name="load">oneapi/eng-compiler/2023.05.15.007</command>
         </modules>
         <modules compiler="gnu">
            <command name="unload">spack cmake</command>
            <command name="load">gcc/10.3.0</command>
-        </modules>
-        <modules>
-          <command name="load">cray-pals</command>
-          <command name="load">append-deps/default</command>
-          <command name="load">libfabric/1.15.2.0</command>
         </modules>
      </module_system>
      <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -2960,6 +3035,8 @@
      <environment_variables>
         <env name="NETCDF_PATH">/lus/gila/projects/CSC249ADSE15_CNDA/software/oneAPI.2022.12.30.003/netcdf</env>
         <env name="PNETCDF_PATH">/lus/gila/projects/CSC249ADSE15_CNDA/software/oneAPI.2022.12.30.003/pnetcdf</env>
+        <env name="LD_LIBRARY_PATH">/lus/gila/projects/CSC249ADSE15_CNDA/software/oneAPI.2022.12.30.003/netcdf/lib:$ENV{LD_LIBRARY_PATH}</env>
+        <env name="PATH">/lus/gila/projects/CSC249ADSE15_CNDA/software/oneAPI.2022.12.30.003/netcdf/bin:$ENV{PATH}</env>
      </environment_variables>
      <environment_variables mpilib="mpich" DEBUG="TRUE">
         <env name="HYDRA_TOPO_DEBUG">1</env>
@@ -2991,11 +3068,120 @@
         <env name="MPIR_CVAR_ENABLE_GPU">0</env>
         <env name="GPU_TILE_COMPACT"> </env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="!gnu">
+    <environment_variables BUILD_THREADED="TRUE" compiler="!gnu">
         <env name="KMP_AFFINITY">verbose,granularity=thread,balanced</env>
         <env name="OMP_STACKSIZE">128M</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="gnu">
+    <environment_variables BUILD_THREADED="TRUE" compiler="gnu">
+        <env name="OMP_PLACES">threads</env>
+        <env name="OMP_STACKSIZE">128M</env>
+    </environment_variables>
+    <resource_limits>
+        <resource name="RLIMIT_STACK">-1</resource>
+    </resource_limits>
+  </machine>
+
+  <machine MACH="aurora">
+    <DESC>ALCF Aurora, 10624 nodes, 2x52c SPR, 6x2s PVC, 2x512GB DDR5, 2x64GB CPU-HBM, 6x128GB GPU-HBM, Slingshot 11, PBSPro</DESC>
+    <NODENAME_REGEX>aurora-uan-.*</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>oneapi-ifx,oneapi-ifxgpu,gnu</COMPILERS>
+    <MPILIBS>mpich</MPILIBS>
+    <CHARGE_ACCOUNT>CSC249ADSE15_CNDA</CHARGE_ACCOUNT>
+    <SAVE_TIMING_DIR>/lus/gecko/projects/CSC249ADSE15_CNDA/performance_archive</SAVE_TIMING_DIR>
+    <SAVE_TIMING_DIR_PROJECTS>.*</SAVE_TIMING_DIR_PROJECTS>
+    <CIME_OUTPUT_ROOT>/lus/gecko/projects/CSC249ADSE15_CNDA/$USER/scratch</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/lus/gecko/projects/CSC249ADSE15_CNDA/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/lus/gecko/projects/CSC249ADSE15_CNDA/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/lus/gecko/projects/CSC249ADSE15_CNDA/baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/lus/gecko/projects/CSC249ADSE15_CNDA/tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>16</GMAKE_J>
+    <TESTS>e3sm_developer</TESTS>
+    <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
+    <BATCH_SYSTEM>pbspro</BATCH_SYSTEM>
+    <SUPPORTED_BY>e3sm</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>208</MAX_TASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE compiler="oneapi-ifxgpu">104</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>104</MAX_MPITASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE compiler="oneapi-ifxgpu">12</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
+    <mpirun mpilib="default">
+       <executable>mpiexec</executable>
+       <!--executable>numactl -m 2-3 mpiexec</executable--><!--for HBM runs-->
+       <arguments>
+          <arg name="total_num_tasks">-np {{ total_tasks }} --label</arg>
+          <arg name="ranks_per_node">-ppn {{ tasks_per_node }}</arg>
+          <arg name="ranks_bind">--cpu-bind $ENV{RANKS_BIND} -envall</arg>
+          <arg name="threads_per_rank">-d $ENV{OMP_NUM_THREADS}</arg>
+          <arg name="gpu_maps">$ENV{GPU_TILE_COMPACT}</arg>
+       </arguments>
+    </mpirun>
+    <module_system type="module" allow_error="true">
+       <init_path lang="sh">/lus/gecko/projects/CSC249ADSE15_CNDA/modules/lmod.sh</init_path>
+       <init_path lang="csh">/soft/sunspot_migrate/soft/packaging/lmod/lmod/init/csh</init_path>
+       <init_path lang="python">/soft/sunspot_migrate/soft/packaging/lmod/lmod/init/env_modules_python.py</init_path>
+       <cmd_path lang="sh">module</cmd_path>
+       <cmd_path lang="csh">module</cmd_path>
+       <cmd_path lang="python">/soft/sunspot_migrate/soft/packaging/lmod/lmod/libexec/lmod python</cmd_path>
+       <modules>
+          <command name="purge"></command>
+          <command name="use">/soft/modulefiles</command>
+          <command name="use">/soft/restricted/CNDA/updates/modulefiles</command>
+          <command name="load">spack-pe-gcc cmake</command>
+        </modules>
+        <modules compiler="!gnu">
+          <command name="load">oneapi/eng-compiler/2023.05.15.007</command>
+        </modules>
+        <modules compiler="gnu">
+           <command name="unload">spack-pe-gcc cmake</command>
+           <command name="load">gcc/10.3.0</command>
+        </modules>
+        <modules>
+          <command name="load">cray-pals</command>
+          <command name="load">libfabric/1.15.2.0</command>
+          <command name="load">cray-libpals/1.3.2</command>
+        </modules>
+     </module_system>
+     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+     <environment_variables>
+        <env name="NETCDF_C_PATH">/lus/gecko/projects/CSC249ADSE15_CNDA/software/netcdf-c/4.9.2/oneapi.eng.2023.05.15.007</env>
+        <env name="NETCDF_FORTRAN_PATH">/lus/gecko/projects/CSC249ADSE15_CNDA/software/netcdf-fortran/4.6.1/oneapi.eng.2023.05.15.007</env>
+        <env name="PNETCDF_PATH">/lus/gecko/projects/CSC249ADSE15_CNDA/software/pnetcdf/1.12.3/oneapi.eng.2023.05.15.007</env>
+        <env name="LD_LIBRARY_PATH">/lus/gecko/projects/CSC249ADSE15_CNDA/software/pnetcdf/1.12.3/oneapi.eng.2023.05.15.007/lib:/lus/gecko/projects/CSC249ADSE15_CNDA/software/netcdf-fortran/4.6.1/oneapi.eng.2023.05.15.007/lib:/lus/gecko/projects/CSC249ADSE15_CNDA/software/netcdf-c/4.9.2/oneapi.eng.2023.05.15.007/lib:$ENV{LD_LIBRARY_PATH}</env>
+        <env name="PATH">/lus/gecko/projects/CSC249ADSE15_CNDA/software/pnetcdf/1.12.3/oneapi.eng.2023.05.15.007/bin:/lus/gecko/projects/CSC249ADSE15_CNDA/software/netcdf-fortran/4.6.1/oneapi.eng.2023.05.15.007/bin:/lus/gecko/projects/CSC249ADSE15_CNDA/software/netcdf-c/4.9.2/oneapi.eng.2023.05.15.007/bin:$ENV{PATH}</env>
+        <env name="RANKS_BIND">list:0-7,104-111:8-15,112-119:16-23,120-127:24-31,128-135:32-39,136-143:40-47,144-151:52-59,156-163:60-67,164-171:68-75,172-179:76-83,180-187:84-91,188-195:92-99,196-203</env>
+     </environment_variables>
+     <environment_variables DEBUG="TRUE">
+        <env name="HYDRA_TOPO_DEBUG">1</env>
+     </environment_variables>
+     <environment_variables compiler="oneapi-ifxgpu">
+        <env name="ONEAPI_DEVICE_SELECTOR">level_zero:gpu</env>
+        <env name="ONEAPI_MPICH_GPU">NO_GPU</env>
+        <env name="MPIR_CVAR_ENABLE_GPU">0</env>
+        <env name="romio_cb_read">disable</env>
+        <env name="romio_cb_write">disable</env>
+        <env name="SYCL_CACHE_PERSISTENT">1</env>
+        <env name="GATOR_INITIAL_MB">4000MB</env>
+        <env name="GATOR_DISABLE">0</env>
+        <env name="GPU_TILE_COMPACT">/soft/tools/mpi_wrapper_utils/gpu_tile_compact.sh</env>
+        <env name="FI_CXI_DEFAULT_CQ_SIZE">131072</env>
+        <env name="FI_CXI_CQ_FILL_PERCENT">20</env>
+    </environment_variables>
+    <environment_variables compiler="oneapi-ifx">
+        <env name="LIBOMPTARGET_DEBUG">0</env><!--default 0, max 5 -->
+        <env name="OMP_TARGET_OFFLOAD">DISABLED</env><!--default OMP_TARGET_OFFLOAD=MANDATORY-->
+        <env name="FI_CXI_DEFAULT_CQ_SIZE">131072</env>
+        <env name="FI_CXI_CQ_FILL_PERCENT">20</env>
+        <env name="MPIR_CVAR_ENABLE_GPU">0</env>
+        <env name="GPU_TILE_COMPACT"> </env>
+    </environment_variables>
+    <environment_variables BUILD_THREADED="TRUE" compiler="!gnu">
+        <env name="KMP_AFFINITY">verbose,granularity=thread,balanced</env>
+        <env name="OMP_STACKSIZE">128M</env>
+    </environment_variables>
+    <environment_variables BUILD_THREADED="TRUE" compiler="gnu">
         <env name="OMP_PLACES">threads</env>
         <env name="OMP_STACKSIZE">128M</env>
     </environment_variables>
@@ -3149,7 +3335,7 @@
     <EXEROOT>$CIME_OUTPUT_ROOT/csmruns/$CASE/bld</EXEROOT>
     <environment_variables>
       <env name="OMP_STACKSIZE">64M</env>
-      <env name="NETCDF_HOME">$ENV{NETCDF_ROOT}</env>
+      <env name="NETCDF_PATH">$ENV{NETCDF_ROOT}</env>
     </environment_variables>
     <environment_variables compiler="intel">
       <env name="MKL_PATH">$ENV{MLIBHOME}</env>
@@ -3271,7 +3457,7 @@
     </environment_variables>
     <environment_variables>
       <env name="OMP_STACKSIZE">64M</env>
-      <env name="NETCDF_HOME">$ENV{NETCDF_LIB}/../</env>
+      <env name="NETCDF_PATH">$ENV{NETCDF_LIB}/../</env>
     </environment_variables>
     <environment_variables compiler="intel">
       <env name="MKL_PATH">$ENV{MKLROOT}</env>
@@ -3366,7 +3552,8 @@
     <TEST_TPUT_TOLERANCE>0.05</TEST_TPUT_TOLERANCE>
     <MAX_GB_OLD_TEST_DATA>0</MAX_GB_OLD_TEST_DATA>
     <environment_variables>
-      <env name="NETCDF_HOME">$ENV{NETCDF_ROOT}/</env>
+      <env name="NETCDF_PATH">$ENV{NETCDF_ROOT}/</env>
+      <env name="PNETCDF_PATH">$ENV{PNETCDF_ROOT}/</env>
       <env name="MKL_PATH">$ENV{MKLROOT}</env>
     </environment_variables>
     <environment_variables compiler="intel">
@@ -3382,21 +3569,9 @@
     <environment_variables mpilib="impi" DEBUG="TRUE">
       <env name="I_MPI_DEBUG">10</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">64M</env>
       <env name="OMP_PLACES">cores</env>
-    </environment_variables>
-    <environment_variables compiler="intel" mpilib="impi">
-      <env name="ADIOS2_DIR">/qfs/people/wuda020/3rdparty/adios2/2.8.3.patch/intelmpi-2019u4/intel-19.0.5</env>
-    </environment_variables>
-    <environment_variables compiler="pgi" mpilib="impi">
-      <env name="ADIOS2_DIR">/qfs/people/wuda020/3rdparty/adios2/2.8.3.patch/intelmpi-2019u3/pgi-19.10</env>
-    </environment_variables>
-    <environment_variables compiler="intel" mpilib="mvapich2">
-      <env name="ADIOS2_DIR">/qfs/people/wuda020/3rdparty/adios2/2.8.3.patch/mvapich2-2.3.1/intel-19.0.4</env>
-    </environment_variables>
-    <environment_variables compiler="pgi" mpilib="mvapich2">
-      <env name="ADIOS2_DIR">/qfs/people/wuda020/3rdparty/adios2/2.8.3.patch/mvapich2-2.3.1/pgi-19.7</env>
     </environment_variables>
   </machine>
 
@@ -3477,7 +3652,7 @@
     <TEST_TPUT_TOLERANCE>0.05</TEST_TPUT_TOLERANCE>
     <MAX_GB_OLD_TEST_DATA>0</MAX_GB_OLD_TEST_DATA>
     <environment_variables>
-      <env name="HDF5_PATH">$SHELL{dirname $(dirname $(which h5diff))}</env>
+      <env name="HDF5_ROOT">$SHELL{dirname $(dirname $(which h5diff))}</env>
       <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
       <env name="MKL_PATH">$ENV{MKLROOT}</env>
@@ -3493,7 +3668,7 @@
     <environment_variables mpilib="impi" DEBUG="TRUE">
       <env name="I_MPI_DEBUG">10</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">64M</env>
       <env name="OMP_PLACES">cores</env>
     </environment_variables>
@@ -3595,6 +3770,9 @@
     </environment_variables>
     <environment_variables>
       <env name="PERL5LIB">/software/user_tools/current/cades-ccsi/perl5/lib/perl5/</env>
+      <env name="NETCDF_PATH">/software/dev_tools/swtree/cs400_centos7.2_pe2016-08/netcdf-hdf5parallel/4.3.3.1/centos7.2_gnu5.3.0</env>
+      <env name="PNETCDF_PATH">/software/dev_tools/swtree/cs400_centos7.2_pe2016-08/pnetcdf/1.9.0/centos7.2_gnu5.3.0</env>
+      <env name="LAPACK_ROOT">/software/tools/compilers/intel_2017/mkl/lib/intel64</env>
     </environment_variables>
 
   </machine>
@@ -3672,8 +3850,6 @@
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <environment_variables>
-      <env name="PNETCDF_PATH">$ENV{PNETCDF_PATH}</env>
-      <env name="NETCDF_PATH">$ENV{NETCDF_PATH}</env>
       <env name="MKLROOT">$ENV{MKLROOT}</env>
       <env name="PNETCDF_HINTS">romio_ds_write=disable;romio_ds_read=disable;romio_cb_write=enable;romio_cb_read=enable</env>
     </environment_variables>
@@ -3752,8 +3928,6 @@
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
     <environment_variables>
-      <env name="PNETCDF_PATH">$ENV{PNETCDF_PATH}</env>
-      <env name="NETCDF_PATH">$ENV{NETCDF_PATH}</env>
       <env name="MKLROOT">$ENV{MKLROOT}</env>
       <env name="PNETCDF_HINTS">romio_ds_write=disable;romio_ds_read=disable;romio_cb_write=enable;romio_cb_read=enable</env>
     </environment_variables>
@@ -3810,30 +3984,31 @@
         <command name="unload">PrgEnv-aocc</command>
         <command name="unload">craype-accel-nvidia80</command>
         <command name="unload">craype-accel-host</command>
+        <command name="unload">cce</command>
       </modules>
 
       <modules compiler="gnu">
-        <command name="load">PrgEnv-gnu/8.3.3</command>
-        <command name="load">gcc/12.1.0</command>
+        <command name="load">PrgEnv-gnu/8.4.0</command>
+        <command name="load">gcc/12.2.0</command>
       </modules>
 
       <modules compiler="nvidia">
-        <command name="load">PrgEnv-nvidia/8.3.3</command>
-        <command name="load">nvidia/22.3</command>
+        <command name="load">PrgEnv-nvidia/8.4.0</command>
+        <command name="load">nvidia/22.7</command>
       </modules>
 
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel/8.3.3</command>
-        <command name="load">intel-classic/2022.2.1</command>
+        <command name="load">PrgEnv-intel/8.4.0</command>
+        <command name="load">intel-classic/2023.2.0</command>
       </modules>
 
       <modules compiler="aocc">
-        <command name="load">PrgEnv-aocc</command>
+        <command name="load">PrgEnv-aocc/8.4.0</command>
         <command name="load">aocc/3.2.0</command>
       </modules>
 
       <modules compiler="amdclang">
-        <command name="load">PrgEnv-aocc</command>
+        <command name="load">PrgEnv-aocc/8.4.0</command>
         <command name="load">aocc/3.2.0</command>
       </modules>
 
@@ -3841,12 +4016,12 @@
         <command name="load">craype-accel-host</command>
         <command name="load">cray-libsci</command>
         <command name="load">craype</command>
-        <command name="load">cray-mpich/8.1.21</command>
-        <command name="load">libfabric/1.15.0.0</command>
-        <command name="load">cray-hdf5-parallel/1.12.2.1</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.9.0.1</command>
-        <command name="load">cray-parallel-netcdf/1.12.3.1</command>
-        <command name="load">cmake/3.20.3</command>
+        <command name="load">cray-mpich/8.1.26</command>
+        <command name="load">libfabric/1.15.2.0</command>
+        <command name="load">cray-hdf5-parallel/1.12.2.3</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.3</command>
+        <command name="load">cmake/3.22.3</command>
       </modules>
     </module_system>
 
@@ -3865,6 +4040,8 @@
       <env name="PNETCDF_HINTS">romio_ds_write=disable;romio_ds_read=disable;romio_cb_write=enable;romio_cb_read=enable</env>
       <env name="FI_CXI_RX_MATCH_MODE">software</env>
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
+      <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
+      <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>
@@ -3952,6 +4129,9 @@
     <!-- complete path to a long term archiving directory -->
     <!-- where the cesm testing scripts write and read baseline results -->
     <!-- path to the cprnc tool used to compare netcdf history files in testing -->
+    <environment_variables>
+      <env name="NETCDF_PATH">/soft/netcdf/fortran-4.4-intel-sp1-update3-parallel/lib</env>
+    </environment_variables>
   </machine>
 
   <machine MACH="lawrencium-lr3">
@@ -4031,6 +4211,12 @@
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+
+    <environment_variables>
+      <env name="NETCDF_PATH">$ENV{NETCDF_DIR}</env>
+      <env name="PNETCDF_PATH">$ENV{PNETCDF_DIR}</env>
+      <env name="LAPACK_ROOT">/global/software/sl-6.x86_64/modules/intel/2016.1.150/lapack/3.6.0-intel</env>
+    </environment_variables>
   </machine>
 
   <machine MACH="lawrencium-lr6">
@@ -4059,12 +4245,10 @@
       </arguments>
     </mpirun>
     <mpirun mpilib="default">
-
       <executable>mpirun</executable>
       <arguments>
         <arg name="num_tasks">-np {{ total_tasks }}</arg>
       </arguments>
-
     </mpirun>
     <module_system type="module">
       <init_path lang="sh">/etc/profile.d/modules.sh</init_path>
@@ -4076,10 +4260,10 @@
       <cmd_path lang="perl">/usr/Modules/bin/modulecmd perl</cmd_path>
       <cmd_path lang="python">/usr/Modules/bin/modulecmd python</cmd_path>
       <modules>
-	     <command name="purge"/>
+	<command name="purge"/>
         <command name="load">cmake/3.15.0</command>
         <command name="load">perl</command>
-	     <command name="load">xml-libxml/2.0116</command>
+	<command name="load">xml-libxml/2.0116</command>
         <command name="load">python/3.6</command>
       </modules>
       <modules compiler="intel">
@@ -4110,6 +4294,12 @@
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+
+    <environment_variables>
+      <env name="NETCDF_PATH">$ENV{NETCDF_DIR}</env>
+      <env name="PNETCDF_PATH">$ENV{PNETCDF_DIR}</env>
+      <env name="LAPACK_ROOT">/global/software/sl-6.x86_64/modules/intel/2016.1.150/lapack/3.6.0-intel</env>
+    </environment_variables>
   </machine>
 
   <machine MACH="lobata">
@@ -4188,6 +4378,7 @@
     <module_system type="none"/>
     <environment_variables compiler="gnu" >
       <env name="CMAKE_ROOT">/usr/local/share/cmake-3.21/</env>
+      <env name="NETCDF_PATH">$ENV{NETCDF_HOME}</env>
     </environment_variables>
   </machine>
 
@@ -4290,16 +4481,19 @@
     <environment_variables>
       <env name="NETCDF_C_PATH">$ENV{OLCF_NETCDF_C_ROOT}</env>
       <env name="NETCDF_FORTRAN_PATH">$ENV{OLCF_NETCDF_FORTRAN_ROOT}</env>
+      <env name="LAPACK_ROOT">$ENV{OLCF_NETLIB_LAPACK_ROOT}</env>
+      <env name="BLA_VENDOR">Generic</env>
       <env name="ESSL_PATH">$ENV{OLCF_ESSL_ROOT}</env>
-      <env name="HDF5_PATH">$ENV{OLCF_HDF5_ROOT}</env>
+      <env name="HDF5_ROOT">$ENV{OLCF_HDF5_ROOT}</env>
+      <env name="HDF5_USE_STATIC_LIBRARIES">True</env>
       <env name="PNETCDF_PATH">$ENV{OLCF_PARALLEL_NETCDF_ROOT}</env>
       <env name="PGI_ACC_POOL_ALLOC">0</env>
       <env name="SMPIARGS"> </env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="FALSE">
+    <environment_variables BUILD_THREADED="FALSE">
       <env name="JSRUN_THREAD_VARS"> </env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="JSRUN_THREAD_VARS">-E OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS} -E OMP_PROC_BIND=spread -E OMP_PLACES=threads -E OMP_STACKSIZE=256M</env>
     </environment_variables>
     <environment_variables compiler=".*gpu.*">
@@ -4359,13 +4553,13 @@
       <env name="PAMI_IBV_DEVICE_NAME">mlx5_0:1,mlx5_3:1</env>
     </environment_variables>
     <environment_variables compiler="ibm.*" mpilib="spectrum-mpi">
-      <env name="ADIOS2_DIR">/gpfs/alpine/cli115/world-shared/3rdparty/adios2/2.8.3.patch/spectrum-mpi-10.4.0.3/xl-16.1.1-10</env>
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /gpfs/alpine/cli115/world-shared/3rdparty/adios2/2.9.1/spectrum-mpi-10.4.0.3/xl-16.1.1-10; else echo "$ADIOS2_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="pgi.*" mpilib="spectrum-mpi">
-      <env name="ADIOS2_DIR">/gpfs/alpine/cli115/world-shared/3rdparty/adios2/2.8.3.patch/spectrum-mpi-10.4.0.3/nvhpc-21.11</env>
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /gpfs/alpine/cli115/world-shared/3rdparty/adios2/2.9.1/spectrum-mpi-10.4.0.3/nvhpc-21.11; else echo "$ADIOS2_ROOT"; fi}</env>
     </environment_variables>
     <environment_variables compiler="gnu.*" mpilib="spectrum-mpi">
-      <env name="ADIOS2_DIR">/gpfs/alpine/cli115/world-shared/3rdparty/adios2/2.8.3.patch/spectrum-mpi-10.4.0.3/gcc-9.1.0</env>
+      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /gpfs/alpine/cli115/world-shared/3rdparty/adios2/2.9.1/spectrum-mpi-10.4.0.3/gcc-9.1.0; else echo "$ADIOS2_ROOT"; fi}</env>
     </environment_variables>
   </machine>
 
@@ -4464,15 +4658,18 @@
       <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
+      <env name="LAPACK_ROOT">$ENV{OLCF_NETLIB_LAPACK_ROOT}</env>
+      <env name="BLA_VENDOR">Generic</env>
       <env name="ESSL_PATH">$ENV{OLCF_ESSL_ROOT}</env>
-      <env name="HDF5_PATH">$ENV{OLCF_HDF5_ROOT}</env>
+      <env name="HDF5_ROOT">$ENV{OLCF_HDF5_ROOT}</env>
+      <env name="HDF5_USE_STATIC_LIBRARIES">True</env>
       <env name="PGI_ACC_POOL_ALLOC">0</env>
       <env name="SMPIARGS"> </env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="FALSE">
+    <environment_variables BUILD_THREADED="FALSE">
       <env name="JSRUN_THREAD_VARS"> </env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="JSRUN_THREAD_VARS">-E OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS} -E OMP_PROC_BIND=spread -E OMP_PLACES=threads -E OMP_STACKSIZE=256M</env>
     </environment_variables>
     <environment_variables compiler=".*gpu.*">
@@ -4637,7 +4834,7 @@
       <env name="LD_LIBRARY_PATH">/home/groups/coegroup/e3sm/soft/openmpi/2.1.6/gcc/8.2.0/lib:/home/groups/coegroup/e3sm/soft/netcdf/4.4.1c-4.2cxx-4.4.4f/gcc/8.2.0/lib:$ENV{LD_LIBRARY_PATH}</env>
       <env name="PNETCDF_PATH">/home/groups/coegroup/e3sm/soft/pnetcdf/1.12.1/gcc/8.2.0/openmpi/2.1.6</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PLACES">threads</env>
     </environment_variables>
@@ -4724,17 +4921,17 @@
     <TEST_TPUT_TOLERANCE>0.2</TEST_TPUT_TOLERANCE>
     <TEST_MEMLEAK_TOLERANCE>0.20</TEST_MEMLEAK_TOLERANCE>
     <environment_variables compiler="gnu">
-      <env name="HDF5_PATH">$SHELL{dirname $(dirname $(which h5diff))}</env>
+      <env name="HDF5_ROOT">$SHELL{dirname $(dirname $(which h5diff))}</env>
       <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf-config))}</env>
       <env name="OPENBLAS_PATH">/opt/apps/spack/opt/spack/linux-centos7-zen2/gcc-12.2.0/openblas-0.3.21-z66r7lyxwkhsshgreexm4cedffp73scp</env>
-      <env name="LAPACK_PATH">/opt/apps/spack/opt/spack/linux-centos7-zen2/gcc-12.2.0/netlib-lapack-3.10.1-lkhddpuidlw2z74g5ui6eq5iattsfjxp</env>
+      <env name="LAPACK_ROOT">/opt/apps/spack/opt/spack/linux-centos7-zen2/gcc-12.2.0/netlib-lapack-3.10.1-lkhddpuidlw2z74g5ui6eq5iattsfjxp</env>
       <env name="PERL5LIB">$ENV{PERL5LIB}:/opt/apps/spack/opt/spack/linux-centos7-zen2/gcc-12.2.0/perl-5.36.0-sly2pft2edg2p3iyijfyy6dzntusokno/lib/site_perl/5.36.0</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
     </environment_variables>
 
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PLACES">threads</env>
     </environment_variables>
@@ -4814,16 +5011,16 @@
     <TEST_TPUT_TOLERANCE>0.2</TEST_TPUT_TOLERANCE>
     <TEST_MEMLEAK_TOLERANCE>0.20</TEST_MEMLEAK_TOLERANCE>
     <environment_variables compiler="gnu">
-      <env name="HDF5_PATH">$SHELL{dirname $(dirname $(which h5diff))}</env>
+      <env name="HDF5_ROOT">$SHELL{dirname $(dirname $(which h5diff))}</env>
       <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf-config))}</env>
       <env name="OPENBLAS_PATH">/apps/spack/opt/spack/linux-centos7-cascadelake/gcc-12.2.0/openblas-0.3.20-nxcsxdi56nj2gxyo65iyuaecp3cbd4xd</env>
-      <env name="LAPACK_PATH">/apps/spack/opt/spack/linux-centos7-cascadelake/gcc-12.2.0/netlib-lapack-3.10.1-xjw3q4abrpdihbyvx72em7l4wrzxm3zp</env>
+      <env name="LAPACK_ROOT">/apps/spack/opt/spack/linux-centos7-cascadelake/gcc-12.2.0/netlib-lapack-3.10.1-xjw3q4abrpdihbyvx72em7l4wrzxm3zp</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
     </environment_variables>
 
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PLACES">threads</env>
     </environment_variables>
@@ -4897,10 +5094,10 @@
       <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="gnu">
+    <environment_variables BUILD_THREADED="TRUE" compiler="gnu">
       <env name="OMP_PLACES">cores</env>
     </environment_variables>
   </machine>
@@ -5005,6 +5202,7 @@
 
       <!--env name="HDF5_DISABLE_VERSION_CHECK">2</env-->
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
+      <env name="NETCDF_PATH">$ENV{NETCDF_DIR}</env>
     </environment_variables>
     <environment_variables compiler="intel">
       <env name="FORT_BUFFERED">yes</env>
@@ -5240,6 +5438,8 @@
     <environment_variables>
       <env name="OMPI_ALLOW_RUN_AS_ROOT">1</env>
       <env name="OMPI_ALLOW_RUN_AS_ROOT_CONFIRM">1</env>
+      <env name="NETCDF_PATH">/opt/conda</env>
+      <env name="PNETCDF_PATH">/opt/conda</env>
     </environment_variables>
   </machine>
 

--- a/mache/machines/pm-gpu.cfg
+++ b/mache/machines/pm-gpu.cfg
@@ -1,0 +1,84 @@
+# Options related to deploying an e3sm-unified conda environment on supported
+# machines
+[e3sm_unified]
+
+# the unix group for permissions for the e3sm-unified conda environment
+group = e3sm
+
+# the compiler set to use for system libraries and MPAS builds
+compiler = nvidiagpu
+
+# the system MPI library to use for intel18 compiler
+mpi = mpich
+
+# the path to the directory where activation scripts, the base environment, and
+# system libraries will be deployed
+base_path = /global/common/software/e3sm/anaconda_envs
+
+# whether to use system modules for hdf5, netcdf-c, netcdf-fortran and pnetcdf
+# (spack modules are used otherwise)
+use_system_hdf5_netcdf = True
+
+
+# config options related to data needed by diagnostics software such as
+# e3sm_diags and MPAS-Analysis
+[diagnostics]
+
+# The base path to the diagnostics directory
+base_path = /global/cfs/cdirs/e3sm/diagnostics
+
+# the unix group for permissions for diagnostics
+group = e3sm
+
+
+# config options associated with web portals
+[web_portal]
+
+# The path to the base of the web portals
+base_path = /global/cfs/cdirs/e3sm/www
+
+# The base URL that corresponds to the base path
+base_url = https://portal.nersc.gov/cfs/e3sm
+
+
+# The parallel section describes options related to running jobs in parallel
+[parallel]
+
+# parallel system of execution: slurm, cobalt or single_node
+system = slurm
+
+# whether to use mpirun or srun to run a task
+parallel_executable = srun
+
+# cores per node on the machine
+cores_per_node = 256
+
+# account for running diagnostics jobs
+account = e3sm
+
+# available constraint(s) (default is the first)
+constraints = gpu
+
+# quality of service (default is the first)
+qos = regular, debug, premium
+
+# Config options related to spack environments
+[spack]
+
+# whether to load modules from the spack yaml file before loading the spack
+# environment
+modules_before = False
+
+# whether to load modules from the spack yaml file after loading the spack
+# environment
+modules_after = False
+
+# whether the machine uses cray compilers
+cray_compilers = True
+
+
+# config options related to synchronizing files
+[sync]
+
+# the full hostname of the machine
+hostname = perlmutter-p1.nersc.gov

--- a/mache/spack/pm-cpu_gnu_mpich.csh
+++ b/mache/spack/pm-cpu_gnu_mpich.csh
@@ -21,10 +21,10 @@ module load craype-accel-host
 {% if e3sm_lapack %}
 module load cray-libsci/23.02.1.1
 {% endif %}
-module load craype/2.7.19
+module load craype/2.7.20
 module rm cray-mpich &> /dev/null
 module load libfabric/1.15.2.0
-module load cray-mpich/8.1.24
+module load cray-mpich/8.1.25
 {% if e3sm_hdf5_netcdf %}
 module rm cray-hdf5-parallel &> /dev/null
 module rm cray-netcdf-hdf5parallel &> /dev/null

--- a/mache/spack/pm-cpu_gnu_mpich.sh
+++ b/mache/spack/pm-cpu_gnu_mpich.sh
@@ -21,10 +21,10 @@ module load craype-accel-host
 {% if e3sm_lapack %}
 module load cray-libsci/23.02.1.1
 {% endif %}
-module load craype/2.7.19
+module load craype/2.7.20
 module rm cray-mpich &> /dev/null
 module load libfabric/1.15.2.0
-module load cray-mpich/8.1.24
+module load cray-mpich/8.1.25
 {% if e3sm_hdf5_netcdf %}
 module rm cray-hdf5-parallel &> /dev/null
 module rm cray-netcdf-hdf5parallel &> /dev/null

--- a/mache/spack/pm-cpu_gnu_mpich.yaml
+++ b/mache/spack/pm-cpu_gnu_mpich.yaml
@@ -59,7 +59,7 @@ spack:
       buildable: false
     m4:
       externals:
-      - spec: m4@6.1.20180317
+      - spec: m4@1.4.18
         prefix: /usr
       buildable: false
     ncurses:

--- a/mache/spack/pm-cpu_gnu_mpich.yaml
+++ b/mache/spack/pm-cpu_gnu_mpich.yaml
@@ -18,7 +18,7 @@ spack:
     all:
       compiler: [gcc@11.2.0]
       providers:
-        mpi: [cray-mpich@8.1.24]
+        mpi: [cray-mpich@8.1.25]
 {% if e3sm_lapack %}
         lapack: [cray-libsci@23.02.1.1]
 {% endif %}
@@ -32,9 +32,24 @@ spack:
       - spec: curl@7.66.0
         prefix: /usr
       buildable: false
+    cmake:
+      externals:
+      - spec: cmake@3.24.3
+        prefix: /global/common/software/nersc/pm-2022q4/spack/linux-sles15-zen/cmake-3.24.3-k5msymx/
+      buildable: false
     gettext:
       externals:
       - spec: gettext@0.20.2
+        prefix: /usr
+      buildable: false
+    gmake:
+      externals:
+      - spec: gmake@4.2.1
+        prefix: /usr
+      buildable: false
+    libuv:
+      externals:
+      - spec: libuv@1.44.2
         prefix: /usr
       buildable: false
     libxml2:
@@ -42,9 +57,19 @@ spack:
       - spec: libxml2@2.9.7
         prefix: /usr
       buildable: false
+    m4:
+      externals:
+      - spec: m4@6.1.20180317
+        prefix: /usr
+      buildable: false
     ncurses:
       externals:
       - spec: ncurses@6.1.20180317
+        prefix: /usr
+      buildable: false
+    ninja:
+      externals:
+      - spec: ninja@1.10.0
         prefix: /usr
       buildable: false
     openssl:
@@ -81,16 +106,16 @@ spack:
         - PrgEnv-gnu/8.3.3
         - gcc/11.2.0
         - craype-accel-host
-        - craype/2.7.19
+        - craype/2.7.20
         - libfabric/1.15.2.0
       buildable: false
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.24
-        prefix: /opt/cray/pe/mpich/8.1.24/ofi/gnu/9.1
+      - spec: cray-mpich@8.1.25
+        prefix: /opt/cray/pe/mpich/8.1.25/ofi/gnu/9.1
         modules:
         - libfabric/1.15.2.0
-        - cray-mpich/8.1.24
+        - cray-mpich/8.1.25
       buildable: false
     libfabric:
       externals:
@@ -108,7 +133,7 @@ spack:
         - cray-libsci/23.02.1.1
       buildable: false
 {% endif %}
-{% if e3sm_hdf5_netcdf %}
+{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared
@@ -126,36 +151,8 @@ spack:
       buildable: false
     netcdf-fortran:
       externals:
-      - spec: netcdf-fortran@4.5.3 ^netcdf-c+mpi
+      - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/GNU/9.1
-      buildable: false
-{% endif %}
-{% if system_hdf5_netcdf %}
-    hdf5:
-      externals:
-      - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared
-        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.3/GNU/9.1
-      - spec: hdf5@1.12.2.3~cxx+fortran+hl~java~mpi+shared
-        prefix: /opt/cray/pe/hdf5/1.12.2.3/GNU/9.1
-      buildable: false
-    parallel-netcdf:
-      externals:
-      - spec: parallel-netcdf@1.12.3.3+cxx+fortran+pic+shared
-        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.3/GNU/9.1/
-      buildable: false
-    netcdf-c:
-      externals:
-      - spec: netcdf-c@4.9.0.3+mpi~parallel-netcdf
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/GNU/9.1
-      - spec: netcdf-c@4.9.0.3~mpi~parallel-netcdf
-        prefix: /opt/cray/pe/netcdf/4.9.0.3/GNU/9.1
-      buildable: false
-    netcdf-fortran:
-      externals:
-      - spec: netcdf-fortran@4.5.3 ^netcdf-c+mpi
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/GNU/9.1
-      - spec: netcdf-fortran@4.5.3 ^netcdf-c~mpi
-        prefix: /opt/cray/pe/netcdf/4.9.0.3/GNU/9.1
       buildable: false
 {% endif %}
   config:
@@ -175,8 +172,8 @@ spack:
       - PrgEnv-gnu/8.3.3
       - gcc/11.2.0
       - craype-accel-host
-      - craype/2.7.19
+      - craype/2.7.20
       - libfabric/1.15.2.0
       environment:
         prepend_path:
-          PKG_CONFIG_PATH: "/opt/cray/xpmem/2.5.2-2.4_3.30__gd0f7936.shasta/lib64/pkgconfig"
+          PKG_CONFIG_PATH: "/opt/cray/xpmem/2.6.2-2.5_2.33__gd067c3f.shasta/lib64/pkgconfig"

--- a/mache/spack/pm-cpu_intel_mpich.csh
+++ b/mache/spack/pm-cpu_intel_mpich.csh
@@ -18,10 +18,9 @@ module rm darshan &> /dev/null
 module load PrgEnv-intel/8.3.3
 module load intel/2023.1.0
 module load craype-accel-host
-module load craype/2.7.19
+module load craype/2.7.20
 module rm cray-mpich &> /dev/null
-module load libfabric/1.15.2.0
-module load cray-mpich/8.1.24
+module load cray-mpich/8.1.25
 {% if e3sm_hdf5_netcdf %}
 module rm cray-hdf5-parallel &> /dev/null
 module rm cray-netcdf-hdf5parallel &> /dev/null

--- a/mache/spack/pm-cpu_intel_mpich.sh
+++ b/mache/spack/pm-cpu_intel_mpich.sh
@@ -18,10 +18,9 @@ module rm darshan &> /dev/null
 module load PrgEnv-intel/8.3.3
 module load intel/2023.1.0
 module load craype-accel-host
-module load craype/2.7.19
+module load craype/2.7.20
 module rm cray-mpich &> /dev/null
-module load libfabric/1.15.2.0
-module load cray-mpich/8.1.24
+module load cray-mpich/8.1.25
 {% if e3sm_hdf5_netcdf %}
 module rm cray-hdf5-parallel &> /dev/null
 module rm cray-netcdf-hdf5parallel &> /dev/null

--- a/mache/spack/pm-cpu_intel_mpich.yaml
+++ b/mache/spack/pm-cpu_intel_mpich.yaml
@@ -53,7 +53,7 @@ spack:
       buildable: false
     m4:
       externals:
-      - spec: m4@6.1.20180317
+      - spec: m4@1.4.18
         prefix: /usr
       buildable: false
     ncurses:

--- a/mache/spack/pm-cpu_intel_mpich.yaml
+++ b/mache/spack/pm-cpu_intel_mpich.yaml
@@ -26,9 +26,24 @@ spack:
       - spec: curl@7.66.0
         prefix: /usr
       buildable: false
+    cmake:
+      externals:
+      - spec: cmake@3.24.3
+        prefix: /global/common/software/nersc/pm-2022q4/spack/linux-sles15-zen/cmake-3.24.3-k5msymx/
+      buildable: false
     gettext:
       externals:
       - spec: gettext@0.20.2
+        prefix: /usr
+      buildable: false
+    gmake:
+      externals:
+      - spec: gmake@4.2.1
+        prefix: /usr
+      buildable: false
+    libuv:
+      externals:
+      - spec: libuv@1.44.2
         prefix: /usr
       buildable: false
     libxml2:
@@ -36,9 +51,19 @@ spack:
       - spec: libxml2@2.9.7
         prefix: /usr
       buildable: false
+    m4:
+      externals:
+      - spec: m4@6.1.20180317
+        prefix: /usr
+      buildable: false
     ncurses:
       externals:
       - spec: ncurses@6.1.20180317
+        prefix: /usr
+      buildable: false
+    ninja:
+      externals:
+      - spec: ninja@1.10.0
         prefix: /usr
       buildable: false
     openssl:
@@ -75,16 +100,14 @@ spack:
         - PrgEnv-intel/8.3.3
         - intel/2023.1.0
         - craype-accel-host
-        - craype/2.7.19
-        - libfabric/1.15.2.0
+        - craype/2.7.20
       buildable: false
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.24
-        prefix: /opt/cray/pe/mpich/8.1.24/ofi/intel/19.0
+      - spec: cray-mpich@8.1.25
+        prefix: /opt/cray/pe/mpich/8.1.25/ofi/intel/19.0
         modules:
-        - libfabric/1.15.2.0
-        - cray-mpich/8.1.24
+        - cray-mpich/8.1.25
       buildable: false
     libfabric:
       externals:
@@ -93,7 +116,7 @@ spack:
         modules:
         - libfabric/1.15.2.0
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared
@@ -111,36 +134,8 @@ spack:
       buildable: false
     netcdf-fortran:
       externals:
-      - spec: netcdf-fortran@4.5.3 ^netcdf-c+mpi
+      - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/intel/19.0
-      buildable: false
-{% endif %}
-{% if system_hdf5_netcdf %}
-    hdf5:
-      externals:
-      - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared
-        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.3/intel/19.0
-      - spec: hdf5@1.12.2.3~cxx+fortran+hl~java~mpi+shared
-        prefix: /opt/cray/pe/hdf5/1.12.2.3/intel/19.0
-      buildable: false
-    parallel-netcdf:
-      externals:
-      - spec: parallel-netcdf@1.12.3.3+cxx+fortran+pic+shared
-        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.3/intel/19.0/
-      buildable: false
-    netcdf-c:
-      externals:
-      - spec: netcdf-c@4.9.0.3+mpi~parallel-netcdf
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/intel/19.0
-      - spec: netcdf-c@4.9.0.3~mpi~parallel-netcdf
-        prefix: /opt/cray/pe/netcdf/4.9.0.3/intel/19.0
-      buildable: false
-    netcdf-fortran:
-      externals:
-      - spec: netcdf-fortran@4.5.3 ^netcdf-c+mpi
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/intel/19.0
-      - spec: netcdf-fortran@4.5.3 ^netcdf-c~mpi
-        prefix: /opt/cray/pe/netcdf/4.9.0.3/intel/19.0
       buildable: false
 {% endif %}
   config:
@@ -160,8 +155,7 @@ spack:
       - PrgEnv-intel/8.3.3
       - intel/2023.1.0
       - craype-accel-host
-      - craype/2.7.19
-      - libfabric/1.15.2.0
+      - craype/2.7.20
       environment:
         prepend_path:
-          PKG_CONFIG_PATH: "/opt/cray/xpmem/2.5.2-2.4_3.30__gd0f7936.shasta/lib64/pkgconfig"
+          PKG_CONFIG_PATH: "/opt/cray/xpmem/2.6.2-2.5_2.33__gd067c3f.shasta/lib64/pkgconfig"

--- a/mache/spack/pm-cpu_nvidia_mpich.csh
+++ b/mache/spack/pm-cpu_nvidia_mpich.csh
@@ -1,0 +1,52 @@
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module rm PrgEnv-gnu &> /dev/null
+module rm PrgEnv-intel &> /dev/null
+module rm PrgEnv-nvidia &> /dev/null
+module rm PrgEnv-cray &> /dev/null
+module rm PrgEnv-aocc &> /dev/null
+module rm intel &> /dev/null
+module rm intel-oneapi &> /dev/null
+module rm cudatoolkit &> /dev/null
+module rm craype-accel-nvidia80 &> /dev/null
+module rm craype-accel-host &> /dev/null
+module rm perftools-base &> /dev/null
+module rm perftools &> /dev/null
+module rm darshan &> /dev/null
+
+module load PrgEnv-nvidia
+module load nvidia/22.7
+module load craype-x86-milan
+module load libfabric/1.15.2.0
+module load craype-accel-host
+module load craype/2.7.20
+module rm cray-mpich &> /dev/null
+module load cray-mpich/8.1.25
+{% if e3sm_lapack %}
+module load cray-libsci/23.02.1.1
+{% endif %}
+{% if e3sm_hdf5_netcdf %}
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module load cray-hdf5-parallel/1.12.2.3
+module load cray-netcdf-hdf5parallel/4.9.0.3
+module load cray-parallel-netcdf/1.12.3.3
+{% endif %}
+
+{% if e3sm_hdf5_netcdf %}
+setenv NETCDF_C_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
+setenv NETCDF_FORTRAN_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
+setenv PNETCDF_PATH $CRAY_PARALLEL_NETCDF_PREFIX
+{% endif %}
+setenv MPICH_ENV_DISPLAY 1
+setenv MPICH_VERSION_DISPLAY 1
+## purposefully omitting OMP variables that cause trouble in ESMF
+# setenv OMP_STACKSIZE 128M
+# setenv OMP_PROC_BIND spread
+# setenv OMP_PLACES threads
+setenv HDF5_USE_FILE_LOCKING FALSE
+## Not needed
+# setenv PERL5LIB /global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
+setenv MPICH_GPU_SUPPORT_ENABLED 1

--- a/mache/spack/pm-cpu_nvidia_mpich.sh
+++ b/mache/spack/pm-cpu_nvidia_mpich.sh
@@ -1,0 +1,57 @@
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module rm PrgEnv-gnu &> /dev/null
+module rm PrgEnv-intel &> /dev/null
+module rm PrgEnv-nvidia &> /dev/null
+module rm PrgEnv-cray &> /dev/null
+module rm PrgEnv-aocc &> /dev/null
+module rm intel &> /dev/null
+module rm intel-oneapi &> /dev/null
+module rm cudatoolkit &> /dev/null
+module rm craype-accel-nvidia80 &> /dev/null
+module rm craype-accel-host &> /dev/null
+module rm perftools-base &> /dev/null
+module rm perftools &> /dev/null
+module rm darshan &> /dev/null
+
+module load PrgEnv-nvidia
+module load nvidia/22.7
+module load craype-x86-milan
+module load libfabric/1.15.2.0
+module load craype-accel-host
+module load craype/2.7.20
+module rm cray-mpich &> /dev/null
+module load cray-mpich/8.1.25
+{% if e3sm_lapack %}
+module load cray-libsci/23.02.1.1
+{% endif %}
+{% if e3sm_hdf5_netcdf %}
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module load cray-hdf5-parallel/1.12.2.3
+module load cray-netcdf-hdf5parallel/4.9.0.3
+module load cray-parallel-netcdf/1.12.3.3
+{% endif %}
+
+{% if e3sm_hdf5_netcdf %}
+export NETCDF_C_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
+export NETCDF_FORTRAN_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
+export PNETCDF_PATH=$CRAY_PARALLEL_NETCDF_PREFIX
+{% endif %}
+export MPICH_ENV_DISPLAY=1
+export MPICH_VERSION_DISPLAY=1
+## purposefully omitting OMP variables that cause trouble in ESMF
+# export OMP_STACKSIZE=128M
+# export OMP_PROC_BIND=spread
+# export OMP_PLACES=threads
+export HDF5_USE_FILE_LOCKING=FALSE
+## Not needed
+# export PERL5LIB=/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+if [ -z "${NERSC_HOST:-}" ]; then
+  # happens when building spack environment
+  export NERSC_HOST="perlmutter"
+fi

--- a/mache/spack/pm-cpu_nvidia_mpich.yaml
+++ b/mache/spack/pm-cpu_nvidia_mpich.yaml
@@ -1,0 +1,166 @@
+spack:
+  specs:
+  - cray-mpich
+{% if e3sm_lapack %}
+  - cray-libsci
+{% endif %}
+{% if e3sm_hdf5_netcdf %}
+  - hdf5
+  - netcdf-c
+  - netcdf-fortran
+  - parallel-netcdf
+{% endif %}
+{{ specs }}
+  concretizer:
+    unify: when_possible
+  packages:
+    all:
+      compiler: [nvhpc@22.7]
+      providers:
+        mpi: [cray-mpich@8.1.25]
+{% if e3sm_lapack %}
+        lapack: [cray-libsci@23.02.1.1]
+{% endif %}
+    bzip2:
+      externals:
+      - spec: bzip2@1.0.6
+        prefix: /usr
+      buildable: false
+    curl:
+      externals:
+      - spec: curl@7.66.0
+        prefix: /usr
+      buildable: false
+    cmake:
+      externals:
+      - spec: cmake@3.24.3
+        prefix: /global/common/software/nersc/pm-2022q4/spack/linux-sles15-zen/cmake-3.24.3-k5msymx/
+      buildable: false
+    gettext:
+      externals:
+      - spec: gettext@0.20.2
+        prefix: /usr
+      buildable: false
+    gmake:
+      externals:
+      - spec: gmake@4.2.1
+        prefix: /usr
+      buildable: false
+    libuv:
+      externals:
+      - spec: libuv@1.44.2
+        prefix: /usr
+      buildable: false
+    libxml2:
+      externals:
+      - spec: libxml2@2.9.7
+        prefix: /usr
+      buildable: false
+    m4:
+      externals:
+      - spec: m4@6.1.20180317
+        prefix: /usr
+      buildable: false
+    ncurses:
+      externals:
+      - spec: ncurses@6.1.20180317
+        prefix: /usr
+      buildable: false
+    ninja:
+      externals:
+      - spec: ninja@1.10.0
+        prefix: /usr
+      buildable: false
+    openssl:
+      externals:
+      - spec: openssl@1.1.1d
+        prefix: /usr
+      buildable: false
+    perl:
+      externals:
+      - spec: perl@5.26.1
+        prefix: /usr
+      buildable: false
+    python:
+      externals:
+      - spec: python@3.9.7
+        prefix: /global/common/software/nersc/pm-2022q3/sw/python/3.9-anaconda-2021.11
+        modules:
+        - python/3.9-anaconda-2021.11
+      buildable: false
+    tar:
+      externals:
+      - spec: tar@1.34
+        prefix: /usr
+      buildable: false
+    xz:
+      externals:
+      - spec: xz@5.2.3
+        prefix: /usr
+      buildable: false
+    cray-mpich:
+      externals:
+      - spec: cray-mpich@8.1.25
+        prefix: /opt/cray/pe/mpich/8.1.25/ofi/nvidia/20.7
+        modules:
+        - libfabric/1.15.2.0
+        - cray-mpich/8.1.25
+      buildable: false
+    libfabric:
+      externals:
+      - spec: libfabric@1.15.2.0
+        prefix: /opt/cray/libfabric/1.15.2.0
+        modules:
+        - libfabric/1.15.2.0
+      buildable: false
+{% if e3sm_lapack %}
+    cray-libsci:
+      externals:
+      - spec: cray-libsci@23.02.1.1
+        prefix: /opt/cray/pe/libsci/23.02.1.1/NVIDIA/20.7/x86_64
+      buildable: false
+{% endif %}
+{% if e3sm_hdf5_netcdf or system_hdf5_netcdf%}
+    hdf5:
+      externals:
+      - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared
+        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.3/nvidia/20.7
+      buildable: false
+    parallel-netcdf:
+      externals:
+      - spec: parallel-netcdf@1.12.3.3+cxx+fortran+pic+shared
+        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.3/nvidia/20.7
+      buildable: false
+    netcdf-c:
+      externals:
+      - spec: netcdf-c@4.9.0.3+mpi~parallel-netcdf
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/nvidia/20.7
+      buildable: false
+    netcdf-fortran:
+      externals:
+      - spec: netcdf-fortran@4.5.3
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/nvidia/20.7
+      buildable: false
+{% endif %}
+  config:
+    install_missing_compilers: false
+  compilers:
+  - compiler:
+      spec: nvhpc@22.7
+      paths:
+        cc: /opt/nvidia/hpc_sdk/Linux_x86_64/22.7/compilers/bin/nvc
+        cxx: /opt/nvidia/hpc_sdk/Linux_x86_64/22.7/compilers/bin/nvc++
+        f77: /opt/nvidia/hpc_sdk/Linux_x86_64/22.7/compilers/bin/nvfortran
+        fc: /opt/nvidia/hpc_sdk/Linux_x86_64/22.7/compilers/bin/nvfortran
+      flags: {}
+      operating_system: sles15
+      target: any
+      modules:
+      - PrgEnv-nvidia
+      - nvidia/22.7
+      - craype-x86-milan
+      - libfabric
+      - craype-accel-host
+      environment:
+        prepend_path:
+          PKG_CONFIG_PATH: "/opt/cray/xpmem/2.6.2-2.5_2.33__gd067c3f.shasta/lib64/pkgconfig"

--- a/mache/spack/pm-cpu_nvidia_mpich.yaml
+++ b/mache/spack/pm-cpu_nvidia_mpich.yaml
@@ -58,7 +58,7 @@ spack:
       buildable: false
     m4:
       externals:
-      - spec: m4@6.1.20180317
+      - spec: m4@1.4.18
         prefix: /usr
       buildable: false
     ncurses:

--- a/mache/spack/pm-gpu_gnu_mpich.csh
+++ b/mache/spack/pm-gpu_gnu_mpich.csh
@@ -1,0 +1,1 @@
+pm-cpu_gnu_mpich.csh

--- a/mache/spack/pm-gpu_gnu_mpich.sh
+++ b/mache/spack/pm-gpu_gnu_mpich.sh
@@ -1,0 +1,1 @@
+pm-cpu_gnu_mpich.sh

--- a/mache/spack/pm-gpu_gnu_mpich.yaml
+++ b/mache/spack/pm-gpu_gnu_mpich.yaml
@@ -1,0 +1,1 @@
+pm-cpu_gnu_mpich.yaml

--- a/mache/spack/pm-gpu_gnugpu_mpich.csh
+++ b/mache/spack/pm-gpu_gnugpu_mpich.csh
@@ -1,0 +1,53 @@
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module rm PrgEnv-gnu &> /dev/null
+module rm PrgEnv-intel &> /dev/null
+module rm PrgEnv-nvidia &> /dev/null
+module rm PrgEnv-cray &> /dev/null
+module rm PrgEnv-aocc &> /dev/null
+module rm intel &> /dev/null
+module rm intel-oneapi &> /dev/null
+module rm cudatoolkit &> /dev/null
+module rm craype-accel-nvidia80 &> /dev/null
+module rm craype-accel-host &> /dev/null
+module rm perftools-base &> /dev/null
+module rm perftools &> /dev/null
+module rm darshan &> /dev/null
+
+module load PrgEnv-gnu/8.3.3
+module load gcc/11.2.0
+module load craype-x86-milan
+module load libfabric/1.15.2.0
+module load cudatoolkit/11.7
+module load craype-accel-nvidia80
+module load craype/2.7.20
+module rm cray-mpich &> /dev/null
+module load cray-mpich/8.1.25
+{% if e3sm_lapack %}
+module load cray-libsci/23.02.1.1
+{% endif %}
+{% if e3sm_hdf5_netcdf %}
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module load cray-hdf5-parallel/1.12.2.3
+module load cray-netcdf-hdf5parallel/4.9.0.3
+module load cray-parallel-netcdf/1.12.3.3
+{% endif %}
+
+{% if e3sm_hdf5_netcdf %}
+setenv NETCDF_C_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
+setenv NETCDF_FORTRAN_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
+setenv PNETCDF_PATH $CRAY_PARALLEL_NETCDF_PREFIX
+{% endif %}
+setenv MPICH_ENV_DISPLAY 1
+setenv MPICH_VERSION_DISPLAY 1
+## purposefully omitting OMP variables that cause trouble in ESMF
+# setenv OMP_STACKSIZE 128M
+# setenv OMP_PROC_BIND spread
+# setenv OMP_PLACES threads
+setenv HDF5_USE_FILE_LOCKING FALSE
+## Not needed
+# setenv PERL5LIB /global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
+setenv MPICH_GPU_SUPPORT_ENABLED 1

--- a/mache/spack/pm-gpu_gnugpu_mpich.sh
+++ b/mache/spack/pm-gpu_gnugpu_mpich.sh
@@ -1,0 +1,58 @@
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module rm PrgEnv-gnu &> /dev/null
+module rm PrgEnv-intel &> /dev/null
+module rm PrgEnv-nvidia &> /dev/null
+module rm PrgEnv-cray &> /dev/null
+module rm PrgEnv-aocc &> /dev/null
+module rm intel &> /dev/null
+module rm intel-oneapi &> /dev/null
+module rm cudatoolkit &> /dev/null
+module rm craype-accel-nvidia80 &> /dev/null
+module rm craype-accel-host &> /dev/null
+module rm perftools-base &> /dev/null
+module rm perftools &> /dev/null
+module rm darshan &> /dev/null
+
+module load PrgEnv-gnu/8.3.3
+module load gcc/11.2.0
+module load craype-x86-milan
+module load libfabric/1.15.2.0
+module load cudatoolkit/11.7
+module load craype-accel-nvidia80
+module load craype/2.7.20
+module rm cray-mpich &> /dev/null
+module load cray-mpich/8.1.25
+{% if e3sm_lapack %}
+module load cray-libsci/23.02.1.1
+{% endif %}
+{% if e3sm_hdf5_netcdf %}
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module load cray-hdf5-parallel/1.12.2.3
+module load cray-netcdf-hdf5parallel/4.9.0.3
+module load cray-parallel-netcdf/1.12.3.3
+{% endif %}
+
+{% if e3sm_hdf5_netcdf %}
+export NETCDF_C_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
+export NETCDF_FORTRAN_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
+export PNETCDF_PATH=$CRAY_PARALLEL_NETCDF_PREFIX
+{% endif %}
+export MPICH_ENV_DISPLAY=1
+export MPICH_VERSION_DISPLAY=1
+## purposefully omitting OMP variables that cause trouble in ESMF
+# export OMP_STACKSIZE=128M
+# export OMP_PROC_BIND=spread
+# export OMP_PLACES=threads
+export HDF5_USE_FILE_LOCKING=FALSE
+## Not needed
+# export PERL5LIB=/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+if [ -z "${NERSC_HOST:-}" ]; then
+  # happens when building spack environment
+  export NERSC_HOST="perlmutter"
+fi

--- a/mache/spack/pm-gpu_gnugpu_mpich.yaml
+++ b/mache/spack/pm-gpu_gnugpu_mpich.yaml
@@ -59,7 +59,7 @@ spack:
       buildable: false
     m4:
       externals:
-      - spec: m4@6.1.20180317
+      - spec: m4@1.4.18
         prefix: /usr
       buildable: false
     ncurses:

--- a/mache/spack/pm-gpu_gnugpu_mpich.yaml
+++ b/mache/spack/pm-gpu_gnugpu_mpich.yaml
@@ -1,0 +1,181 @@
+spack:
+  specs:
+  - gcc
+  - cray-mpich
+{% if e3sm_lapack %}
+  - cray-libsci
+{% endif %}
+{% if e3sm_hdf5_netcdf %}
+  - hdf5
+  - netcdf-c
+  - netcdf-fortran
+  - parallel-netcdf
+{% endif %}
+{{ specs }}
+  concretizer:
+    unify: when_possible
+  packages:
+    all:
+      compiler: [gcc@11.2.0]
+      providers:
+        mpi: [cray-mpich@8.1.24]
+{% if e3sm_lapack %}
+        lapack: [cray-libsci@23.02.1.1]
+{% endif %}
+    bzip2:
+      externals:
+      - spec: bzip2@1.0.6
+        prefix: /usr
+      buildable: false
+    curl:
+      externals:
+      - spec: curl@7.66.0
+        prefix: /usr
+      buildable: false
+    cmake:
+      externals:
+      - spec: cmake@3.24.3
+        prefix: /global/common/software/nersc/pm-2022q4/spack/linux-sles15-zen/cmake-3.24.3-k5msymx/
+      buildable: false
+    gettext:
+      externals:
+      - spec: gettext@0.20.2
+        prefix: /usr
+      buildable: false
+    gmake:
+      externals:
+      - spec: gmake@4.2.1
+        prefix: /usr
+      buildable: false
+    libuv:
+      externals:
+      - spec: libuv@1.44.2
+        prefix: /usr
+      buildable: false
+    libxml2:
+      externals:
+      - spec: libxml2@2.9.7
+        prefix: /usr
+      buildable: false
+    m4:
+      externals:
+      - spec: m4@6.1.20180317
+        prefix: /usr
+      buildable: false
+    ncurses:
+      externals:
+      - spec: ncurses@6.1.20180317
+        prefix: /usr
+      buildable: false
+    ninja:
+      externals:
+      - spec: ninja@1.10.0
+        prefix: /usr
+      buildable: false
+    openssl:
+      externals:
+      - spec: openssl@1.1.1d
+        prefix: /usr
+      buildable: false
+    perl:
+      externals:
+      - spec: perl@5.26.1
+        prefix: /usr
+      buildable: false
+    python:
+      externals:
+      - spec: python@3.9.7
+        prefix: /global/common/software/nersc/pm-2022q3/sw/python/3.9-anaconda-2021.11
+        modules:
+        - python/3.9-anaconda-2021.11
+      buildable: false
+    tar:
+      externals:
+      - spec: tar@1.34
+        prefix: /usr
+      buildable: false
+    xz:
+      externals:
+      - spec: xz@5.2.3
+        prefix: /usr
+      buildable: false
+    gcc:
+      externals:
+      - spec: gcc@11.2.0
+        modules:
+        - PrgEnv-gnu/8.3.3
+        - gcc/11.2.0
+        - cudatoolkit/11.7
+        - craype-accel-nvidia80
+        - craype/2.7.19
+        - libfabric/1.15.2.0
+      buildable: false
+    cray-mpich:
+      externals:
+      - spec: cray-mpich@8.1.25
+        prefix: /opt/cray/pe/mpich/8.1.25/ofi/gnu/9.1
+        modules:
+        - libfabric/1.15.2.0
+        - cray-mpich/8.1.25
+      buildable: false
+    libfabric:
+      externals:
+      - spec: libfabric@1.15.2.0
+        prefix: /opt/cray/libfabric/1.15.2.0
+        modules:
+        - libfabric/1.15.2.0
+      buildable: false
+{% if e3sm_lapack %}
+    cray-libsci:
+      externals:
+      - spec: cray-libsci@23.02.1.1
+        prefix: /opt/cray/pe/libsci/23.02.1.1/GNU/9.1/x86_64
+        modules:
+        - cray-libsci/23.02.1.1
+      buildable: false
+{% endif %}
+{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
+    hdf5:
+      externals:
+      - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared
+        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.3/GNU/9.1
+      buildable: false
+    parallel-netcdf:
+      externals:
+      - spec: parallel-netcdf@1.12.3.3+cxx+fortran+pic+shared
+        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.3/GNU/9.1/
+      buildable: false
+    netcdf-c:
+      externals:
+      - spec: netcdf-c@4.9.0.3+mpi~parallel-netcdf
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/GNU/9.1
+      buildable: false
+    netcdf-fortran:
+      externals:
+      - spec: netcdf-fortran@4.5.3
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/GNU/9.1
+      buildable: false
+{% endif %}
+  config:
+    install_missing_compilers: false
+  compilers:
+  - compiler:
+      spec: gcc@11.2.0
+      paths:
+        cc: cc
+        cxx: CC
+        f77: ftn
+        fc: ftn
+      flags: {}
+      operating_system: sles15
+      target: any
+      modules:
+      - PrgEnv-gnu/8.3.3
+      - gcc/11.2.0
+      - cudatoolkit/11.7
+      - craype-accel-nvidia80
+      - craype/2.7.20
+      - libfabric/1.15.2.0
+      environment:
+        prepend_path:
+          PKG_CONFIG_PATH: "/opt/cray/xpmem/2.6.2-2.5_2.33__gd067c3f.shasta/lib64/pkgconfig"

--- a/mache/spack/pm-gpu_nvidia_mpich.csh
+++ b/mache/spack/pm-gpu_nvidia_mpich.csh
@@ -1,0 +1,1 @@
+pm-cpu_nvidia_mpich.csh

--- a/mache/spack/pm-gpu_nvidia_mpich.sh
+++ b/mache/spack/pm-gpu_nvidia_mpich.sh
@@ -1,0 +1,1 @@
+pm-cpu_nvidia_mpich.sh

--- a/mache/spack/pm-gpu_nvidia_mpich.yaml
+++ b/mache/spack/pm-gpu_nvidia_mpich.yaml
@@ -1,0 +1,1 @@
+pm-cpu_nvidia_mpich.yaml

--- a/mache/spack/pm-gpu_nvidiagpu_mpich.csh
+++ b/mache/spack/pm-gpu_nvidiagpu_mpich.csh
@@ -1,0 +1,53 @@
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module rm PrgEnv-gnu &> /dev/null
+module rm PrgEnv-intel &> /dev/null
+module rm PrgEnv-nvidia &> /dev/null
+module rm PrgEnv-cray &> /dev/null
+module rm PrgEnv-aocc &> /dev/null
+module rm intel &> /dev/null
+module rm intel-oneapi &> /dev/null
+module rm cudatoolkit &> /dev/null
+module rm craype-accel-nvidia80 &> /dev/null
+module rm craype-accel-host &> /dev/null
+module rm perftools-base &> /dev/null
+module rm perftools &> /dev/null
+module rm darshan &> /dev/null
+
+module load PrgEnv-nvidia
+module load nvidia/22.7
+module load craype-x86-milan
+module load libfabric/1.15.2.0
+module load cudatoolkit/11.7
+module load craype-accel-nvidia80
+module load craype/2.7.20
+module rm cray-mpich &> /dev/null
+module load cray-mpich/8.1.25
+{% if e3sm_lapack %}
+module load cray-libsci/23.02.1.1
+{% endif %}
+{% if e3sm_hdf5_netcdf %}
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module load cray-hdf5-parallel/1.12.2.3
+module load cray-netcdf-hdf5parallel/4.9.0.3
+module load cray-parallel-netcdf/1.12.3.3
+{% endif %}
+
+{% if e3sm_hdf5_netcdf %}
+setenv NETCDF_C_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
+setenv NETCDF_FORTRAN_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
+setenv PNETCDF_PATH $CRAY_PARALLEL_NETCDF_PREFIX
+{% endif %}
+setenv MPICH_ENV_DISPLAY 1
+setenv MPICH_VERSION_DISPLAY 1
+## purposefully omitting OMP variables that cause trouble in ESMF
+# setenv OMP_STACKSIZE 128M
+# setenv OMP_PROC_BIND spread
+# setenv OMP_PLACES threads
+setenv HDF5_USE_FILE_LOCKING FALSE
+## Not needed
+# setenv PERL5LIB /global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
+setenv MPICH_GPU_SUPPORT_ENABLED 1

--- a/mache/spack/pm-gpu_nvidiagpu_mpich.csh
+++ b/mache/spack/pm-gpu_nvidiagpu_mpich.csh
@@ -21,6 +21,7 @@ module load craype-x86-milan
 module load libfabric/1.15.2.0
 module load cudatoolkit/11.7
 module load craype-accel-nvidia80
+module load gcc-mixed/11.2.0
 module load craype/2.7.20
 module rm cray-mpich &> /dev/null
 module load cray-mpich/8.1.25

--- a/mache/spack/pm-gpu_nvidiagpu_mpich.sh
+++ b/mache/spack/pm-gpu_nvidiagpu_mpich.sh
@@ -1,0 +1,58 @@
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module rm PrgEnv-gnu &> /dev/null
+module rm PrgEnv-intel &> /dev/null
+module rm PrgEnv-nvidia &> /dev/null
+module rm PrgEnv-cray &> /dev/null
+module rm PrgEnv-aocc &> /dev/null
+module rm intel &> /dev/null
+module rm intel-oneapi &> /dev/null
+module rm cudatoolkit &> /dev/null
+module rm craype-accel-nvidia80 &> /dev/null
+module rm craype-accel-host &> /dev/null
+module rm perftools-base &> /dev/null
+module rm perftools &> /dev/null
+module rm darshan &> /dev/null
+
+module load PrgEnv-nvidia
+module load nvidia/22.7
+module load craype-x86-milan
+module load libfabric/1.15.2.0
+module load cudatoolkit/11.7
+module load craype-accel-nvidia80
+module load craype/2.7.20
+module rm cray-mpich &> /dev/null
+module load cray-mpich/8.1.25
+{% if e3sm_lapack %}
+module load cray-libsci/23.02.1.1
+{% endif %}
+{% if e3sm_hdf5_netcdf %}
+module rm cray-hdf5-parallel &> /dev/null
+module rm cray-netcdf-hdf5parallel &> /dev/null
+module rm cray-parallel-netcdf &> /dev/null
+module load cray-hdf5-parallel/1.12.2.3
+module load cray-netcdf-hdf5parallel/4.9.0.3
+module load cray-parallel-netcdf/1.12.3.3
+{% endif %}
+
+{% if e3sm_hdf5_netcdf %}
+export NETCDF_C_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
+export NETCDF_FORTRAN_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
+export PNETCDF_PATH=$CRAY_PARALLEL_NETCDF_PREFIX
+{% endif %}
+export MPICH_ENV_DISPLAY=1
+export MPICH_VERSION_DISPLAY=1
+## purposefully omitting OMP variables that cause trouble in ESMF
+# export OMP_STACKSIZE=128M
+# export OMP_PROC_BIND=spread
+# export OMP_PLACES=threads
+export HDF5_USE_FILE_LOCKING=FALSE
+## Not needed
+# export PERL5LIB=/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+if [ -z "${NERSC_HOST:-}" ]; then
+  # happens when building spack environment
+  export NERSC_HOST="perlmutter"
+fi

--- a/mache/spack/pm-gpu_nvidiagpu_mpich.sh
+++ b/mache/spack/pm-gpu_nvidiagpu_mpich.sh
@@ -21,6 +21,7 @@ module load craype-x86-milan
 module load libfabric/1.15.2.0
 module load cudatoolkit/11.7
 module load craype-accel-nvidia80
+module load gcc-mixed/11.2.0
 module load craype/2.7.20
 module rm cray-mpich &> /dev/null
 module load cray-mpich/8.1.25

--- a/mache/spack/pm-gpu_nvidiagpu_mpich.yaml
+++ b/mache/spack/pm-gpu_nvidiagpu_mpich.yaml
@@ -162,6 +162,7 @@ spack:
       - nvidia/22.7
       - cudatoolkit/11.7
       - craype-accel-nvidia80
+      - gcc-mixed/11.2.0
       - craype-x86-milan
       - libfabric
       environment:

--- a/mache/spack/pm-gpu_nvidiagpu_mpich.yaml
+++ b/mache/spack/pm-gpu_nvidiagpu_mpich.yaml
@@ -1,0 +1,169 @@
+spack:
+  specs:
+  - cray-mpich
+{% if e3sm_lapack %}
+  - cray-libsci
+{% endif %}
+{% if e3sm_hdf5_netcdf %}
+  - hdf5
+  - netcdf-c
+  - netcdf-fortran
+  - parallel-netcdf
+{% endif %}
+{{ specs }}
+  concretizer:
+    unify: when_possible
+  packages:
+    all:
+      compiler: [nvhpc@22.7]
+      providers:
+        mpi: [cray-mpich@8.1.25]
+{% if e3sm_lapack %}
+        lapack: [cray-libsci@23.02.1.1]
+{% endif %}
+    bzip2:
+      externals:
+      - spec: bzip2@1.0.6
+        prefix: /usr
+      buildable: false
+    curl:
+      externals:
+      - spec: curl@7.66.0
+        prefix: /usr
+      buildable: false
+    cmake:
+      externals:
+      - spec: cmake@3.24.3
+        prefix: /global/common/software/nersc/pm-2022q4/spack/linux-sles15-zen/cmake-3.24.3-k5msymx/
+      buildable: false
+    gettext:
+      externals:
+      - spec: gettext@0.20.2
+        prefix: /usr
+      buildable: false
+    gmake:
+      externals:
+      - spec: gmake@4.2.1
+        prefix: /usr
+      buildable: false
+    libuv:
+      externals:
+      - spec: libuv@1.44.2
+        prefix: /usr
+      buildable: false
+    libxml2:
+      externals:
+      - spec: libxml2@2.9.7
+        prefix: /usr
+      buildable: false
+    m4:
+      externals:
+      - spec: m4@6.1.20180317
+        prefix: /usr
+      buildable: false
+    ncurses:
+      externals:
+      - spec: ncurses@6.1.20180317
+        prefix: /usr
+      buildable: false
+    ninja:
+      externals:
+      - spec: ninja@1.10.0
+        prefix: /usr
+      buildable: false
+    openssl:
+      externals:
+      - spec: openssl@1.1.1d
+        prefix: /usr
+      buildable: false
+    perl:
+      externals:
+      - spec: perl@5.26.1
+        prefix: /usr
+      buildable: false
+    python:
+      externals:
+      - spec: python@3.9.7
+        prefix: /global/common/software/nersc/pm-2022q3/sw/python/3.9-anaconda-2021.11
+        modules:
+        - python/3.9-anaconda-2021.11
+      buildable: false
+    tar:
+      externals:
+      - spec: tar@1.34
+        prefix: /usr
+      buildable: false
+    xz:
+      externals:
+      - spec: xz@5.2.3
+        prefix: /usr
+      buildable: false
+    cray-mpich:
+      externals:
+      - spec: cray-mpich@8.1.25
+        prefix: /opt/cray/pe/mpich/8.1.25/ofi/nvidia/20.7
+        modules:
+        - libfabric/1.15.2.0
+        - cray-mpich/8.1.25
+      buildable: false
+    libfabric:
+      externals:
+      - spec: libfabric@1.15.2.0
+        prefix: /opt/cray/libfabric/1.15.2.0
+        modules:
+        - libfabric/1.15.2.0
+      buildable: false
+{% if e3sm_lapack %}
+    cray-libsci:
+      externals:
+      - spec: cray-libsci@23.02.1.1
+        prefix: /opt/cray/pe/libsci/23.02.1.1/NVIDIA/20.7/x86_64
+        modules:
+        - cray-libsci/23.02.1.1
+      buildable: false
+{% endif %}
+{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
+    hdf5:
+      externals:
+      - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared
+        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.3/nvidia/20.7
+      buildable: false
+    parallel-netcdf:
+      externals:
+      - spec: parallel-netcdf@1.12.3.3+cxx+fortran+pic+shared
+        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.3/nvidia/20.7
+      buildable: false
+    netcdf-c:
+      externals:
+      - spec: netcdf-c@4.9.0.3+mpi~parallel-netcdf
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/nvidia/20.7
+      buildable: false
+    netcdf-fortran:
+      externals:
+      - spec: netcdf-fortran@4.5.3
+        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.3/nvidia/20.7
+      buildable: false
+{% endif %}
+  config:
+    install_missing_compilers: false
+  compilers:
+  - compiler:
+      spec: nvhpc@22.7
+      paths:
+        cc: /opt/nvidia/hpc_sdk/Linux_x86_64/22.7/compilers/bin/nvc
+        cxx: /opt/nvidia/hpc_sdk/Linux_x86_64/22.7/compilers/bin/nvc++
+        f77: /opt/nvidia/hpc_sdk/Linux_x86_64/22.7/compilers/bin/nvfortran
+        fc: /opt/nvidia/hpc_sdk/Linux_x86_64/22.7/compilers/bin/nvfortran
+      flags: {}
+      operating_system: sles15
+      target: any
+      modules:
+      - PrgEnv-nvidia
+      - nvidia/22.7
+      - cudatoolkit/11.7
+      - craype-accel-nvidia80
+      - craype-x86-milan
+      - libfabric
+      environment:
+        prepend_path:
+          PKG_CONFIG_PATH: "/opt/cray/xpmem/2.6.2-2.5_2.33__gd067c3f.shasta/lib64/pkgconfig"

--- a/mache/spack/pm-gpu_nvidiagpu_mpich.yaml
+++ b/mache/spack/pm-gpu_nvidiagpu_mpich.yaml
@@ -58,7 +58,7 @@ spack:
       buildable: false
     m4:
       externals:
-      - spec: m4@6.1.20180317
+      - spec: m4@1.4.18
         prefix: /usr
       buildable: false
     ncurses:


### PR DESCRIPTION
This merge updates the `config_machines.xml` file frm E3SM to commit 7f7920b

It also updates `pm-cpu` spack support:
* Updates `gnu` builds
* Adds `intel`
* Adds `nvidia`

This merge also adds `pm-gpu` support:
* Adds a machine config file that is mostly a copy of `pm-cpu`
* Adds `gnu`, `gnugpu`, `nvidia`, and `nvidiagpu` compilers to spack support