### PR TITLE
Remove deprecated `install_missing_compilers` spack config

### DIFF
--- a/mache/spack/anvil_gnu_mvapich.yaml
+++ b/mache/spack/anvil_gnu_mvapich.yaml
@@ -150,8 +150,6 @@ spack:
         - parallel-netcdf/1.11.0-c22b2bn
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: gcc@8.2.0

--- a/mache/spack/anvil_gnu_openmpi.yaml
+++ b/mache/spack/anvil_gnu_openmpi.yaml
@@ -150,8 +150,6 @@ spack:
         - parallel-netcdf/1.11.0-a7ohxsg
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: gcc@8.2.0

--- a/mache/spack/anvil_intel_impi.yaml
+++ b/mache/spack/anvil_intel_impi.yaml
@@ -148,8 +148,6 @@ spack:
         - parallel-netcdf/1.11.0-y3nmmej
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: intel@20.0.4

--- a/mache/spack/anvil_intel_mvapich.yaml
+++ b/mache/spack/anvil_intel_mvapich.yaml
@@ -151,8 +151,6 @@ spack:
         - parallel-netcdf/1.11.0-kj4jsvt
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: intel@20.0.4

--- a/mache/spack/anvil_intel_openmpi.yaml
+++ b/mache/spack/anvil_intel_openmpi.yaml
@@ -148,8 +148,6 @@ spack:
         - parallel-netcdf/1.11.0-x4n5s7k
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: intel@20.0.4

--- a/mache/spack/chicoma-cpu_gnu_mpich.yaml
+++ b/mache/spack/chicoma-cpu_gnu_mpich.yaml
@@ -136,8 +136,6 @@ spack:
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.9/gnu/12.3
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: gcc@12.3

--- a/mache/spack/chicoma-cpu_nvidia_mpich.yaml
+++ b/mache/spack/chicoma-cpu_nvidia_mpich.yaml
@@ -123,8 +123,6 @@ spack:
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.9/nvidia/23.3
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: nvhpc@24.7

--- a/mache/spack/chrysalis_gnu_openmpi.yaml
+++ b/mache/spack/chrysalis_gnu_openmpi.yaml
@@ -131,8 +131,6 @@ spack:
         - parallel-netcdf/1.11.0-d7h4ysd
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: gcc@11.2.0

--- a/mache/spack/chrysalis_intel_impi.yaml
+++ b/mache/spack/chrysalis_intel_impi.yaml
@@ -131,8 +131,6 @@ spack:
         - parallel-netcdf/1.11.0-b74wv4m
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: intel@20.0.4

--- a/mache/spack/chrysalis_intel_openmpi.yaml
+++ b/mache/spack/chrysalis_intel_openmpi.yaml
@@ -131,8 +131,6 @@ spack:
         - parallel-netcdf/1.11.0-icrpxty
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: intel@20.0.4

--- a/mache/spack/compy_gnu_openmpi.yaml
+++ b/mache/spack/compy_gnu_openmpi.yaml
@@ -148,8 +148,6 @@ spack:
         - pnetcdf/1.9.0
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: gcc@10.2.0

--- a/mache/spack/compy_intel_impi.yaml
+++ b/mache/spack/compy_intel_impi.yaml
@@ -149,8 +149,6 @@ spack:
         - pnetcdf/1.9.0
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: intel@20.0.0

--- a/mache/spack/frontier_crayclang_mpich.yaml
+++ b/mache/spack/frontier_crayclang_mpich.yaml
@@ -144,8 +144,6 @@ spack:
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/crayclang/14.0
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: cce@15.0.1

--- a/mache/spack/frontier_crayclanggpu_mpich.yaml
+++ b/mache/spack/frontier_crayclanggpu_mpich.yaml
@@ -144,8 +144,6 @@ spack:
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/crayclang/14.0
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: cce@15.0.1

--- a/mache/spack/frontier_gnu_mpich.yaml
+++ b/mache/spack/frontier_gnu_mpich.yaml
@@ -154,8 +154,6 @@ spack:
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/GNU/9.1
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: gcc@12.2.0

--- a/mache/spack/frontier_gnugpu_mpich.yaml
+++ b/mache/spack/frontier_gnugpu_mpich.yaml
@@ -155,8 +155,6 @@ spack:
       buildable: false
 {% endif %}
 
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: gcc@11.2.0

--- a/mache/spack/pm-cpu_gnu_mpich.yaml
+++ b/mache/spack/pm-cpu_gnu_mpich.yaml
@@ -141,8 +141,6 @@ spack:
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.9/gnu/12.3
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: gcc@12.3

--- a/mache/spack/pm-cpu_intel_mpich.yaml
+++ b/mache/spack/pm-cpu_intel_mpich.yaml
@@ -132,8 +132,6 @@ spack:
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.9/intel/2023.2
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: intel@2023.2.0

--- a/mache/spack/pm-cpu_nvidia_mpich.yaml
+++ b/mache/spack/pm-cpu_nvidia_mpich.yaml
@@ -134,8 +134,6 @@ spack:
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.9/nvidia/23.3
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: nvhpc@24.5

--- a/mache/spack/pm-gpu_gnugpu_mpich.yaml
+++ b/mache/spack/pm-gpu_gnugpu_mpich.yaml
@@ -152,8 +152,6 @@ spack:
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.9/gnu/12.3
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: gcc@12.3

--- a/mache/spack/pm-gpu_nvidiagpu_mpich.yaml
+++ b/mache/spack/pm-gpu_nvidiagpu_mpich.yaml
@@ -146,8 +146,6 @@ spack:
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.9/nvidia/23.3
       buildable: false
 {% endif %}
-  config:
-    install_missing_compilers: false
   compilers:
   - compiler:
       spec: nvhpc@24.5


### PR DESCRIPTION
We are seeing:
```
==> Warning: The config:install_missing_compilers option has been deprecated in Spack v0.23, and is currently ignored. It will be removed from config in Spack v0.25.
```
This merge removes the deprecated config option.
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

