### PR TITLE
Remove `[include_]system_hdf5_netcdf`

### DIFF
--- a/mache/machines/anvil.cfg
+++ b/mache/machines/anvil.cfg
@@ -15,10 +15,6 @@ mpi = openmpi
 # system libraries will be deployed
 base_path = /lcrc/soft/climate/e3sm-unified
 
-# whether to use system modules for hdf5, netcdf-c, netcdf-fortran and pnetcdf
-# (spack modules are used otherwise)
-use_system_hdf5_netcdf = False
-
 
 # config options related to data needed by diagnostics software such as
 # e3sm_diags and MPAS-Analysis

--- a/mache/machines/chicoma-cpu.cfg
+++ b/mache/machines/chicoma-cpu.cfg
@@ -15,10 +15,6 @@ mpi = mpich
 # system libraries will be deployed
 base_path = /usr/projects/e3sm/e3sm-unified
 
-# whether to use system modules for hdf5, netcdf-c, netcdf-fortran and pnetcdf
-# (spack modules are used otherwise)
-use_system_hdf5_netcdf = True
-
 # location of a spack mirror for E3SM-Unified to use
 spack_mirror = /usr/projects/e3sm/e3sm-unified/spack/spack_mirror
 

--- a/mache/machines/chrysalis.cfg
+++ b/mache/machines/chrysalis.cfg
@@ -15,10 +15,6 @@ mpi = openmpi
 # system libraries will be deployed
 base_path = /lcrc/soft/climate/e3sm-unified
 
-# whether to use system modules for hdf5, netcdf-c, netcdf-fortran and pnetcdf
-# (spack modules are used otherwise)
-use_system_hdf5_netcdf = False
-
 
 # config options related to data needed by diagnostics software such as
 # e3sm_diags and MPAS-Analysis

--- a/mache/machines/compy.cfg
+++ b/mache/machines/compy.cfg
@@ -15,10 +15,6 @@ mpi = openmpi
 # system libraries will be deployed
 base_path = /share/apps/E3SM/conda_envs
 
-# whether to use the same modules for hdf5, netcdf-c, netcdf-fortran and
-# pnetcdf as E3SM (spack modules are used otherwise)
-use_system_hdf5_netcdf = False
-
 
 # config options related to data needed by diagnostics software such as
 # e3sm_diags and MPAS-Analysis

--- a/mache/machines/frontier.cfg
+++ b/mache/machines/frontier.cfg
@@ -15,10 +15,6 @@ mpi = mpich
 # system libraries will be deployed
 base_path = /ccs/proj/cli115/software/e3sm-unified
 
-# whether to use system modules for hdf5, netcdf-c, netcdf-fortran and pnetcdf
-# (spack modules are used otherwise)
-use_system_hdf5_netcdf = True
-
 
 # config options related to data needed by diagnostics software such as
 # e3sm_diags and MPAS-Analysis

--- a/mache/machines/pm-cpu.cfg
+++ b/mache/machines/pm-cpu.cfg
@@ -15,10 +15,6 @@ mpi = mpich
 # system libraries will be deployed
 base_path = /global/common/software/e3sm/anaconda_envs
 
-# whether to use system modules for hdf5, netcdf-c, netcdf-fortran and pnetcdf
-# (spack modules are used otherwise)
-use_system_hdf5_netcdf = True
-
 
 # config options related to data needed by diagnostics software such as
 # e3sm_diags and MPAS-Analysis

--- a/mache/machines/pm-gpu.cfg
+++ b/mache/machines/pm-gpu.cfg
@@ -15,10 +15,6 @@ mpi = mpich
 # system libraries will be deployed
 base_path = /global/common/software/e3sm/anaconda_envs
 
-# whether to use system modules for hdf5, netcdf-c, netcdf-fortran and pnetcdf
-# (spack modules are used otherwise)
-use_system_hdf5_netcdf = True
-
 
 # config options related to data needed by diagnostics software such as
 # e3sm_diags and MPAS-Analysis

