### PR TITLE
Switch pre-commit `autoupdate_schedule` to `weekly`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,4 +45,4 @@ repos:
 # https://pre-commit.ci/#configuration
 ci:
   autofix_prs: false
-  autoupdate_schedule: monthly
+  autoupdate_schedule: weekly


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR switches the recently added pre-commit `autoupdate_schedule` CI from monthly to weekly, so that we can observe the behavior sooner for testing. This will likely be switched back to monthly after we confirm that it works as expected.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

