### PR TITLE
Update GitHub actions to additionally run Python 3.12

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -59,7 +59,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master


### PR DESCRIPTION
The test mache action will now run with Python 3.12 in addition to Python 3.8-3.11. Will test this behavior with the creation of this PR and update with the results in a comment.