--- a/mache/spack/__init__.py
+++ b/mache/spack/__init__.py
@@ -14,7 +14,6 @@ from mache.version import __version__
 def make_spack_env(spack_path, env_name, spack_specs, compiler, mpi,
                    machine=None, config_file=None, include_e3sm_lapack=False,
                    include_e3sm_hdf5_netcdf=False,
-                   include_system_hdf5_netcdf=False,
                    yaml_template=None, tmpdir=None, spack_mirror=None,
                    custom_spack=''):
     """
@@ -54,10 +53,6 @@ def make_spack_env(spack_path, env_name, spack_specs, compiler, mpi,
         Whether to include the same hdf5, netcdf-c, netcdf-fortran and pnetcdf
         as used in E3SM
 
-    include_system_hdf5_netcdf : bool, optional
-        Whether to include the system hdf5, netcdf-c, netcdf-fortran and
-        pnetcdf (not necessarily the same as E3SM)
-
     yaml_template : str, optional
         A jinja template for a yaml file to be used for the environment instead
         of the mache template.  This allows you to use compilers and other
@@ -95,8 +90,7 @@ def make_spack_env(spack_path, env_name, spack_specs, compiler, mpi,
     specs = ''.join([f'  - {spec}\n' for spec in spack_specs])  # noqa: E221
 
     yaml_data = _get_yaml_data(machine, compiler, mpi, include_e3sm_lapack,
-                               include_e3sm_hdf5_netcdf,
-                               include_system_hdf5_netcdf, specs,
+                               include_e3sm_hdf5_netcdf, specs,
                                yaml_template)
 
     yaml_filename = os.path.abspath(f'{env_name}.yaml')
@@ -124,8 +118,7 @@ def make_spack_env(spack_path, env_name, spack_specs, compiler, mpi,
             continue
         bash_script = template.render(
             e3sm_lapack=include_e3sm_lapack,
-            e3sm_hdf5_netcdf=include_e3sm_hdf5_netcdf,
-            system_hdf5_netcdf=include_system_hdf5_netcdf)
+            e3sm_hdf5_netcdf=include_e3sm_hdf5_netcdf)
 
         modules = f'{modules}\n{bash_script}'
 
@@ -159,7 +152,7 @@ def make_spack_env(spack_path, env_name, spack_specs, compiler, mpi,
 def get_spack_script(spack_path, env_name, compiler, mpi, shell, machine=None,
                      config_file=None, include_e3sm_lapack=False,
                      include_e3sm_hdf5_netcdf=False,
-                     include_system_hdf5_netcdf=False, yaml_template=None):
+                     yaml_template=None):
     """
     Build a snippet of a load script for the given spack environment
 
