### PR TITLE
Add `termcolor` dependency

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - pyyaml
     - progressbar2
     - rsync
+    - termcolor
 
 test:
   source_files:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "lxml",
     "pyyaml",
     "progressbar2",
+    "termcolor",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This pull request includes small changes to the dependencies in the `conda/meta.yaml` and `pyproject.toml` files. The changes add the `termcolor` package to the list of dependencies in both files.

Dependency updates:

* [`conda/meta.yaml`](diffhunk://#diff-e4db5852c039b631ee11f2e6f3b000f53e0774918ff1ba8f983f428f72b4fe4cR28): Added `termcolor` to the `requirements` section.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R30): Added `termcolor` to the `dependencies` section.