### PR TITLE
Fix netcdf-fortran spack spec for frontier with gnu

### DIFF
--- a/mache/machines/frontier.cfg
+++ b/mache/machines/frontier.cfg
@@ -41,7 +41,7 @@ system = slurm
 parallel_executable = srun
 
 # cores per node on the machine
-cores_per_node = 64
+cores_per_node = 56
 
 # account for running diagnostics jobs
 account = cli115

--- a/mache/spack/frontier_gnu_mpich.yaml
+++ b/mache/spack/frontier_gnu_mpich.yaml
@@ -107,7 +107,7 @@ spack:
         - cray-libsci/22.12.1.1
       buildable: false
 {% endif %}
-{% if e3sm_hdf5_netcdf %}
+{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.1~cxx+fortran+hl~java+mpi+shared
@@ -125,38 +125,8 @@ spack:
       buildable: false
     netcdf-fortran:
       externals:
-      - spec: netcdf-fortran@4.5.3 ^netcdf-c+mpi
+      - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/GNU/9.1
-      - spec: netcdf-fortran@4.5.3 ^netcdf-c~mpi
-        prefix: /opt/cray/pe/netcdf/4.9.0.1/GNU/9.1
-      buildable: false
-{% endif %}
-{% if system_hdf5_netcdf %}
-    hdf5:
-      externals:
-      - spec: hdf5@1.12.2.1~cxx+fortran+hl~java+mpi+shared
-        prefix: /opt/cray/pe/hdf5-parallel/1.12.2.1/GNU/9.1
-      - spec: hdf5@1.12.2.1~cxx+fortran+hl~java~mpi+shared
-        prefix: /opt/cray/pe/hdf5/1.12.2.1/GNU/9.1
-      buildable: false
-    parallel-netcdf:
-      externals:
-      - spec: parallel-netcdf@1.12.3.1+cxx+fortran+pic+shared
-        prefix: /opt/cray/pe/parallel-netcdf/1.12.3.1/GNU/9.1/
-      buildable: false
-    netcdf-c:
-      externals:
-      - spec: netcdf-c@4.9.0.1+mpi~parallel-netcdf
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/GNU/9.1
-      - spec: netcdf-c@4.9.0.1~mpi~parallel-netcdf
-        prefix: /opt/cray/pe/netcdf/4.9.0.1/GNU/9.1
-      buildable: false
-    netcdf-fortran:
-      externals:
-      - spec: netcdf-fortran@4.5.3 ^netcdf-c+mpi
-        prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/GNU/9.1
-      - spec: netcdf-fortran@4.5.3 ^netcdf-c~mpi
-        prefix: /opt/cray/pe/netcdf/4.9.0.1/GNU/9.1
       buildable: false
 {% endif %}
   config:


### PR DESCRIPTION
This slipped through the cracks in #143 