@@ -195,10 +188,6 @@ def get_spack_script(spack_path, env_name, compiler, mpi, shell, machine=None,
         Whether to include the same hdf5, netcdf-c, netcdf-fortran and pnetcdf
         as used in E3SM
 
-    include_system_hdf5_netcdf : bool, optional
-        Whether to include the system hdf5, netcdf-c, netcdf-fortran and
-        pnetcdf (not necessarily the same as E3SM)
-
     yaml_template : str, optional
         A jinja template for a yaml file to be used for the environment instead
         of the mache template.  This allows you to use compilers and other
@@ -231,7 +220,7 @@ def get_spack_script(spack_path, env_name, compiler, mpi, shell, machine=None,
 
     yaml_data = _get_yaml_data(
         machine, compiler, mpi, include_e3sm_lapack, include_e3sm_hdf5_netcdf,
-        include_system_hdf5_netcdf, specs='', yaml_template=yaml_template)
+        specs='', yaml_template=yaml_template)
 
     if modules_before or modules_after:
         load_script = 'module purge\n'
@@ -259,8 +248,7 @@ def get_spack_script(spack_path, env_name, compiler, mpi, shell, machine=None,
             continue
         shell_script = template.render(
             e3sm_lapack=include_e3sm_lapack,
-            e3sm_hdf5_netcdf=include_e3sm_hdf5_netcdf,
-            system_hdf5_netcdf=include_system_hdf5_netcdf)
+            e3sm_hdf5_netcdf=include_e3sm_hdf5_netcdf)
         load_script = f'{load_script}\n{shell_script}'
 
     if modules_after:
@@ -273,7 +261,6 @@ def get_spack_script(spack_path, env_name, compiler, mpi, shell, machine=None,
 def get_modules_env_vars_and_mpi_compilers(machine, compiler, mpi, shell,
                                            include_e3sm_lapack=False,
                                            include_e3sm_hdf5_netcdf=False,
-                                           include_system_hdf5_netcdf=False,
                                            yaml_template=None):
     """
     Get the non-spack modules, environment variables and compiler names for a
@@ -301,10 +288,6 @@ def get_modules_env_vars_and_mpi_compilers(machine, compiler, mpi, shell,
     include_e3sm_hdf5_netcdf : bool, optional
         Whether to include the same hdf5, netcdf-c, netcdf-fortran and pnetcdf
         as used in E3SM
-
-    include_system_hdf5_netcdf : bool, optional
-        Whether to include the system hdf5, netcdf-c, netcdf-fortran and
-        pnetcdf (not necessarily the same as E3SM)
 
     yaml_template : str, optional
         A jinja template for a yaml file to be used for the environment instead
@@ -350,7 +333,7 @@ def get_modules_env_vars_and_mpi_compilers(machine, compiler, mpi, shell,
     if with_modules:
         yaml_data = _get_yaml_data(
             machine, compiler, mpi, include_e3sm_lapack,
-            include_e3sm_hdf5_netcdf, include_system_hdf5_netcdf, specs='',
+            include_e3sm_hdf5_netcdf, specs='',
             yaml_template=yaml_template)
         mods = _get_modules(yaml_data)
         mod_env_commands = f'{mod_env_commands}\n{mods}\n'
@@ -367,8 +350,7 @@ def get_modules_env_vars_and_mpi_compilers(machine, compiler, mpi, shell,
             continue
         shell_script = template.render(
             e3sm_lapack=include_e3sm_lapack,
-            e3sm_hdf5_netcdf=include_e3sm_hdf5_netcdf,
-            system_hdf5_netcdf=include_system_hdf5_netcdf)
+            e3sm_hdf5_netcdf=include_e3sm_hdf5_netcdf)
         mod_env_commands = f'{mod_env_commands}\n{shell_script}'
 
     mpicc, mpicxx, mpifc = _get_mpi_compilers(machine, compiler, mpi,
@@ -378,7 +360,7 @@ def get_modules_env_vars_and_mpi_compilers(machine, compiler, mpi, shell,
 
 
 def _get_yaml_data(machine, compiler, mpi, include_e3sm_lapack,
-                   include_e3sm_hdf5_netcdf, include_system_hdf5_netcdf, specs,
+                   include_e3sm_hdf5_netcdf, specs,
                    yaml_template):
     """ Get the data from the jinja-templated yaml file based on settings """
     if yaml_template is None:
@@ -397,8 +379,7 @@ def _get_yaml_data(machine, compiler, mpi, include_e3sm_lapack,
 
     yaml_data = template.render(specs=specs,
                                 e3sm_lapack=include_e3sm_lapack,
-                                e3sm_hdf5_netcdf=include_e3sm_hdf5_netcdf,
-                                system_hdf5_netcdf=include_system_hdf5_netcdf)
+                                e3sm_hdf5_netcdf=include_e3sm_hdf5_netcdf)
     return yaml_data
 
 

--- a/mache/spack/chicoma-cpu_gnu_mpich.yaml
+++ b/mache/spack/chicoma-cpu_gnu_mpich.yaml
@@ -123,7 +123,7 @@ spack:
         - cray-libsci/23.05.1.4
       buildable: false
 {% endif %}
-{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
+{% if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared

--- a/mache/spack/chicoma-cpu_nvidia_mpich.yaml
+++ b/mache/spack/chicoma-cpu_nvidia_mpich.yaml
@@ -115,7 +115,7 @@ spack:
         prefix: /opt/cray/pe/libsci/23.05.1.4/NVIDIA/20.7/x86_64
       buildable: false
 {% endif %}
-{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
+{% if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared

--- a/mache/spack/frontier_crayclang_mpich.yaml
+++ b/mache/spack/frontier_crayclang_mpich.yaml
@@ -122,7 +122,7 @@ spack:
         - cray-libsci/22.12.1.1
       buildable: false
 {% endif %}
-{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
+{% if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.1~cxx+fortran+hl~java+mpi+shared

--- a/mache/spack/frontier_crayclanggpu_mpich.yaml
+++ b/mache/spack/frontier_crayclanggpu_mpich.yaml
@@ -122,7 +122,7 @@ spack:
         - cray-libsci/22.12.1.1
       buildable: false
 {% endif %}
-{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
+{% if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.1~cxx+fortran+hl~java+mpi+shared

--- a/mache/spack/frontier_gnu_mpich.yaml
+++ b/mache/spack/frontier_gnu_mpich.yaml
@@ -132,7 +132,7 @@ spack:
         - cray-libsci/22.12.1.1
       buildable: false
 {% endif %}
-{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
+{% if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.1~cxx+fortran+hl~java+mpi+shared

--- a/mache/spack/frontier_gnugpu_mpich.yaml
+++ b/mache/spack/frontier_gnugpu_mpich.yaml
@@ -132,7 +132,7 @@ spack:
         - cray-libsci/22.12.1.1
       buildable: false
 {% endif %}
-{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
+{% if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.1~cxx+fortran+hl~java+mpi+shared

--- a/mache/spack/pm-cpu_gnu_mpich.yaml
+++ b/mache/spack/pm-cpu_gnu_mpich.yaml
@@ -133,7 +133,7 @@ spack:
         - cray-libsci/23.02.1.1
       buildable: false
 {% endif %}
-{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
+{% if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared

--- a/mache/spack/pm-cpu_intel_mpich.yaml
+++ b/mache/spack/pm-cpu_intel_mpich.yaml
@@ -118,7 +118,7 @@ spack:
         modules:
         - libfabric/1.15.2.0
       buildable: false
-{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
+{% if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.9~cxx+fortran+hl~java+mpi+shared

--- a/mache/spack/pm-cpu_nvidia_mpich.yaml
+++ b/mache/spack/pm-cpu_nvidia_mpich.yaml
@@ -120,7 +120,7 @@ spack:
         prefix: /opt/cray/pe/libsci/23.02.1.1/NVIDIA/20.7/x86_64
       buildable: false
 {% endif %}
-{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
+{% if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared

--- a/mache/spack/pm-gpu_gnugpu_mpich.yaml
+++ b/mache/spack/pm-gpu_gnugpu_mpich.yaml
@@ -146,7 +146,7 @@ spack:
         - cray-libsci/23.02.1.1
       buildable: false
 {% endif %}
-{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
+{% if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared

--- a/mache/spack/pm-gpu_nvidiagpu_mpich.yaml
+++ b/mache/spack/pm-gpu_nvidiagpu_mpich.yaml
@@ -135,7 +135,7 @@ spack:
         - cray-libsci/23.02.1.1
       buildable: false
 {% endif %}
-{% if e3sm_hdf5_netcdf or system_hdf5_netcdf %}
+{% if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.3~cxx+fortran+hl~java+mpi+shared


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR removes the deprecated `include_system_hdf5_netcdf` and `system_hdf5_netcdf` from Spack files and machine config files.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

