### PR TITLE
Switch all mamba actions to miniforge/conda

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CANCEL_OTHERS: true
-  PATHS_IGNORE: '["**/README.rst", "**/docs/**"]'
+  PATHS_IGNORE: '["**/README.md", "**/docs/**"]'
 
 jobs:
   pre-commit-hooks:
@@ -87,10 +87,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: "mache_ci"
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
           channels: conda-forge,defaults
           channel-priority: strict
           auto-update-conda: true
@@ -99,7 +96,7 @@ jobs:
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install mache
         run: |
-          mamba create -n mache_dev --file spec-file.txt \
+          conda create -n mache_dev --file spec-file.txt \
               python=${{ matrix.python-version }}
           conda activate mache_dev
           python -m pip install -e .


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
In this PR, I updated the build workflow to use miniforge instead of mambaforge. I also made a small change to the pre-commit action that references the README - it was using the old file extension `.rst` which we just changed to `.md` in a previous PR.

The testing for this PR will start once the PR is created (as it changes actions that occur at PR-creation time). I will update the testing progress in the comments.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

