### PR TITLE
Drop python 3.8 from supported versions

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -59,7 +59,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -14,11 +14,11 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    - python >=3.9
     - pip
     - setuptools >=60
   run:
-    - python >=3.8
+    - python >=3.9
     - importlib_resources
     - jinja2
     - lxml

--- a/mache/machine_info.py
+++ b/mache/machine_info.py
@@ -1,16 +1,9 @@
 import configparser
 import os
 import pwd
-import sys
-from typing import TYPE_CHECKING
+from importlib import resources as importlib_resources
 
 from lxml import etree
-
-if TYPE_CHECKING or sys.version_info >= (3, 9, 0):
-    from importlib import resources as importlib_resources
-else:
-    # python <= 3.8
-    import importlib_resources
 
 from mache.discover import discover_machine
 

--- a/mache/machine_info.py
+++ b/mache/machine_info.py
@@ -12,7 +12,6 @@ else:
     # python <= 3.8
     import importlib_resources
 
-
 from mache.discover import discover_machine
 
 
@@ -122,15 +121,17 @@ class MachineInfo:
             The contents as a string for printing to the terminal
         """
 
-        info = f'Machine: {self.machine}\n' \
-               f'  E3SM Supported Machine: {self.e3sm_supported}'
+        info = \
+            f'Machine: {self.machine}\n' \
+            f'  E3SM Supported Machine: {self.e3sm_supported}'
 
         if self.e3sm_supported and self.compilers is not None and \
                 self.mpilibs is not None and self.os is not None:
-            info = f'{info}\n' \
-                   f'  Compilers: {", ".join(self.compilers)}\n' \
-                   f'  MPI libraries: {", ".join(self.mpilibs)}\n' \
-                   f'  OS: {self.os}'
+            info = \
+                f'{info}\n' \
+                f'  Compilers: {", ".join(self.compilers)}\n' \
+                f'  MPI libraries: {", ".join(self.mpilibs)}\n' \
+                f'  OS: {self.os}'
 
         info = f'{info}\n'
 
@@ -138,41 +139,51 @@ class MachineInfo:
                          self.e3sm_unified_base is not None or
                          self.e3sm_unified_mpi is not None)
         if print_unified:
-            info = f'{info}\n' \
-                   f'E3SM-Unified:'
+            info = \
+                f'{info}\n' \
+                f'E3SM-Unified: '
 
             if self.e3sm_unified_activation is None:
-                info = f'{info}\n' \
-                       f'  E3SM-Unified is not currently loaded'
+                info = \
+                    f'{info}\n' \
+                    f'  E3SM-Unified is not currently loaded'
             else:
-                info = f'{info}\n' \
-                       f'  Activation: {self.e3sm_unified_activation}'
+                info = \
+                    f'{info}\n' \
+                    f'  Activation: {self.e3sm_unified_activation}'
             if self.e3sm_unified_base is not None:
-                info = f'{info}\n' \
-                       f'  Base path: {self.e3sm_unified_base}'
+                info = \
+                    f'{info}\n' \
+                    f'  Base path: {self.e3sm_unified_base}'
             if self.e3sm_unified_mpi is not None:
-                info = f'{info}\n' \
-                       f'  MPI type: {self.e3sm_unified_mpi}'
+                info = \
+                    f'{info}\n' \
+                    f'  MPI type: {self.e3sm_unified_mpi}'
             info = f'{info}\n'
 
         print_diags = self.diagnostics_base is not None
         if print_diags:
-            info = f'{info}\n' \
-                   f'Diagnostics:'
+            info = \
+                f'{info}\n' \
+                f'Diagnostics: '
 
             if self.diagnostics_base is not None:
-                info = f'{info}\n' \
-                       f'  Base path: {self.diagnostics_base}'
+                info = \
+                    f'{info}\n' \
+                    f'  Base path: {self.diagnostics_base}'
             info = f'{info}\n'
 
-        info = f'{info}\n' \
-               f'Config options:'
+        info = \
+            f'{info}\n' \
+            f'Config options: '
         for section in self.config.sections():
-            info = f'{info}\n' \
-                   f'  [{section}]'
+            info = \
+                f'{info}\n' \
+                f'  [{section}]'
             for key, value in self.config.items(section):
-                info = f'{info}\n' \
-                       f'    {key} = {value}'
+                info = \
+                    f'{info}\n' \
+                    f'    {key} = {value}'
             info = f'{info}\n'
         return info
 

--- a/mache/spack/__init__.py
+++ b/mache/spack/__init__.py
@@ -1,17 +1,11 @@
 import os
 import subprocess
 import sys
+from importlib import resources as importlib_resources
 from typing import TYPE_CHECKING
 
-from jinja2 import Template
-
-if TYPE_CHECKING or sys.version_info >= (3, 9, 0):
-    from importlib import resources as importlib_resources
-else:
-    # python <= 3.8
-    import importlib_resources
-
 import yaml
+from jinja2 import Template
 
 from mache.machine_info import MachineInfo, discover_machine
 from mache.version import __version__

--- a/mache/spack/__init__.py
+++ b/mache/spack/__init__.py
@@ -98,7 +98,7 @@ def make_spack_env(spack_path, env_name, spack_specs, compiler, mpi,
                     section.getboolean('modules_after'))
 
     # add the package specs to the appropriate template
-    specs = ''.join([f'  - {spec}\n' for spec in spack_specs])
+    specs = ''.join([f'  - {spec}\n' for spec in spack_specs])  # noqa: E221
 
     yaml_data = _get_yaml_data(machine, compiler, mpi, include_e3sm_lapack,
                                include_e3sm_hdf5_netcdf,
@@ -111,8 +111,9 @@ def make_spack_env(spack_path, env_name, spack_specs, compiler, mpi,
 
     if with_modules:
         mods = _get_modules(yaml_data)
-        modules = f'module purge\n' \
-                  f'{mods}'
+        modules = \
+            f'module purge\n' \
+            f'{mods}'
     else:
         modules = ''
 
@@ -139,8 +140,9 @@ def make_spack_env(spack_path, env_name, spack_specs, compiler, mpi,
     with open(str(path)) as fp:
         template = Template(fp.read())
     if tmpdir is not None:
-        modules = f'{modules}\n' \
-                  f'export TMPDIR={tmpdir}'
+        modules = \
+            f'{modules}\n' \
+            f'export TMPDIR={tmpdir}'
 
     template_args = dict(modules=modules, version=__version__,
                          spack_path=spack_path, env_name=env_name,
@@ -245,9 +247,10 @@ def get_spack_script(spack_path, env_name, compiler, mpi, shell, machine=None,
     else:
         load_script = ''
 
-    load_script = f'{load_script}' \
-                  f'source {spack_path}/share/spack/setup-env.{shell}\n' \
-                  f'spack env activate {env_name}'
+    load_script = \
+        f'{load_script}' \
+        f'source {spack_path}/share/spack/setup-env.{shell}\n' \
+        f'spack env activate {env_name}'
 
     for shell_filename in [f'{machine}.{shell}',
                            f'{machine}_{compiler}_{mpi}.{shell}']:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,9 @@ authors = [
 description = "A package for providing configuration data related to E3SM supported machines."
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     # these are only for searching/browsing projects on PyPI
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/spec-file.txt
+++ b/spec-file.txt
@@ -1,4 +1,4 @@
-python >=3.8
+python >=3.9
 importlib_resources
 jinja2
 lxml


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
I updated a few places where python 3.8 was referenced or used, and either removed them or changed them to 3.9. During this process, I also had to update some file formatting to comply with the linter. 
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

