### PR TITLE
Drop spack build in E3SM-Unified on Chicoma

### DIFF
--- a/mache/machines/chicoma-cpu.cfg
+++ b/mache/machines/chicoma-cpu.cfg
@@ -5,22 +5,9 @@
 # the unix group for permissions for the e3sm-unified conda environment
 group = climate
 
-# the compiler set to use for system libraries and MPAS builds
-compiler = gnu
-
-# the system MPI library to use for intel18 compiler
-mpi = mpich
-
 # the path to the directory where activation scripts, the base environment, and
 # system libraries will be deployed
 base_path = /usr/projects/e3sm/e3sm-unified
-
-# whether to use E3SM modules for hdf5, netcdf-c, netcdf-fortran and pnetcdf
-# (spack modules are used otherwise)
-use_e3sm_hdf5_netcdf = True
-
-# location of a spack mirror for E3SM-Unified to use
-spack_mirror = /usr/projects/e3sm/e3sm-unified/spack/spack_mirror
 
 
 # config options related to data needed by diagnostics software such as


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

I am having trouble with installing mpi4py with system compilers on LANL's Chicoma machine and it's just not worth the trouble to fix this.  Instead, I think we can provide E3SM-Unified without system compiler and MPI support, like we do in Andes and ALCF Polaris.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

