### PR TITLE
Various fixes to the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,10 +6,6 @@
 
 import os
 from datetime import date
-import sphinx_rtd_theme
-
-from sphinx.application import Sphinx
-from sphinx.transforms.post_transforms import SphinxPostTransform
 
 from mache.version import __version__
 
@@ -95,7 +91,6 @@ myst_enable_checkboxes = True
 # -- HTML output -------------------------------------------------
 
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_title = ""
 
 # Add any paths that contain custom static files (such as style sheets) here,
@@ -112,4 +107,3 @@ html_sidebars = {
 smv_tag_whitelist = r"^\d+\.\d+.\d+$"  # Include tags like "tags/2.5.0"
 smv_branch_whitelist = "main"
 smv_remote_whitelist = r"^(origin|upstream)$"  # Use branches from origin
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,10 @@ dependencies = [
 [project.optional-dependencies]
 docs = [
     # building documentation
-    "sphinx",
+    "sphinx >=8.0.0",
     "sphinx_rtd_theme",
     "myst-parser",
     "sphinx-multiversion",
-    "rst-to-myst",
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 [project.optional-dependencies]
 docs = [
     # building documentation
-    "sphinx >=8.0.0",
+    "sphinx >=7.0.0",
     "sphinx_rtd_theme",
     "myst-parser",
     "sphinx-multiversion",

--- a/spec-file.txt
+++ b/spec-file.txt
@@ -19,8 +19,7 @@ mypy
 pre-commit
 
 # Documentation
-sphinx
+sphinx >=8.0.0
 sphinx_rtd_theme
 myst-parser
 sphinx-multiversion
-rst-to-myst

--- a/spec-file.txt
+++ b/spec-file.txt
@@ -19,7 +19,7 @@ mypy
 pre-commit
 
 # Documentation
-sphinx >=8.0.0
+sphinx >=7.0.0
 sphinx_rtd_theme
 myst-parser
 sphinx-multiversion


### PR DESCRIPTION
This merge removes `myst-to-rst` (which is not being maintained) and constrain sphinx to newer versions (>= 8.0.0).

It also includes some cleanup of the config script for the docs, including removing unused imports and removing an unneeded path to the read-the-docs theme files.