### PR TITLE
Add dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "xylar"
+      - "altheaden"
+    reviewers:
+      - "xylar"
+      - "altheaden"
+


### PR DESCRIPTION
This is a direct copy of the dependabot workflow in polaris [(link)](https://github.com/E3SM-Project/polaris/blob/main/.github/dependabot.yml), but with both myself and Xylar as assignees and reviewers.

I'm not totally sure how to test that this is set up correctly, but since I made almost no changes to the Polaris version, I think it's safe to say that the file is most likely set up correctly. I didn't find any locations elsewhere in the Polaris repo that referred to dependabot, and from my searching online it looks like this file is the only thing required to set it up. Therefore, I don't think there are any additional changes that should be included in this PR, but again I'm just not sure how to test it to know for sure.