### PR TITLE
Add `extra_attributes` to all external gcc spack packages

### DIFF
--- a/mache/spack/anvil_gnu_mvapich.yaml
+++ b/mache/spack/anvil_gnu_mvapich.yaml
@@ -90,7 +90,7 @@ spack:
     zlib:
       externals:
       - spec: zlib@1.2.11
-        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/zlib-1.2.11-dudhhig
+        prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/zlib-1.2.11-m3ugpb3
       buildable: false
     perl:
       externals:

--- a/mache/spack/anvil_gnu_mvapich.yaml
+++ b/mache/spack/anvil_gnu_mvapich.yaml
@@ -105,6 +105,11 @@ spack:
         prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-8.2.0-xhxgy33
         modules:
         - gcc/8.2.0-xhxgy33
+        extra_attributes:
+          compilers:
+            c: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-8.2.0-xhxgy33/bin/gcc
+            cxx: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-8.2.0-xhxgy33/bin/g++
+            fortran: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-8.2.0-xhxgy33/bin/gfortran
       buildable: false
     mvapich2:
       externals:

--- a/mache/spack/anvil_gnu_openmpi.yaml
+++ b/mache/spack/anvil_gnu_openmpi.yaml
@@ -105,6 +105,11 @@ spack:
         prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-8.2.0-xhxgy33
         modules:
         - gcc/8.2.0-xhxgy33
+        extra_attributes:
+          compilers:
+            c: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-8.2.0-xhxgy33/bin/gcc
+            cxx: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-8.2.0-xhxgy33/bin/g++
+            fortran: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-8.2.0-xhxgy33/bin/gfortran
       buildable: false
     openmpi:
       externals:

--- a/mache/spack/anvil_gnu_openmpi.yaml
+++ b/mache/spack/anvil_gnu_openmpi.yaml
@@ -90,7 +90,7 @@ spack:
     zlib:
       externals:
       - spec: zlib@1.2.11
-        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/zlib-1.2.11-dudhhig
+        prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/zlib-1.2.11-m3ugpb3
       buildable: false
     perl:
       externals:

--- a/mache/spack/anvil_intel_impi.yaml
+++ b/mache/spack/anvil_intel_impi.yaml
@@ -90,7 +90,7 @@ spack:
     zlib:
       externals:
       - spec: zlib@1.2.11
-        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/zlib-1.2.11-dudhhig
+        prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/zlib-1.2.11-m3ugpb3
       buildable: false
     perl:
       externals:

--- a/mache/spack/anvil_intel_mvapich.yaml
+++ b/mache/spack/anvil_intel_mvapich.yaml
@@ -90,7 +90,7 @@ spack:
     zlib:
       externals:
       - spec: zlib@1.2.11
-        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/zlib-1.2.11-dudhhig
+        prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/zlib-1.2.11-m3ugpb3
       buildable: false
     perl:
       externals:

--- a/mache/spack/anvil_intel_openmpi.yaml
+++ b/mache/spack/anvil_intel_openmpi.yaml
@@ -90,7 +90,7 @@ spack:
     zlib:
       externals:
       - spec: zlib@1.2.11
-        prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/zlib-1.2.11-dudhhig
+        prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/zlib-1.2.11-m3ugpb3
       buildable: false
     perl:
       externals:

--- a/mache/spack/chicoma-cpu_gnu_mpich.yaml
+++ b/mache/spack/chicoma-cpu_gnu_mpich.yaml
@@ -101,6 +101,11 @@ spack:
         - craype/2.7.30
         - craype-accel-host
         - craype-x86-rome
+        extra_attributes:
+          compilers:
+            c: cc
+            cxx: CC
+            fortran: ftn
       buildable: false
     cray-mpich:
       externals:

--- a/mache/spack/chrysalis_gnu_openmpi.yaml
+++ b/mache/spack/chrysalis_gnu_openmpi.yaml
@@ -90,6 +90,11 @@ spack:
         prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/gcc-11.2.0-bgddrif
         modules:
         - gcc/11.2.0-bgddrif
+        extra_attributes:
+          compilers:
+            c: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/gcc-11.2.0-bgddrif/bin/gcc
+            cxx: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/gcc-11.2.0-bgddrif/bin/g++
+            fortran: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/gcc-11.2.0-bgddrif/bin/gfortran
       buildable: false
     openmpi:
       externals:

--- a/mache/spack/compy_gnu_openmpi.yaml
+++ b/mache/spack/compy_gnu_openmpi.yaml
@@ -103,6 +103,11 @@ spack:
         prefix: /share/apps/gcc/10.2.0
         modules:
         - gcc/10.2.0
+        extra_attributes:
+          compilers:
+            c: /share/apps/gcc/10.2.0/bin/gcc
+            cxx: /share/apps/gcc/10.2.0/bin/g++
+            fortran: /share/apps/gcc/10.2.0/bin/gfortran
       buildable: false
     openmpi:
       externals:

--- a/mache/spack/frontier_gnu_mpich.yaml
+++ b/mache/spack/frontier_gnu_mpich.yaml
@@ -107,6 +107,11 @@ spack:
         - gcc/12.2.0
         - craype/2.7.19
         - libfabric/1.15.2.0
+        extra_attributes:
+          compilers:
+            c: cc
+            cxx: CC
+            fortran: ftn
       buildable: false
     cray-mpich:
       externals:

--- a/mache/spack/frontier_gnugpu_mpich.yaml
+++ b/mache/spack/frontier_gnugpu_mpich.yaml
@@ -107,6 +107,11 @@ spack:
         - gcc/11.2.0
         - craype/2.7.19
         - libfabric/1.15.2.0
+        extra_attributes:
+          compilers:
+            c: cc
+            cxx: CC
+            fortran: ftn
       buildable: false
     cray-mpich:
       externals:

--- a/mache/spack/pm-cpu_gnu_mpich.yaml
+++ b/mache/spack/pm-cpu_gnu_mpich.yaml
@@ -105,6 +105,11 @@ spack:
         - craype-accel-host
         - craype/2.7.30
         - libfabric/1.20.1
+        extra_attributes:
+          compilers:
+            c: cc
+            cxx: CC
+            fortran: ftn
       buildable: false
     cray-mpich:
       externals:

--- a/mache/spack/pm-gpu_gnugpu_mpich.yaml
+++ b/mache/spack/pm-gpu_gnugpu_mpich.yaml
@@ -106,6 +106,11 @@ spack:
         - libfabric/1.20.1
         - craype/2.7.30
         - cudatoolkit/12.4
+        extra_attributes:
+          compilers:
+            c: cc
+            cxx: CC
+            fortran: ftn
       buildable: false
     cuda:
       externals:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This is needed in the latest spack release because of changes made to how the `gcc` package detects the path to the compilers themselves.

This PR also changes Anvil spack to point its correct zlib (and not the version on Chrysalis).

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

