### PR TITLE
Tweak pre-commit autoupdate CI workflow

### DIFF
--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -10,6 +10,9 @@ on:
     # 5. Entry: Weekday when the process will be started [0-6] [0 is Sunday]
     - cron: '0 8 * * 3'
 
+env:
+  UP_TO_DATE: false
+
 jobs:
   auto-update:
     runs-on: ubuntu-latest
@@ -35,9 +38,10 @@ jobs:
           pre-commit autoupdate
           git add .
           # The second command will fail if no changes were present, so we ignore it
-          git commit -m "Update pre-commit dependencies" || true
+          git commit -m "Update pre-commit dependencies" || ( echo "UP_TO_DATE=true" >> "$GITHUB_ENV")
 
       - name: Push Changes
+        if: ${{ env.UP_TO_DATE == 'false' }}
         uses: ad-m/github-push-action@master
         with:
           branch: update-pre-commit-deps
@@ -47,12 +51,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Make PR
+      - name: Make PR and add reviewers and labels
+        if: ${{ env.UP_TO_DATE == 'false' }}
         run: |
           cd update-pre-commit-deps
-          gh pr create --title "Update pre-commit and its dependencies" \
+          gh pr create \
+          --title "Update pre-commit and its dependencies" \
           --body "This PR was auto-generated to update pre-commit and its dependencies." \
-          --head update-pre-commit-deps
+          --head update-pre-commit-deps \
+          --reviewer altheaden,xylar \
+          --label ci
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR makes a few tweaks to the new pre-commit CI workflow. This workflow now skips the push and PR-creating steps when no changes are present (i.e., when pre-commit is already up-to-date). Also, PRs created via this action will automatically be assigned reviewers and a `ci` label.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

