### PR TITLE
Add basic PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!--
+Thank you for your pull request.
+Please add a description of what is accomplished in the PR here at the top:
+-->
+
+<!--
+Below are a few things we ask you or your reviewers to kindly check. 
+***Remove checks that are not relevant by deleting the line(s) below.***
+-->
+Checklist
+* [ ] `Testing` comment in the PR documents testing used to verify the changes
+
+<!--
+Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
+-->
+


### PR DESCRIPTION
I added a basic PR template, with only one checklist item (testing). I kept the pluralized wording and checklist format since we will be adding additional checklist items later (such as building the documentation). A PR with this template will look as follows:

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->