### PR TITLE
Update to spack builds on Chrysalis

### DIFF
--- a/mache/spack/chrysalis_gnu_openmpi.yaml
+++ b/mache/spack/chrysalis_gnu_openmpi.yaml
@@ -42,6 +42,11 @@ spack:
       - spec: diffutils@3.7
         prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.2.0/diffutils-3.7-nnauuo4
       buildable: false
+    findutils:
+      externals:
+      - spec: findutils@4.6.0
+        prefix: /usr
+      buildable: false
     gmake:
       externals:
       - spec: gmake@4.2.1

--- a/mache/spack/chrysalis_gnu_openmpi.yaml
+++ b/mache/spack/chrysalis_gnu_openmpi.yaml
@@ -136,7 +136,7 @@ spack:
         f77: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/gcc-9.2.0-ugetvbp/bin/gfortran
         fc: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/gcc-9.2.0-ugetvbp/bin/gfortran
       flags: {}
-      operating_system: centos8
+      operating_system: rhel8
       target: x86_64
       modules: []
       environment: {}

--- a/mache/spack/chrysalis_gnu_openmpi.yaml
+++ b/mache/spack/chrysalis_gnu_openmpi.yaml
@@ -42,6 +42,11 @@ spack:
       - spec: diffutils@3.7
         prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.2.0/diffutils-3.7-nnauuo4
       buildable: false
+    gmake:
+      externals:
+      - spec: gmake@4.2.1
+        prefix: /usr
+      buildable: false
     libiconv:
       externals:
       - spec: libiconv@1.16

--- a/mache/spack/chrysalis_intel_impi.yaml
+++ b/mache/spack/chrysalis_intel_impi.yaml
@@ -136,7 +136,7 @@ spack:
         f77: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/intel-20.0.4-kodw73g/compilers_and_libraries_2020.4.304/linux/bin/intel64/ifort
         fc: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/intel-20.0.4-kodw73g/compilers_and_libraries_2020.4.304/linux/bin/intel64/ifort
       flags: {}
-      operating_system: centos8
+      operating_system: rhel8
       target: x86_64
       modules: []
       environment: {}

--- a/mache/spack/chrysalis_intel_impi.yaml
+++ b/mache/spack/chrysalis_intel_impi.yaml
@@ -42,6 +42,11 @@ spack:
       - spec: diffutils@3.7
         prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/diffutils-3.7-bml5fc4
       buildable: false
+    gmake:
+      externals:
+      - spec: gmake@4.2.1
+        prefix: /usr
+      buildable: false
     libiconv:
       externals:
       - spec: libiconv@1.16

--- a/mache/spack/chrysalis_intel_impi.yaml
+++ b/mache/spack/chrysalis_intel_impi.yaml
@@ -42,6 +42,11 @@ spack:
       - spec: diffutils@3.7
         prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/diffutils-3.7-bml5fc4
       buildable: false
+    findutils:
+      externals:
+      - spec: findutils@4.6.0
+        prefix: /usr
+      buildable: false
     gmake:
       externals:
       - spec: gmake@4.2.1

--- a/mache/spack/chrysalis_intel_openmpi.yaml
+++ b/mache/spack/chrysalis_intel_openmpi.yaml
@@ -136,7 +136,7 @@ spack:
         f77: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/intel-20.0.4-kodw73g/compilers_and_libraries_2020.4.304/linux/bin/intel64/ifort
         fc: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/intel-20.0.4-kodw73g/compilers_and_libraries_2020.4.304/linux/bin/intel64/ifort
       flags: {}
-      operating_system: centos8
+      operating_system: rhel8
       target: x86_64
       modules: []
       environment: {}

--- a/mache/spack/chrysalis_intel_openmpi.yaml
+++ b/mache/spack/chrysalis_intel_openmpi.yaml
@@ -42,6 +42,11 @@ spack:
       - spec: diffutils@3.7
         prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/diffutils-3.7-bml5fc4
       buildable: false
+    gmake:
+      externals:
+      - spec: gmake@4.2.1
+        prefix: /usr
+      buildable: false
     libiconv:
       externals:
       - spec: libiconv@1.16

--- a/mache/spack/chrysalis_intel_openmpi.yaml
+++ b/mache/spack/chrysalis_intel_openmpi.yaml
@@ -42,6 +42,11 @@ spack:
       - spec: diffutils@3.7
         prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/diffutils-3.7-bml5fc4
       buildable: false
+    findutils:
+      externals:
+      - spec: findutils@4.6.0
+        prefix: /usr
+      buildable: false
     gmake:
       externals:
       - spec: gmake@4.2.1


### PR DESCRIPTION
Following recent maintenance, the OS on both login nodes is now `rhel8`, so the spack OS has been updated accordingly.

For convenience, I added the system `gmake` and `findutils` so spack doesn't try to build them.