### PR TITLE
Update to v1.29.0

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mache" %}
-{% set version = "1.28.0" %}
+{% set version = "1.29.0" %}
 
 package:
   name: {{ name|lower }}

--- a/mache/version.py
+++ b/mache/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (1, 28, 0)
+__version_info__ = (1, 29, 0)
 __version__ = '.'.join(str(vi) for vi in __version_info__)


### PR DESCRIPTION
This differs from 1.28.0 only in pointing to a different spack branch