### PR TITLE
Fix setuptools on conda-forge feedstock

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include mache/cime_machine_config/*.xml
+include mache/machines/*.cfg
+include mache/spack/*.yaml
+include mache/spack/*.template
+include mache/spack/*.sh
+include mache/spack/*.csh

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,7 +17,6 @@ requirements:
     - python >=3.8
     - pip
     - setuptools >=60
-    - setuptools-scm >=8.0
   run:
     - python >=3.8
     - importlib_resources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,10 +66,7 @@ warn_redundant_casts = true
 warn_unused_configs = true
 
 [build-system]
-requires = [
-    "setuptools>=60",
-    "setuptools-scm>=8.0",
-]
+requires = ["setuptools>=60"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/spec-file.txt
+++ b/spec-file.txt
@@ -8,7 +8,6 @@ rsync
 
 # Building
 setuptools >=60
-setuptools-scm >=8.0
 
 # Linting and testing
 pip


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
A previously added setuptools option, `setuptools-scm`, was set in #175 during the transition from `setup.cfg` to `pyproject.toml`, and this option ended up not working on the conda-forge feedstock. This PR removes that option and replaces it again with the `MANIFEST.in` file.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

