### PR TITLE
Omit OMP* environment variables with gnu on chrysalis

### DIFF
--- a/mache/spack/chrysalis_gnu_openmpi.csh
+++ b/mache/spack/chrysalis_gnu_openmpi.csh
@@ -1,4 +1,5 @@
 setenv OMPI_MCA_sharedfp "^lockedfile,individual"
 setenv UCX_TLS "^xpmem"
-setenv OMP_STACKSIZE 128M
-setenv OMP_PLACES cores
+## purposefully omitting OMP variables that slow down MPAS-Ocean runs
+#setenv OMP_STACKSIZE 128M
+#setenv OMP_PLACES cores

--- a/mache/spack/chrysalis_gnu_openmpi.sh
+++ b/mache/spack/chrysalis_gnu_openmpi.sh
@@ -1,4 +1,5 @@
 export OMPI_MCA_sharedfp="^lockedfile,individual"
 export UCX_TLS="^xpmem"
-export OMP_STACKSIZE=128M
-export OMP_PLACES=cores
+## purposefully omitting OMP variables that slow down MPAS-Ocean runs
+#export OMP_STACKSIZE=128M
+#export OMP_PLACES=cores


### PR DESCRIPTION
They are causing very bad slowdown in the Polaris pr test suite.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

