### PR TITLE
Switch CI from miniconda to micromamba

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -73,21 +73,22 @@ jobs:
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Set up Conda Environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: "mache_ci"
-          miniforge-version: latest
-          channels: conda-forge
-          channel-priority: strict
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
+          environment-name: mache_dev
+          init-shell: bash
+          condarc: |
+            channel_priority: strict
+            channels: 
+                - conda-forge
+          create-args: >-
+            python=${{ matrix.python-version }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install mache
         run: |
-          conda create -n mache_dev --file spec-file.txt \
-              python=${{ matrix.python-version }}
-          conda activate mache_dev
+          conda install -y --file spec-file.txt \
+            python=${{ matrix.python-version }}
           python -m pip install --no-deps --no-build-isolation -vv -e .
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
@@ -96,7 +97,6 @@ jobs:
            CHECK_IMAGES: False
         run: |
           set -e
-          conda activate mache_dev
           pip check
           mache sync diags --help
           pytest tests
@@ -104,7 +104,6 @@ jobs:
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Build Sphinx Docs
         run: |
-          conda activate mache_dev
           # sphinx-multiversion expects at least a "main" branch
           git branch main || echo "branch main already exists."
           cd docs

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -25,34 +25,33 @@ jobs:
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Set up Conda Environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: "mache_ci"
-          miniforge-version: latest
-          channels: conda-forge
-          channel-priority: strict
-          auto-update-conda: true
-          python-version: ${{ env.PYTHON_VERSION }}
+          environment-name: mache_dev
+          init-shell: bash
+          condarc: |
+            channel_priority: strict
+            channels:
+                - conda-forge
+          create-args: >-
+            python=${{ env.PYTHON_VERSION }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install mache
         run: |
           git config --global url."https://github.com/".insteadOf "git@github.com:"
-          conda create -n mache_dev --file spec-file.txt \
+          conda install -y --file spec-file.txt \
             python=${{ env.PYTHON_VERSION }}
-          conda activate mache_dev
           python -m pip install -vv --no-deps --no-build-isolation -e .
 
       - name: Build Sphinx Docs
         run: |
           set -e
-          conda activate mache_dev
           cd docs
           sphinx-multiversion . _build/html
       - name: Copy Docs and Commit
         run: |
           set -e
-          conda activate mache_dev
           cd docs
           # gh-pages branch must already exist
           git clone https://github.com/E3SM-Project/mache.git --branch gh-pages --single-branch gh-pages


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR switches CI to use the `setup-micromamba` GitHub action instead of the `setup-miniconda` GitHub action, in an effort to fix CI crashes caused by the latest `miniconda` version. 
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation has been [built locally](https://docs.e3sm.org/mache/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

