### PR TITLE
Fix intel on Perlmutter

### DIFF
--- a/mache/spack/pm-cpu_intel_mpich.csh
+++ b/mache/spack/pm-cpu_intel_mpich.csh
@@ -19,6 +19,7 @@ module load PrgEnv-intel/8.3.3
 module load intel/2023.1.0
 module load craype-accel-host
 module load craype/2.7.20
+module load libfabric/1.15.2.0
 module rm cray-mpich &> /dev/null
 module load cray-mpich/8.1.25
 {% if e3sm_hdf5_netcdf %}

--- a/mache/spack/pm-cpu_intel_mpich.sh
+++ b/mache/spack/pm-cpu_intel_mpich.sh
@@ -19,6 +19,7 @@ module load PrgEnv-intel/8.3.3
 module load intel/2023.1.0
 module load craype-accel-host
 module load craype/2.7.20
+module load libfabric/1.15.2.0
 module rm cray-mpich &> /dev/null
 module load cray-mpich/8.1.25
 {% if e3sm_hdf5_netcdf %}

--- a/mache/spack/pm-cpu_intel_mpich.yaml
+++ b/mache/spack/pm-cpu_intel_mpich.yaml
@@ -101,6 +101,7 @@ spack:
         - intel/2023.1.0
         - craype-accel-host
         - craype/2.7.20
+        - libfabric/1.15.2.0
       buildable: false
     cray-mpich:
       externals:
@@ -108,6 +109,7 @@ spack:
         prefix: /opt/cray/pe/mpich/8.1.25/ofi/intel/19.0
         modules:
         - cray-mpich/8.1.25
+        - libfabric/1.15.2.0
       buildable: false
     libfabric:
       externals:
@@ -156,6 +158,7 @@ spack:
       - intel/2023.1.0
       - craype-accel-host
       - craype/2.7.20
+      - libfabric/1.15.2.0
       environment:
         prepend_path:
           PKG_CONFIG_PATH: "/opt/cray/xpmem/2.6.2-2.5_2.33__gd067c3f.shasta/lib64/pkgconfig"


### PR DESCRIPTION
It appears that we do need to explicitly load `libfabric`, even though doing so produces a warning.