### PR TITLE
Spack and machines cleanup

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mache" %}
-{% set version = "1.30.0" %}
+{% set version = "1.31.0" %}
 
 package:
   name: {{ name|lower }}

--- a/mache/machines/andes.cfg
+++ b/mache/machines/andes.cfg
@@ -24,7 +24,7 @@ group = cli115
 # The parallel section describes options related to running jobs in parallel
 [parallel]
 
-# parallel system of execution: slurm, cobalt or single_node
+# parallel system of execution: slurm, pbs or single_node
 system = slurm
 
 # whether to use mpirun or srun to run a task

--- a/mache/machines/anvil.cfg
+++ b/mache/machines/anvil.cfg
@@ -44,7 +44,7 @@ base_url = https://web.lcrc.anl.gov/public/e3sm/diagnostic_output
 # The parallel section describes options related to running jobs in parallel
 [parallel]
 
-# parallel system of execution: slurm, cobalt or single_node
+# parallel system of execution: slurm, pbs or single_node
 system = slurm
 
 # whether to use mpirun or srun to run a task

--- a/mache/machines/anvil.cfg
+++ b/mache/machines/anvil.cfg
@@ -5,10 +5,10 @@
 # the unix group for permissions for the e3sm-unified conda environment
 group = cels
 
-# the compiler set to use for system libraries and MPAS builds
+# the compiler set to use for system libraries
 compiler = gnu
 
-# the system MPI library to use for intel18 compiler
+# the system MPI library
 mpi = openmpi
 
 # the path to the directory where activation scripts, the base environment, and

--- a/mache/machines/chicoma-cpu.cfg
+++ b/mache/machines/chicoma-cpu.cfg
@@ -24,7 +24,7 @@ group = climate
 # The parallel section describes options related to running jobs in parallel
 [parallel]
 
-# parallel system of execution: slurm, cobalt or single_node
+# parallel system of execution: slurm, pbs or single_node
 system = slurm
 
 # whether to use mpirun or srun to run a task

--- a/mache/machines/chrysalis.cfg
+++ b/mache/machines/chrysalis.cfg
@@ -44,7 +44,7 @@ base_url = https://web.lcrc.anl.gov/public/e3sm/diagnostic_output
 # The parallel section describes options related to running jobs in parallel
 [parallel]
 
-# parallel system of execution: slurm, cobalt or single_node
+# parallel system of execution: slurm, pbs or single_node
 system = slurm
 
 # whether to use mpirun or srun to run a task

--- a/mache/machines/chrysalis.cfg
+++ b/mache/machines/chrysalis.cfg
@@ -5,10 +5,10 @@
 # the unix group for permissions for the e3sm-unified conda environment
 group = cels
 
-# the compiler set to use for system libraries and MPAS builds
+# the compiler set to use for system libraries
 compiler = gnu
 
-# the system MPI library to use for intel18 compiler
+# the system MPI library
 mpi = openmpi
 
 # the path to the directory where activation scripts, the base environment, and

--- a/mache/machines/compy.cfg
+++ b/mache/machines/compy.cfg
@@ -5,10 +5,10 @@
 # the unix group for permissions for the e3sm-unified conda environment
 group = users
 
-# the compiler set to use for system libraries and MPAS builds
+# the compiler set to use for system libraries
 compiler = gnu
 
-# the system MPI library to use for intel18 compiler
+# the system MPI library
 mpi = openmpi
 
 # the path to the directory where activation scripts, the base environment, and

--- a/mache/machines/compy.cfg
+++ b/mache/machines/compy.cfg
@@ -44,7 +44,7 @@ base_url = https://compy-dtn.pnl.gov
 # The parallel section describes options related to running jobs in parallel
 [parallel]
 
-# parallel system of execution: slurm, cobalt or single_node
+# parallel system of execution: slurm, pbs or single_node
 system = slurm
 
 # whether to use mpirun or srun to run a task

--- a/mache/machines/dane.cfg
+++ b/mache/machines/dane.cfg
@@ -5,10 +5,10 @@
 # the unix group for permissions for the e3sm-unified conda environment
 group = e3sm
 
-# the compiler set to use for system libraries and MPAS builds
+# the compiler set to use for system libraries
 compiler = intel
 
-# the system MPI library to use for intel18 compiler
+# the system MPI library
 mpi = mvapich2
 
 # the path to the directory where activation scripts, the base environment, and

--- a/mache/machines/dane.cfg
+++ b/mache/machines/dane.cfg
@@ -40,7 +40,7 @@ base_url = https://lc.llnl.gov/e3sm/diagnostic_output
 # The parallel section describes options related to running jobs in parallel
 [parallel]
 
-# parallel system of execution: slurm, cobalt or single_node
+# parallel system of execution: slurm, pbs or single_node
 system = slurm
 
 # whether to use mpirun or srun to run a task

--- a/mache/machines/frontier.cfg
+++ b/mache/machines/frontier.cfg
@@ -34,7 +34,7 @@ group = cli115
 # The parallel section describes options related to running jobs in parallel
 [parallel]
 
-# parallel system of execution: slurm, cobalt or single_node
+# parallel system of execution: slurm, pbs or single_node
 system = slurm
 
 # whether to use mpirun or srun to run a task

--- a/mache/machines/frontier.cfg
+++ b/mache/machines/frontier.cfg
@@ -5,10 +5,10 @@
 # the unix group for permissions for the e3sm-unified conda environment
 group = cli115
 
-# the compiler set to use for system libraries and MPAS builds
+# the compiler set to use for system libraries
 compiler = craygnu
 
-# the system MPI library to use for intel18 compiler
+# the system MPI library
 mpi = mpich
 
 # the path to the directory where activation scripts, the base environment, and

--- a/mache/machines/pm-cpu.cfg
+++ b/mache/machines/pm-cpu.cfg
@@ -5,10 +5,10 @@
 # the unix group for permissions for the e3sm-unified conda environment
 group = e3sm
 
-# the compiler set to use for system libraries and MPAS builds
+# the compiler set to use for system libraries
 compiler = gnu
 
-# the system MPI library to use for intel18 compiler
+# the system MPI library
 mpi = mpich
 
 # the path to the directory where activation scripts, the base environment, and

--- a/mache/machines/pm-cpu.cfg
+++ b/mache/machines/pm-cpu.cfg
@@ -44,7 +44,7 @@ base_url = https://portal.nersc.gov/cfs/e3sm
 # The parallel section describes options related to running jobs in parallel
 [parallel]
 
-# parallel system of execution: slurm, cobalt or single_node
+# parallel system of execution: slurm, pbs or single_node
 system = slurm
 
 # whether to use mpirun or srun to run a task

--- a/mache/machines/pm-gpu.cfg
+++ b/mache/machines/pm-gpu.cfg
@@ -44,7 +44,7 @@ base_url = https://portal.nersc.gov/cfs/e3sm
 # The parallel section describes options related to running jobs in parallel
 [parallel]
 
-# parallel system of execution: slurm, cobalt or single_node
+# parallel system of execution: slurm, pbs or single_node
 system = slurm
 
 # whether to use mpirun or srun to run a task

--- a/mache/machines/pm-gpu.cfg
+++ b/mache/machines/pm-gpu.cfg
@@ -5,10 +5,10 @@
 # the unix group for permissions for the e3sm-unified conda environment
 group = e3sm
 
-# the compiler set to use for system libraries and MPAS builds
+# the compiler set to use for system libraries
 compiler = nvidiagpu
 
-# the system MPI library to use for intel18 compiler
+# the system MPI library
 mpi = mpich
 
 # the path to the directory where activation scripts, the base environment, and

--- a/mache/machines/ruby.cfg
+++ b/mache/machines/ruby.cfg
@@ -5,10 +5,10 @@
 # the unix group for permissions for the e3sm-unified conda environment
 group = e3sm
 
-# the compiler set to use for system libraries and MPAS builds
+# the compiler set to use for system libraries
 compiler = intel
 
-# the system MPI library to use for intel18 compiler
+# the system MPI library
 mpi = mvapich2
 
 # the path to the directory where activation scripts, the base environment, and

--- a/mache/machines/ruby.cfg
+++ b/mache/machines/ruby.cfg
@@ -40,7 +40,7 @@ base_url = https://lc.llnl.gov/e3sm/diagnostic_output
 # The parallel section describes options related to running jobs in parallel
 [parallel]
 
-# parallel system of execution: slurm, cobalt or single_node
+# parallel system of execution: slurm, pbs or single_node
 system = slurm
 
 # whether to use mpirun or srun to run a task

--- a/mache/spack/__init__.py
+++ b/mache/spack/__init__.py
@@ -95,16 +95,13 @@ def make_spack_env(
         'modules_after'
     )
 
-    # add the package specs to the appropriate template
-    specs = ''.join([f'  - {spec}\n' for spec in spack_specs])  # noqa: E221
-
     yaml_data = _get_yaml_data(
         machine,
         compiler,
         mpi,
         include_e3sm_lapack,
         include_e3sm_hdf5_netcdf,
-        specs,
+        spack_specs,
         yaml_template,
     )
 
@@ -250,7 +247,7 @@ def get_spack_script(
         mpi,
         include_e3sm_lapack,
         include_e3sm_hdf5_netcdf,
-        specs='',
+        specs=[],
         yaml_template=yaml_template,
     )
 
@@ -380,7 +377,7 @@ def get_modules_env_vars_and_mpi_compilers(
             mpi,
             include_e3sm_lapack,
             include_e3sm_hdf5_netcdf,
-            specs='',
+            specs=[],
             yaml_template=yaml_template,
         )
         mods = _get_modules(yaml_data)

--- a/mache/spack/templates/anvil_gnu_mvapich.csh
+++ b/mache/spack/templates/anvil_gnu_mvapich.csh
@@ -12,13 +12,13 @@ module load \
     intel-mkl/2020.4.304-d6zw4xa \
     mvapich2/2.2-verbs-ppznoge
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     netcdf/4.4.1-ve2zfkw \
     netcdf-cxx/4.2-2rkopdl \
     netcdf-fortran/4.4.4-thtylny \
     parallel-netcdf/1.11.0-c22b2bn
-{% endif %}
+{%- endif %}
 
 setenv UCX_TLS "self,sm,ud"
 setenv UCX_UD_MLX5_RX_QUEUE_LEN "16384"

--- a/mache/spack/templates/anvil_gnu_mvapich.sh
+++ b/mache/spack/templates/anvil_gnu_mvapich.sh
@@ -12,13 +12,13 @@ module load \
     intel-mkl/2020.4.304-d6zw4xa \
     mvapich2/2.2-verbs-ppznoge
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     netcdf/4.4.1-ve2zfkw \
     netcdf-cxx/4.2-2rkopdl \
     netcdf-fortran/4.4.4-thtylny \
     parallel-netcdf/1.11.0-c22b2bn
-{% endif %}
+{%- endif %}
 
 export UCX_TLS="self,sm,ud"
 export UCX_UD_MLX5_RX_QUEUE_LEN="16384"

--- a/mache/spack/templates/anvil_gnu_mvapich.yaml
+++ b/mache/spack/templates/anvil_gnu_mvapich.yaml
@@ -1,24 +1,29 @@
+{%- set compiler = "gcc@8.2.0" %}
+{%- set mpi = "mvapich2@2.2" %}
+
 spack:
   specs:
-  - gcc
-  - mvapich2
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - intel-mkl
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: true
   packages:
     all:
-      compiler: [gcc@8.2.0]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [mvapich2@4.1.1]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
 {%- endif %}
@@ -101,7 +106,7 @@ spack:
       buildable: false
     gcc:
       externals:
-      - spec: gcc@8.2.0
+      - spec: {{ compiler }}
         prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-8.2.0-xhxgy33
         modules:
         - gcc/8.2.0-xhxgy33
@@ -113,7 +118,7 @@ spack:
       buildable: false
     mvapich2:
       externals:
-      - spec: mvapich2@2.2
+      - spec: m{{ mpi }}%{{ compiler }}
         prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-8.2.0/mvapich2-2.2-ppznoge
         modules:
         - mvapich2/2.2-verbs-ppznoge
@@ -157,7 +162,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: gcc@8.2.0
+      spec: {{ compiler }}
       paths:
         cc: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-8.2.0-xhxgy33/bin/gcc
         cxx: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-8.2.0-xhxgy33/bin/g++

--- a/mache/spack/templates/anvil_gnu_mvapich.yaml
+++ b/mache/spack/templates/anvil_gnu_mvapich.yaml
@@ -2,15 +2,15 @@ spack:
   specs:
   - gcc
   - mvapich2
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - intel-mkl
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: true
@@ -19,9 +19,9 @@ spack:
       compiler: [gcc@8.2.0]
       providers:
         mpi: [mvapich2@4.1.1]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
-{% endif %}
+{%- endif %}
     bison:
       externals:
       - spec: bison@3.0.4
@@ -125,7 +125,7 @@ spack:
         modules:
         - intel-mkl/2020.4.304-d6zw4xa
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.10.7+cxx+fortran+hl+mpi
@@ -154,7 +154,7 @@ spack:
         modules:
         - parallel-netcdf/1.11.0-c22b2bn
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: gcc@8.2.0

--- a/mache/spack/templates/anvil_gnu_openmpi.csh
+++ b/mache/spack/templates/anvil_gnu_openmpi.csh
@@ -12,13 +12,13 @@ module load \
     intel-mkl/2020.4.304-d6zw4xa \
     openmpi/4.1.1-x5n4m36
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     netcdf-c/4.4.1-mtfptpl \
     netcdf-cxx/4.2-osp27dq \
     netcdf-fortran/4.4.4-5yd6dos \
     parallel-netcdf/1.11.0-a7ohxsg
-{% endif %}
+{%- endif %}
 
 setenv UCX_TLS "self,sm,ud"
 setenv UCX_UD_MLX5_RX_QUEUE_LEN "16384"

--- a/mache/spack/templates/anvil_gnu_openmpi.sh
+++ b/mache/spack/templates/anvil_gnu_openmpi.sh
@@ -12,13 +12,13 @@ module load \
     intel-mkl/2020.4.304-d6zw4xa \
     openmpi/4.1.1-x5n4m36
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     netcdf-c/4.4.1-mtfptpl \
     netcdf-cxx/4.2-osp27dq \
     netcdf-fortran/4.4.4-5yd6dos \
     parallel-netcdf/1.11.0-a7ohxsg
-{% endif %}
+{%- endif %}
 
 export UCX_TLS="self,sm,ud"
 export UCX_UD_MLX5_RX_QUEUE_LEN="16384"

--- a/mache/spack/templates/anvil_gnu_openmpi.yaml
+++ b/mache/spack/templates/anvil_gnu_openmpi.yaml
@@ -1,24 +1,28 @@
+{%- set compiler = "gcc@8.2.0" %}
+{%- set mpi = "openmpi@4.1.1" %}
 spack:
   specs:
-  - gcc
-  - openmpi
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - intel-mkl
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: true
   packages:
     all:
-      compiler: [gcc@8.2.0]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [openmpi@4.1.1]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
 {%- endif %}
@@ -101,7 +105,7 @@ spack:
       buildable: false
     gcc:
       externals:
-      - spec: gcc@8.2.0
+      - spec: {{ compiler }}
         prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-8.2.0-xhxgy33
         modules:
         - gcc/8.2.0-xhxgy33
@@ -113,7 +117,7 @@ spack:
       buildable: false
     openmpi:
       externals:
-      - spec: openmpi@4.1.1
+      - spec: {{ mpi }}%{{ compiler }}
         prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-8.2.0/openmpi-4.1.1-x5n4m36
         modules:
         - openmpi/4.1.1-x5n4m36
@@ -157,7 +161,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: gcc@8.2.0
+      spec: {{ compiler }}
       paths:
         cc: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-8.2.0-xhxgy33/bin/gcc
         cxx: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-8.2.0-xhxgy33/bin/g++

--- a/mache/spack/templates/anvil_gnu_openmpi.yaml
+++ b/mache/spack/templates/anvil_gnu_openmpi.yaml
@@ -2,15 +2,15 @@ spack:
   specs:
   - gcc
   - openmpi
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - intel-mkl
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: true
@@ -19,9 +19,9 @@ spack:
       compiler: [gcc@8.2.0]
       providers:
         mpi: [openmpi@4.1.1]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
-{% endif %}
+{%- endif %}
     bison:
       externals:
       - spec: bison@3.0.4
@@ -125,7 +125,7 @@ spack:
         modules:
         - intel-mkl/2020.4.304-d6zw4xa
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.10.7+cxx+fortran+hl+mpi
@@ -154,7 +154,7 @@ spack:
         modules:
         - parallel-netcdf/1.11.0-a7ohxsg
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: gcc@8.2.0

--- a/mache/spack/templates/anvil_intel_impi.csh
+++ b/mache/spack/templates/anvil_intel_impi.csh
@@ -13,13 +13,13 @@ module load \
     intel-mkl/2020.4.304-voqlapk \
     intel-mpi/2019.9.304-i42whlw
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     netcdf-c/4.4.1-blyisdg \
     netcdf-cxx/4.2-gkqc6fq \
     netcdf-fortran/4.4.4-eanrh5t \
     parallel-netcdf/1.11.0-y3nmmej
-{% endif %}
+{%- endif %}
 
 setenv UCX_TLS "self,sm,ud"
 setenv UCX_UD_MLX5_RX_QUEUE_LEN "16384"

--- a/mache/spack/templates/anvil_intel_impi.sh
+++ b/mache/spack/templates/anvil_intel_impi.sh
@@ -13,13 +13,13 @@ module load \
     intel-mkl/2020.4.304-voqlapk \
     intel-mpi/2019.9.304-i42whlw
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     netcdf-c/4.4.1-blyisdg \
     netcdf-cxx/4.2-gkqc6fq \
     netcdf-fortran/4.4.4-eanrh5t \
     parallel-netcdf/1.11.0-y3nmmej
-{% endif %}
+{%- endif %}
 
 export UCX_TLS="self,sm,ud"
 export UCX_UD_MLX5_RX_QUEUE_LEN="16384"

--- a/mache/spack/templates/anvil_intel_impi.yaml
+++ b/mache/spack/templates/anvil_intel_impi.yaml
@@ -1,24 +1,28 @@
+{%- set compiler = "intel@20.0.4" %}
+{%- set mpi = "intel-mpi@2019.9.304" %}
 spack:
   specs:
-  - intel
-  - intel-mpi
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - intel-mkl
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: true
   packages:
     all:
-      compiler: [intel@20.0.4]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [intel-mpi@2019.9.304]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
 {%- endif %}
@@ -101,14 +105,14 @@ spack:
       buildable: false
     intel:
       externals:
-      - spec: intel@20.0.4
+      - spec: {{ compiler }}
         modules:
         - gcc/8.2.0
         - intel/20.0.4-lednsve
       buildable: false
     intel-mpi:
       externals:
-      - spec: intel-mpi@2019.9.304
+      - spec: {{ mpi }}%{{ compiler }}
         modules:
         - intel-mpi/2019.9.304-i42whlw
       buildable: false
@@ -150,7 +154,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: intel@20.0.4
+      spec: {{ compiler }}
       paths:
         cc: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/intel-20.0.4-lednsve/compilers_and_libraries_2020.4.304/linux/bin/intel64/icc
         cxx: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/intel-20.0.4-lednsve/compilers_and_libraries_2020.4.304/linux/bin/intel64/icpc

--- a/mache/spack/templates/anvil_intel_impi.yaml
+++ b/mache/spack/templates/anvil_intel_impi.yaml
@@ -2,15 +2,15 @@ spack:
   specs:
   - intel
   - intel-mpi
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - intel-mkl
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: true
@@ -19,9 +19,9 @@ spack:
       compiler: [intel@20.0.4]
       providers:
         mpi: [intel-mpi@2019.9.304]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
-{% endif %}
+{%- endif %}
     bison:
       externals:
       - spec: bison@3.0.4
@@ -118,7 +118,7 @@ spack:
         modules:
         - intel-mkl/2020.4.304-voqlapk
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.10.7+cxx+fortran+hl+mpi
@@ -147,7 +147,7 @@ spack:
         modules:
         - parallel-netcdf/1.11.0-y3nmmej
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: intel@20.0.4

--- a/mache/spack/templates/anvil_intel_mvapich.csh
+++ b/mache/spack/templates/anvil_intel_mvapich.csh
@@ -13,13 +13,13 @@ module load \
     intel-mkl/2020.4.304-voqlapk \
     mvapich2/2.3.6-verbs-x4iz7lq
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     netcdf-c/4.4.1-gei7x7w \
     netcdf-cxx/4.2-db2f5or \
     netcdf-fortran/4.4.4-b4ldb3a \
     parallel-netcdf/1.11.0-kj4jsvt
-{% endif %}
+{%- endif %}
 
 setenv UCX_TLS "self,sm,ud"
 setenv UCX_UD_MLX5_RX_QUEUE_LEN "16384"

--- a/mache/spack/templates/anvil_intel_mvapich.sh
+++ b/mache/spack/templates/anvil_intel_mvapich.sh
@@ -13,13 +13,13 @@ module load \
     intel-mkl/2020.4.304-voqlapk \
     mvapich2/2.3.6-verbs-x4iz7lq
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     netcdf-c/4.4.1-gei7x7w \
     netcdf-cxx/4.2-db2f5or \
     netcdf-fortran/4.4.4-b4ldb3a \
     parallel-netcdf/1.11.0-kj4jsvt
-{% endif %}
+{%- endif %}
 
 export UCX_TLS="self,sm,ud"
 export UCX_UD_MLX5_RX_QUEUE_LEN="16384"

--- a/mache/spack/templates/anvil_intel_mvapich.yaml
+++ b/mache/spack/templates/anvil_intel_mvapich.yaml
@@ -1,24 +1,28 @@
+{%- set compiler = "intel@20.0.4" %}
+{%- set mpi = "mvapich2@4.1.1" %}
 spack:
   specs:
-  - intel
-  - mvapich2
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - intel-mkl
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: true
   packages:
     all:
-      compiler: [intel@20.0.4]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [mvapich2@4.1.1]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
 {%- endif %}
@@ -101,7 +105,7 @@ spack:
       buildable: false
     intel:
       externals:
-      - spec: intel@20.0.4
+      - spec: {{ compiler }}
         prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/intel-20.0.4-lednsve
         modules:
         - gcc/8.2.0
@@ -109,7 +113,7 @@ spack:
       buildable: false
     mvapich2:
       externals:
-      - spec: mvapich2@2.3.6
+      - spec: {{ mpi }}%{{ compiler }}
         prefix: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/intel-20.0.4/mvapich2-2.3.6-x4iz7lq
         modules:
         - mvapich2/2.3.6-verbs-x4iz7lq
@@ -153,7 +157,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: intel@20.0.4
+      spec: {{ compiler }}
       paths:
         cc: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/intel-20.0.4-lednsve/compilers_and_libraries_2020.4.304/linux/bin/intel64/icc
         cxx: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/intel-20.0.4-lednsve/compilers_and_libraries_2020.4.304/linux/bin/intel64/icpc

--- a/mache/spack/templates/anvil_intel_mvapich.yaml
+++ b/mache/spack/templates/anvil_intel_mvapich.yaml
@@ -2,15 +2,15 @@ spack:
   specs:
   - intel
   - mvapich2
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - intel-mkl
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: true
@@ -19,9 +19,9 @@ spack:
       compiler: [intel@20.0.4]
       providers:
         mpi: [mvapich2@4.1.1]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
-{% endif %}
+{%- endif %}
     bison:
       externals:
       - spec: bison@3.0.4
@@ -121,7 +121,7 @@ spack:
         modules:
         - intel-mkl/2020.4.304-voqlapk
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.10.7+cxx+fortran+hl+mpi
@@ -150,7 +150,7 @@ spack:
         modules:
         - parallel-netcdf/1.11.0-kj4jsvt
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: intel@20.0.4

--- a/mache/spack/templates/anvil_intel_openmpi.csh
+++ b/mache/spack/templates/anvil_intel_openmpi.csh
@@ -13,13 +13,13 @@ module load \
     intel-mkl/2020.4.304-voqlapk \
     openmpi/4.1.1-v3b3npd
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     netcdf-c/4.4.1-smyuxme \
     netcdf-cxx/4.2-kfb2aag \
     netcdf-fortran/4.4.4-mablvyc \
     parallel-netcdf/1.11.0-x4n5s7k
-{% endif %}
+{%- endif %}
 
 setenv UCX_TLS "self,sm,ud"
 setenv UCX_UD_MLX5_RX_QUEUE_LEN "16384"

--- a/mache/spack/templates/anvil_intel_openmpi.sh
+++ b/mache/spack/templates/anvil_intel_openmpi.sh
@@ -13,13 +13,13 @@ module load \
     intel-mkl/2020.4.304-voqlapk \
     openmpi/4.1.1-v3b3npd
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     netcdf-c/4.4.1-smyuxme \
     netcdf-cxx/4.2-kfb2aag \
     netcdf-fortran/4.4.4-mablvyc \
     parallel-netcdf/1.11.0-x4n5s7k
-{% endif %}
+{%- endif %}
 
 export UCX_TLS="self,sm,ud"
 export UCX_UD_MLX5_RX_QUEUE_LEN="16384"

--- a/mache/spack/templates/anvil_intel_openmpi.yaml
+++ b/mache/spack/templates/anvil_intel_openmpi.yaml
@@ -2,15 +2,15 @@ spack:
   specs:
   - intel
   - openmpi
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - intel-mkl
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: true
@@ -19,9 +19,9 @@ spack:
       compiler: [intel@20.0.4]
       providers:
         mpi: [openmpi@4.1.1]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
-{% endif %}
+{%- endif %}
     bison:
       externals:
       - spec: bison@3.0.4
@@ -118,7 +118,7 @@ spack:
         modules:
         - intel-mkl/2020.4.304-voqlapk
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.10.7+cxx+fortran+hl+mpi
@@ -147,7 +147,7 @@ spack:
         modules:
         - parallel-netcdf/1.11.0-x4n5s7k
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: intel@20.0.4

--- a/mache/spack/templates/anvil_intel_openmpi.yaml
+++ b/mache/spack/templates/anvil_intel_openmpi.yaml
@@ -1,24 +1,28 @@
+{%- set compiler = "intel@20.0.4" %}
+{%- set mpi = "openmpi@4.1.1" %}
 spack:
   specs:
-  - intel
-  - openmpi
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - intel-mkl
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: true
   packages:
     all:
-      compiler: [intel@20.0.4]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [openmpi@4.1.1]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
 {%- endif %}
@@ -101,14 +105,14 @@ spack:
       buildable: false
     intel:
       externals:
-      - spec: intel@20.0.4
+      - spec: {{ compiler }}
         modules:
         - gcc/8.2.0
         - intel/20.0.4-lednsve
       buildable: false
     openmpi:
       externals:
-      - spec: openmpi@4.1.1
+      - spec: {{ mpi }}%{{ compiler }}
         modules:
         - openmpi/4.1.1-v3b3npd
       buildable: false
@@ -150,7 +154,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: intel@20.0.4
+      spec: {{ compiler }}
       paths:
         cc: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/intel-20.0.4-lednsve/compilers_and_libraries_2020.4.304/linux/bin/intel64/icc
         cxx: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/intel-20.0.4-lednsve/compilers_and_libraries_2020.4.304/linux/bin/intel64/icpc

--- a/mache/spack/templates/build_spack_env.template
+++ b/mache/spack/templates/build_spack_env.template
@@ -14,10 +14,10 @@ else
 fi
 source share/spack/setup-env.sh
 
-{% if spack_mirror is defined %}
+{%- if spack_mirror is defined %}
     spack mirror remove spack_mirror >& /dev/null || true
     spack mirror add spack_mirror file://{{ spack_mirror }}
-{% endif %}
+{%- endif %}
 
 spack env remove -y {{ env_name }} >& /dev/null && \
   echo "recreating environment: {{ env_name }}" || \

--- a/mache/spack/templates/chicoma-cpu_gnu_mpich.csh
+++ b/mache/spack/templates/chicoma-cpu_gnu_mpich.csh
@@ -41,11 +41,11 @@ module load PrgEnv-gnu/8.5.0 \
             craype/2.7.30 \
             cray-mpich/8.1.28 \
             cmake/3.27.7
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \
             cray-parallel-netcdf/1.12.3.9
-{% endif %}
+{%- endif %}
 
 setenv MPICH_ENV_DISPLAY 1
 setenv MPICH_VERSION_DISPLAY 1

--- a/mache/spack/templates/chicoma-cpu_gnu_mpich.sh
+++ b/mache/spack/templates/chicoma-cpu_gnu_mpich.sh
@@ -41,11 +41,11 @@ module load PrgEnv-gnu/8.5.0 \
             craype/2.7.30 \
             cray-mpich/8.1.28 \
             cmake/3.27.7
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \
             cray-parallel-netcdf/1.12.3.9
-{% endif %}
+{%- endif %}
 
 export MPICH_ENV_DISPLAY=1
 export MPICH_VERSION_DISPLAY=1

--- a/mache/spack/templates/chicoma-cpu_gnu_mpich.yaml
+++ b/mache/spack/templates/chicoma-cpu_gnu_mpich.yaml
@@ -3,12 +3,12 @@ spack:
   - gcc
   - cray-mpich
   - cray-libsci
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: true
@@ -119,7 +119,7 @@ spack:
         modules:
         - cray-libsci/23.12.5
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.9~cxx+fortran+hl~java+mpi+shared
@@ -140,7 +140,7 @@ spack:
       - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.9/gnu/12.3
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: gcc@12.3

--- a/mache/spack/templates/chicoma-cpu_gnu_mpich.yaml
+++ b/mache/spack/templates/chicoma-cpu_gnu_mpich.yaml
@@ -1,22 +1,26 @@
+{%- set compiler = "gcc@12.3" %}
+{%- set mpi = "cray-mpich@8.1.28" %}
 spack:
   specs:
-  - gcc
-  - cray-mpich
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
   - cray-libsci
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: true
   packages:
     all:
-      compiler: [gcc@12.3]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [cray-mpich@8.1.28]
+        mpi: [{{ mpi }}%{{ compiler }}]
         lapack: [cray-libsci@23.12.5]
     bzip2:
       externals:
@@ -92,7 +96,7 @@ spack:
       buildable: false
     gcc:
       externals:
-      - spec: gcc@12.3
+      - spec: {{ compiler }}
         modules:
         - PrgEnv-gnu/8.5.0
         - gcc-native/12.3
@@ -109,7 +113,7 @@ spack:
       buildable: false
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.28
+      - spec: {{ mpi }}%{{ compiler }}
         modules:
         - cray-mpich/8.1.28
       buildable: false
@@ -143,7 +147,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: gcc@12.3
+      spec: {{ compiler }}
       paths:
         cc: cc
         cxx: CC

--- a/mache/spack/templates/chicoma-cpu_nvidia_mpich.csh
+++ b/mache/spack/templates/chicoma-cpu_nvidia_mpich.csh
@@ -41,11 +41,11 @@ module load PrgEnv-nvidia/8.5.0 \
             craype/2.7.30 \
             cray-mpich/8.1.28 \
             cmake/3.27.7
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \
             cray-parallel-netcdf/1.12.3.9
-{% endif %}
+{%- endif %}
 
 setenv MPICH_ENV_DISPLAY 1
 setenv MPICH_VERSION_DISPLAY 1

--- a/mache/spack/templates/chicoma-cpu_nvidia_mpich.sh
+++ b/mache/spack/templates/chicoma-cpu_nvidia_mpich.sh
@@ -40,11 +40,11 @@ module load PrgEnv-nvidia/8.5.0 \
             craype/2.7.30 \
             cray-mpich/8.1.28 \
             cmake/3.27.7
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \
             cray-parallel-netcdf/1.12.3.9
-{% endif %}
+{%- endif %}
 
 export MPICH_ENV_DISPLAY=1
 export MPICH_VERSION_DISPLAY=1

--- a/mache/spack/templates/chicoma-cpu_nvidia_mpich.yaml
+++ b/mache/spack/templates/chicoma-cpu_nvidia_mpich.yaml
@@ -2,12 +2,12 @@ spack:
   specs:
   - cray-mpich
   - cray-libsci
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: true
@@ -101,7 +101,7 @@ spack:
         modules:
         - cray-libsci/23.12.5
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.9~cxx+fortran+hl~java+mpi+shared
@@ -122,7 +122,7 @@ spack:
       - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.9/nvidia/23.3
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: nvhpc@24.7

--- a/mache/spack/templates/chicoma-cpu_nvidia_mpich.yaml
+++ b/mache/spack/templates/chicoma-cpu_nvidia_mpich.yaml
@@ -1,21 +1,25 @@
+{%- set compiler = "nvhpc@24.7" %}
+{%- set mpi = "cray-mpich@8.1.28" %}
 spack:
   specs:
-  - cray-mpich
+  - {{ mpi }}%{{ compiler }}
   - cray-libsci
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: true
   packages:
     all:
-      compiler: [nvhpc@24.7]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [cray-mpich@8.1.28]
+        mpi: [{{ mpi }}%{{ compiler }}]
         lapack: [cray-libsci@23.12.5]
     bzip2:
       externals:
@@ -91,7 +95,7 @@ spack:
       buildable: false
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.28
+      - spec: {{ mpi }}%{{ compiler }}
         modules:
         - cray-mpich/8.1.28
       buildable: false
@@ -125,7 +129,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: nvhpc@24.7
+      spec: {{ compiler }}
       paths:
         cc: /opt/nvidia/hpc_sdk/Linux_x86_64/24.7/compilers/bin/nvc
         cxx: /opt/nvidia/hpc_sdk/Linux_x86_64/24.7/compilers/bin/nvc++

--- a/mache/spack/templates/chrysalis_gnu_openmpi.csh
+++ b/mache/spack/templates/chrysalis_gnu_openmpi.csh
@@ -1,3 +1,5 @@
+module load cmake
+
 setenv OMPI_MCA_sharedfp "^lockedfile,individual"
 setenv UCX_TLS "^xpmem"
 ## purposefully omitting OMP variables that slow down MPAS-Ocean runs

--- a/mache/spack/templates/chrysalis_gnu_openmpi.sh
+++ b/mache/spack/templates/chrysalis_gnu_openmpi.sh
@@ -1,3 +1,5 @@
+module load cmake
+
 export OMPI_MCA_sharedfp="^lockedfile,individual"
 export UCX_TLS="^xpmem"
 ## purposefully omitting OMP variables that slow down MPAS-Ocean runs

--- a/mache/spack/templates/chrysalis_gnu_openmpi.yaml
+++ b/mache/spack/templates/chrysalis_gnu_openmpi.yaml
@@ -26,6 +26,11 @@ spack:
 {%- if e3sm_lapack %}
         lapack: [intel-oneapi-mkl@2022.1.0]
 {%- endif %}
+    bison:
+      externals:
+      - spec: bison@3.0.4
+        prefix: /usr
+      buildable: false
     bzip2:
       externals:
       - spec: bzip2@1.0.8

--- a/mache/spack/templates/chrysalis_gnu_openmpi.yaml
+++ b/mache/spack/templates/chrysalis_gnu_openmpi.yaml
@@ -1,24 +1,28 @@
+{%- set compiler = "gcc@11.2.0" %}
+{%- set mpi = "openmpi@4.1.6" %}
 spack:
   specs:
-  - gcc
-  - openmpi
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - intel-oneapi-mkl
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: true
   packages:
     all:
-      compiler: [gcc@11.2.0]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [openmpi@4.1.6]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [intel-oneapi-mkl@2022.1.0]
 {%- endif %}
@@ -86,7 +90,7 @@ spack:
       buildable: false
     gcc:
       externals:
-      - spec: gcc@11.2.0
+      - spec: {{ compiler }}
         prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/gcc-11.2.0-bgddrif
         modules:
         - gcc/11.2.0-bgddrif
@@ -98,7 +102,7 @@ spack:
       buildable: false
     openmpi:
       externals:
-      - spec: openmpi@4.1.6
+      - spec: {{ mpi }}%{{ compiler }}
         prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-11.2.0/openmpi-4.1.6-ggebj5o
         modules:
         - openmpi/4.1.6-ggebj5o
@@ -138,7 +142,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: gcc@11.2.0
+      spec: {{ compiler }}
       paths:
         cc: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/gcc-11.2.0-bgddrif/bin/gcc
         cxx: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/gcc-11.2.0-bgddrif/bin/g++

--- a/mache/spack/templates/chrysalis_gnu_openmpi.yaml
+++ b/mache/spack/templates/chrysalis_gnu_openmpi.yaml
@@ -2,15 +2,15 @@ spack:
   specs:
   - gcc
   - openmpi
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - intel-oneapi-mkl
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: true
@@ -19,9 +19,9 @@ spack:
       compiler: [gcc@11.2.0]
       providers:
         mpi: [openmpi@4.1.6]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [intel-oneapi-mkl@2022.1.0]
-{% endif %}
+{%- endif %}
     bzip2:
       externals:
       - spec: bzip2@1.0.8
@@ -110,7 +110,7 @@ spack:
         modules:
         - intel-oneapi-mkl/2022.1.0-w4kgsn4
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.10.7+cxx+fortran+hl+mpi
@@ -135,7 +135,7 @@ spack:
         modules:
         - parallel-netcdf/1.11.0-d7h4ysd
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: gcc@11.2.0

--- a/mache/spack/templates/chrysalis_intel_impi.yaml
+++ b/mache/spack/templates/chrysalis_intel_impi.yaml
@@ -2,15 +2,15 @@ spack:
   specs:
   - intel
   - intel-mpi
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - intel-mkl
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: true
@@ -19,9 +19,9 @@ spack:
       compiler: [intel@20.0.4]
       providers:
         mpi: [intel-mpi@2019.9.304]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
-{% endif %}
+{%- endif %}
     bzip2:
       externals:
       - spec: bzip2@1.0.8
@@ -105,7 +105,7 @@ spack:
         modules:
         - intel-mkl/2020.4.304-g2qaxzf
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.10.7+cxx+fortran+hl+mpi~shared
@@ -130,7 +130,7 @@ spack:
         modules:
         - parallel-netcdf/1.11.0-b74wv4m
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: intel@20.0.4

--- a/mache/spack/templates/chrysalis_intel_impi.yaml
+++ b/mache/spack/templates/chrysalis_intel_impi.yaml
@@ -26,6 +26,11 @@ spack:
 {%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
 {%- endif %}
+    bison:
+      externals:
+      - spec: bison@3.0.4
+        prefix: /usr
+      buildable: false
     bzip2:
       externals:
       - spec: bzip2@1.0.8

--- a/mache/spack/templates/chrysalis_intel_impi.yaml
+++ b/mache/spack/templates/chrysalis_intel_impi.yaml
@@ -1,24 +1,28 @@
+{%- set compiler = "intel@20.0.4" %}
+{%- set mpi = "intel-mpi@2019.9.304" %}
 spack:
   specs:
-  - intel
-  - intel-mpi
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - intel-mkl
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: true
   packages:
     all:
-      compiler: [intel@20.0.4]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [intel-mpi@2019.9.304]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
 {%- endif %}
@@ -86,14 +90,14 @@ spack:
       buildable: false
     intel:
       externals:
-      - spec: intel@20.0.4
+      - spec: {{ compiler }}
         prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/intel-20.0.4-kodw73g
         modules:
         - intel/20.0.4-kodw73g
       buildable: false
     intel-mpi:
       externals:
-      - spec: intel-mpi@2019.9.304
+      - spec: {{ mpi }}%{{ compiler }}
         prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/intel-mpi-2019.9.304-tkzvizk/compilers_and_libraries_2020.4.304
         modules:
         - intel-mpi/2019.9.304-tkzvizk
@@ -133,7 +137,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: intel@20.0.4
+      spec: {{ compiler }}
       paths:
         cc: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/intel-20.0.4-kodw73g/compilers_and_libraries_2020.4.304/linux/bin/intel64/icc
         cxx: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/intel-20.0.4-kodw73g/compilers_and_libraries_2020.4.304/linux/bin/intel64/icpc

--- a/mache/spack/templates/chrysalis_intel_openmpi.yaml
+++ b/mache/spack/templates/chrysalis_intel_openmpi.yaml
@@ -2,15 +2,15 @@ spack:
   specs:
   - intel
   - openmpi
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - intel-mkl
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: true
@@ -19,9 +19,9 @@ spack:
       compiler: [intel@20.0.4]
       providers:
         mpi: [openmpi@4.1.6]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
-{% endif %}
+{%- endif %}
     bzip2:
       externals:
       - spec: bzip2@1.0.8
@@ -105,7 +105,7 @@ spack:
         modules:
         - intel-mkl/2020.4.304-g2qaxzf
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.10.7+cxx+fortran+hl+mpi
@@ -130,7 +130,7 @@ spack:
         modules:
         - parallel-netcdf/1.11.0-icrpxty
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: intel@20.0.4

--- a/mache/spack/templates/chrysalis_intel_openmpi.yaml
+++ b/mache/spack/templates/chrysalis_intel_openmpi.yaml
@@ -26,6 +26,11 @@ spack:
 {%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
 {%- endif %}
+    bison:
+      externals:
+      - spec: bison@3.0.4
+        prefix: /usr
+      buildable: false
     bzip2:
       externals:
       - spec: bzip2@1.0.8

--- a/mache/spack/templates/chrysalis_intel_openmpi.yaml
+++ b/mache/spack/templates/chrysalis_intel_openmpi.yaml
@@ -1,24 +1,28 @@
+{%- set compiler = "intel@20.0.4" %}
+{%- set mpi = "openmpi@4.1.6" %}
 spack:
   specs:
-  - intel
-  - openmpi
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - intel-mkl
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: true
   packages:
     all:
-      compiler: [intel@20.0.4]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [openmpi@4.1.6]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.4.304]
 {%- endif %}
@@ -86,14 +90,14 @@ spack:
       buildable: false
     intel:
       externals:
-      - spec: intel@20.0.4
+      - spec: {{ compiler }}
         prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/intel-20.0.4-kodw73g
         modules:
         - intel/20.0.4-kodw73g
       buildable: false
     openmpi:
       externals:
-      - spec: openmpi@4.1.6
+      - spec: {{ mpi }}%{{ compiler }}
         prefix: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/intel-20.0.4/openmpi-4.1.6-2mm63n2
         modules:
         - openmpi/4.1.6-2mm63n2
@@ -133,7 +137,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: intel@20.0.4
+      spec: {{ compiler }}
       paths:
         cc: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/intel-20.0.4-kodw73g/compilers_and_libraries_2020.4.304/linux/bin/intel64/icc
         cxx: /gpfs/fs1/soft/chrysalis/spack/opt/spack/linux-centos8-x86_64/gcc-9.3.0/intel-20.0.4-kodw73g/compilers_and_libraries_2020.4.304/linux/bin/intel64/icpc

--- a/mache/spack/templates/compy_gnu_openmpi.yaml
+++ b/mache/spack/templates/compy_gnu_openmpi.yaml
@@ -2,15 +2,15 @@ spack:
   specs:
   - gcc
   - openmpi
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - intel-mkl
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: true
@@ -19,9 +19,9 @@ spack:
       compiler: [gcc@10.2.0]
       providers:
         mpi: [openmpi@4.0.1]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.0.166]
-{% endif %}
+{%- endif %}
     bison:
       externals:
       - spec: bison@3.0.4
@@ -123,7 +123,7 @@ spack:
         modules:
         - mkl/2020
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5~mpi+hl@1.10.5
@@ -152,7 +152,7 @@ spack:
         modules:
         - pnetcdf/1.9.0
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: gcc@10.2.0

--- a/mache/spack/templates/compy_gnu_openmpi.yaml
+++ b/mache/spack/templates/compy_gnu_openmpi.yaml
@@ -1,24 +1,28 @@
+{%- set compiler = "gcc@10.2.0" %}
+{%- set mpi = "openmpi@4.0.1" %}
 spack:
   specs:
-  - gcc
-  - openmpi
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - intel-mkl
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: true
   packages:
     all:
-      compiler: [gcc@10.2.0]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [openmpi@4.0.1]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.0.166]
 {%- endif %}
@@ -99,7 +103,7 @@ spack:
       buildable: false
     gcc:
       externals:
-      - spec: gcc@10.2.0
+      - spec: {{ compiler }}
         prefix: /share/apps/gcc/10.2.0
         modules:
         - gcc/10.2.0
@@ -111,7 +115,7 @@ spack:
       buildable: false
     openmpi:
       externals:
-      - spec: openmpi@4.0.1
+      - spec: {{ mpi }}%{{ compiler }}
         prefix: /share/apps/openmpi/4.0.1/gcc/10.2.0
         modules:
         - openmpi/4.0.1
@@ -155,7 +159,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: gcc@10.2.0
+      spec: {{ compiler }}
       paths:
         cc: /share/apps/gcc/10.2.0/bin/gcc
         cxx: /share/apps/gcc/10.2.0/bin/g++

--- a/mache/spack/templates/compy_intel_impi.yaml
+++ b/mache/spack/templates/compy_intel_impi.yaml
@@ -2,15 +2,15 @@ spack:
   specs:
   - intel
   - intel-mpi
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - intel-mkl
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: true
@@ -19,9 +19,9 @@ spack:
       compiler: [intel@20.0.0]
       providers:
         mpi: [intel-mpi@2020.0.166]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.0.166]
-{% endif %}
+{%- endif %}
     bison:
       externals:
       - spec: bison@3.0.4
@@ -119,7 +119,7 @@ spack:
         modules:
         - mkl/2020
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5~mpi+hl@1.10.5
@@ -148,7 +148,7 @@ spack:
         modules:
         - pnetcdf/1.9.0
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: intel@20.0.0

--- a/mache/spack/templates/compy_intel_impi.yaml
+++ b/mache/spack/templates/compy_intel_impi.yaml
@@ -1,24 +1,28 @@
+{%- set compiler = "intel@20.0.0" %}
+{%- set mpi = "intel-mpi@2020.0.166" %}
 spack:
   specs:
-  - intel
-  - intel-mpi
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - intel-mkl
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: true
   packages:
     all:
-      compiler: [intel@20.0.0]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [intel-mpi@2020.0.166]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [intel-mkl@2020.0.166]
 {%- endif %}
@@ -99,7 +103,7 @@ spack:
       buildable: false
     intel:
       externals:
-      - spec: intel@20.0.0
+      - spec: {{ compiler }}
         prefix: /share/apps/intel/2020/compilers_and_libraries_2020.0.166
         modules:
         - gcc/8.1.0
@@ -107,7 +111,7 @@ spack:
       buildable: false
     intel-mpi:
       externals:
-      - spec: intel-mpi@2020.0.166
+      - spec: {{ mpi }}%{{ compiler }}
         prefix: /share/apps/intel/2020/compilers_and_libraries_2020.0.166
         modules:
         - intelmpi/2020
@@ -151,7 +155,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: intel@20.0.0
+      spec: {{ compiler }}
       paths:
         cc: /share/apps/intel/2020/compilers_and_libraries_2020.0.166/linux/bin/intel64/icc
         cxx: /share/apps/intel/2020/compilers_and_libraries_2020.0.166/linux/bin/intel64/icpc

--- a/mache/spack/templates/dane_intel_mvapich2.yaml
+++ b/mache/spack/templates/dane_intel_mvapich2.yaml
@@ -1,24 +1,28 @@
+{%- set compiler = "intel-oneapi-compilers@2021.6.0" %}
+{%- set mpi = "mvapich2@2.3.7" %}
 spack:
   specs:
-  - intel-oneapi-compilers
-  - mvapich2
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - intel-oneapi-mkl
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: true
   packages:
     all:
-      compiler: [intel-oneapi-compilers@2021.6.0]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [mvapich2@2.3.7]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [intel-oneapi-mkl@2022.1.0]
 {%- endif %}
@@ -119,7 +123,7 @@ spack:
       buildable: false
     mvapich2:
       externals:
-      - spec: mvapich2@2.3.7~cuda~debug+regcache+wrapperrpath ch3_rank_bits=32 file_systems=lustre,nfs,ufs
+      - spec: {{ mpi }}%{{ compiler }}~cuda~debug+regcache+wrapperrpath ch3_rank_bits=32 file_systems=lustre,nfs,ufs
           process_managers=hydra threads=multiple
         prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-intel-classic-2021.6.0-magic
         modules:
@@ -161,7 +165,7 @@ spack:
     install_missing_compilers: false
   compilers:
   - compiler:
-      spec: intel-oneapi-compilers@=2021.6.0
+      spec: {{ compiler }}
       paths:
         cc: /usr/tce/packages/intel-classic/intel-classic-2021.6.0-magic/bin/icc
         cxx: /usr/tce/packages/intel-classic/intel-classic-2021.6.0-magic/bin/icpc

--- a/mache/spack/templates/dane_intel_mvapich2.yaml
+++ b/mache/spack/templates/dane_intel_mvapich2.yaml
@@ -2,15 +2,15 @@ spack:
   specs:
   - intel-oneapi-compilers
   - mvapich2
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - intel-oneapi-mkl
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: true
@@ -19,10 +19,10 @@ spack:
       compiler: [intel-oneapi-compilers@2021.6.0]
       providers:
         mpi: [mvapich2@2.3.7]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [intel-oneapi-mkl@2022.1.0]
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.14.0+cxx+fortran+hl~java+mpi~szip+threadsafe+tools api=v18
@@ -51,7 +51,7 @@ spack:
         modules:
         - parallel-netcdf/1.12.3
       buildable: false
-{% endif %}
+{%- endif %}
     bison:
       externals:
       - spec: bison@3.0.4
@@ -148,7 +148,7 @@ spack:
             c: /usr/tce/bin/gcc
             cxx: /usr/tce/bin/g++
             fortran: /usr/tce/bin/gfortran
-{% if e3ms_lapack %}
+{%- if e3ms_lapack %}
     intel-oneapi-mkl:
       externals:
       - spec: intel-oneapi-mkl@2022.1.0
@@ -156,7 +156,7 @@ spack:
         modules:
         - mkl/2022.1.0
       buildable: false
-{% endif %}
+{%- endif %}
   config:
     install_missing_compilers: false
   compilers:

--- a/mache/spack/templates/frontier_crayamd-mphipcc_mpich.csh
+++ b/mache/spack/templates/frontier_crayamd-mphipcc_mpich.csh
@@ -20,12 +20,12 @@ module load \
 module rm \
     darshan-runtime &> /dev/null
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     cray-hdf5-parallel/1.12.2.1 \
     cray-netcdf-hdf5parallel/4.9.0.1 \
     cray-parallel-netcdf/1.12.3.1
-{% endif %}
+{%- endif %}
 
 setenv HDF5_ROOT ""
 setenv MPICH_GPU_SUPPORT_ENABLED "0"
@@ -41,9 +41,9 @@ setenv GPUS_PER_NODE "--gpus-per-node=8"
 setenv GPU_BIND_ARGS "--gpu-bind=closest"
 setenv PKG_CONFIG_PATH "/lustre/orion/cli115/world-shared/frontier/3rdparty/protobuf/21.6/amdclang-15.0.0/lib/pkgconfig:${CRAY_LIBSCI_PREFIX_DIR}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 setenv NETCDF_PATH "${NETCDF_DIR}"
 setenv NETCDF_C_PATH "${NETCDF_DIR}"
 setenv NETCDF_FORTRAN_PATH "${NETCDF_DIR}"
 setenv PNETCDF_PATH "${PNETCDF_DIR}"
-{% endif %}
+{%- endif %}

--- a/mache/spack/templates/frontier_crayamd-mphipcc_mpich.sh
+++ b/mache/spack/templates/frontier_crayamd-mphipcc_mpich.sh
@@ -20,12 +20,12 @@ module load \
 module rm \
     darshan-runtime &> /dev/null
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     cray-hdf5-parallel/1.12.2.1 \
     cray-netcdf-hdf5parallel/4.9.0.1 \
     cray-parallel-netcdf/1.12.3.1
-{% endif %}
+{%- endif %}
 
 export HDF5_ROOT=""
 export MPICH_GPU_SUPPORT_ENABLED="0"
@@ -41,9 +41,9 @@ export GPUS_PER_NODE="--gpus-per-node=8"
 export GPU_BIND_ARGS="--gpu-bind=closest"
 export PKG_CONFIG_PATH="/lustre/orion/cli115/world-shared/frontier/3rdparty/protobuf/21.6/amdclang-15.0.0/lib/pkgconfig:${CRAY_LIBSCI_PREFIX_DIR}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 export NETCDF_PATH="${NETCDF_DIR}"
 export NETCDF_C_PATH="${NETCDF_DIR}"
 export NETCDF_FORTRAN_PATH="${NETCDF_DIR}"
 export PNETCDF_PATH="${PNETCDF_DIR}"
-{% endif %}
+{%- endif %}

--- a/mache/spack/templates/frontier_crayamd-mphipcc_mpich.yaml
+++ b/mache/spack/templates/frontier_crayamd-mphipcc_mpich.yaml
@@ -1,23 +1,27 @@
+{%- set compiler = "rocmcc@5.4.0" %}
+{%- set mpi = "cray-mpich@8.1.26" %}
 spack:
   specs:
-  - cray-mpich
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - cray-libsci
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: when_possible
   packages:
     all:
-      compiler: [rocmcc@5.4.0]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [cray-mpich@8.1.23]
+        mpi: [{{ mpi }}%{{ compiler }}]
         lapack: [cray-libsci@22.12.1.1]
     autoconf:
       externals:
@@ -110,7 +114,7 @@ spack:
       buildable: false
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.26
+      - spec: {{ mpi }}%{{ compiler }}
         modules:
         - libunwind/1.5.0
         - libfabric/1.20.1
@@ -152,7 +156,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: rocmcc@5.4.0
+      spec: {{ compiler }}
       paths:
         cc: cc
         cxx: CC

--- a/mache/spack/templates/frontier_crayamd-mphipcc_mpich.yaml
+++ b/mache/spack/templates/frontier_crayamd-mphipcc_mpich.yaml
@@ -1,15 +1,15 @@
 spack:
   specs:
   - cray-mpich
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - cray-libsci
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: when_possible
@@ -128,7 +128,7 @@ spack:
         modules:
         - cray-libsci/22.12.1.1
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.1~cxx+fortran+hl~java+mpi+shared
@@ -149,7 +149,7 @@ spack:
       - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/amd/4.3
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: rocmcc@5.4.0

--- a/mache/spack/templates/frontier_crayamd_mpich.csh
+++ b/mache/spack/templates/frontier_crayamd_mpich.csh
@@ -18,12 +18,12 @@ module load \
 module rm \
     darshan-runtime &> /dev/null
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     cray-hdf5-parallel/1.12.2.1 \
     cray-netcdf-hdf5parallel/4.9.0.1 \
     cray-parallel-netcdf/1.12.3.1
-{% endif %}
+{%- endif %}
 
 setenv HDF5_ROOT ""
 setenv MPICH_GPU_SUPPORT_ENABLED "0"
@@ -36,9 +36,9 @@ setenv NTASKS_PER_GPU " "
 setenv GPU_BIND_ARGS " "
 setenv PKG_CONFIG_PATH "/lustre/orion/cli115/world-shared/frontier/3rdparty/protobuf/21.6/amdclang-15.0.0/lib/pkgconfig:${CRAY_LIBSCI_PREFIX_DIR}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 setenv NETCDF_PATH "${NETCDF_DIR}"
 setenv NETCDF_C_PATH "${NETCDF_DIR}"
 setenv NETCDF_FORTRAN_PATH "${NETCDF_DIR}"
 setenv PNETCDF_PATH "${PNETCDF_DIR}"
-{% endif %}
+{%- endif %}

--- a/mache/spack/templates/frontier_crayamd_mpich.sh
+++ b/mache/spack/templates/frontier_crayamd_mpich.sh
@@ -18,12 +18,12 @@ module load \
 module rm \
     darshan-runtime &> /dev/null
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     cray-hdf5-parallel/1.12.2.1 \
     cray-netcdf-hdf5parallel/4.9.0.1 \
     cray-parallel-netcdf/1.12.3.1
-{% endif %}
+{%- endif %}
 
 export HDF5_ROOT=""
 export MPICH_GPU_SUPPORT_ENABLED="0"
@@ -36,9 +36,9 @@ export NTASKS_PER_GPU=" "
 export GPU_BIND_ARGS=" "
 export PKG_CONFIG_PATH="/lustre/orion/cli115/world-shared/frontier/3rdparty/protobuf/21.6/amdclang-15.0.0/lib/pkgconfig:${CRAY_LIBSCI_PREFIX_DIR}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 export NETCDF_PATH="${NETCDF_DIR}"
 export NETCDF_C_PATH="${NETCDF_DIR}"
 export NETCDF_FORTRAN_PATH="${NETCDF_DIR}"
 export PNETCDF_PATH="${PNETCDF_DIR}"
-{% endif %}
+{%- endif %}

--- a/mache/spack/templates/frontier_crayamd_mpich.yaml
+++ b/mache/spack/templates/frontier_crayamd_mpich.yaml
@@ -1,23 +1,27 @@
+{%- set compiler = "rocmcc@5.4.0" %}
+{%- set mpi = "cray-mpich@8.1.26" %}
 spack:
   specs:
-  - cray-mpich
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - cray-libsci
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: when_possible
   packages:
     all:
-      compiler: [rocmcc@5.4.0]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [cray-mpich@8.1.26]
+        mpi: [{{ mpi }}%{{ compiler }}]
         lapack: [cray-libsci@22.12.1.1]
     autoconf:
       externals:
@@ -110,7 +114,7 @@ spack:
       buildable: false
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.26
+      - spec: {{ mpi }}%{{ compiler }}
         modules:
         - libunwind/1.5.0
         - libfabric/1.20.1
@@ -152,7 +156,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: rocmcc@5.4.0
+      spec: {{ compiler }}
       paths:
         cc: cc
         cxx: CC

--- a/mache/spack/templates/frontier_crayamd_mpich.yaml
+++ b/mache/spack/templates/frontier_crayamd_mpich.yaml
@@ -1,15 +1,15 @@
 spack:
   specs:
   - cray-mpich
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - cray-libsci
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: when_possible
@@ -128,7 +128,7 @@ spack:
         modules:
         - cray-libsci/22.12.1.1
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.1~cxx+fortran+hl~java+mpi+shared
@@ -149,7 +149,7 @@ spack:
       - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/amd/4.3
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: rocmcc@5.4.0

--- a/mache/spack/templates/frontier_craycray-mphipcc_mpich.csh
+++ b/mache/spack/templates/frontier_craycray-mphipcc_mpich.csh
@@ -19,12 +19,12 @@ module load \
 module rm \
     darshan-runtime &> /dev/null
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     cray-hdf5-parallel/1.12.2.1 \
     cray-netcdf-hdf5parallel/4.9.0.1 \
     cray-parallel-netcdf/1.12.3.1
-{% endif %}
+{%- endif %}
 
 setenv HDF5_ROOT ""
 setenv MPICH_GPU_SUPPORT_ENABLED "0"
@@ -40,9 +40,9 @@ setenv GPUS_PER_NODE "--gpus-per-node=8"
 setenv GPU_BIND_ARGS "--gpu-bind=closest"
 setenv PKG_CONFIG_PATH "/lustre/orion/cli115/world-shared/frontier/3rdparty/protobuf/21.6/crayclang-15.0.1/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 setenv NETCDF_PATH "${NETCDF_DIR}"
 setenv NETCDF_C_PATH "${NETCDF_DIR}"
 setenv NETCDF_FORTRAN_PATH "${NETCDF_DIR}"
 setenv PNETCDF_PATH "${PNETCDF_DIR}"
-{% endif %}
+{%- endif %}

--- a/mache/spack/templates/frontier_craycray-mphipcc_mpich.sh
+++ b/mache/spack/templates/frontier_craycray-mphipcc_mpich.sh
@@ -19,12 +19,12 @@ module load \
 module rm \
     darshan-runtime &> /dev/null
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     cray-hdf5-parallel/1.12.2.1 \
     cray-netcdf-hdf5parallel/4.9.0.1 \
     cray-parallel-netcdf/1.12.3.1
-{% endif %}
+{%- endif %}
 
 export HDF5_ROOT=""
 export MPICH_GPU_SUPPORT_ENABLED="0"
@@ -40,9 +40,9 @@ export GPUS_PER_NODE="--gpus-per-node=8"
 export GPU_BIND_ARGS="--gpu-bind=closest"
 export PKG_CONFIG_PATH="/lustre/orion/cli115/world-shared/frontier/3rdparty/protobuf/21.6/crayclang-15.0.1/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 export NETCDF_PATH="${NETCDF_DIR}"
 export NETCDF_C_PATH="${NETCDF_DIR}"
 export NETCDF_FORTRAN_PATH="${NETCDF_DIR}"
 export PNETCDF_PATH="${PNETCDF_DIR}"
-{% endif %}
+{%- endif %}

--- a/mache/spack/templates/frontier_craycray-mphipcc_mpich.yaml
+++ b/mache/spack/templates/frontier_craycray-mphipcc_mpich.yaml
@@ -1,23 +1,27 @@
+{%- set compiler = "cce@15.0.1" %}
+{%- set mpi = "cray-mpich@8.1.26" %}
 spack:
   specs:
-  - cray-mpich
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - cray-libsci
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: when_possible
   packages:
     all:
-      compiler: [cce@15.0.1]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [cray-mpich@8.1.26]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [cray-libsci@22.12.1.1]
 {%- endif %}
@@ -112,7 +116,7 @@ spack:
       buildable: false
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.26
+      - spec: {{ mpi }}%{{ compiler }}
         modules:
         - libfabric/1.20.1
         - libunwind/1.5.0
@@ -157,7 +161,7 @@ spack:
 
   compilers:
   - compiler:
-      spec: cce@15.0.1
+      spec: {{ compiler }}
       paths:
         cc: cc
         cxx: CC

--- a/mache/spack/templates/frontier_craycray-mphipcc_mpich.yaml
+++ b/mache/spack/templates/frontier_craycray-mphipcc_mpich.yaml
@@ -1,15 +1,15 @@
 spack:
   specs:
   - cray-mpich
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - cray-libsci
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: when_possible
@@ -18,9 +18,9 @@ spack:
       compiler: [cce@15.0.1]
       providers:
         mpi: [cray-mpich@8.1.26]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [cray-libsci@22.12.1.1]
-{% endif %}
+{%- endif %}
     autoconf:
       externals:
       - spec: autoconf@2.69
@@ -124,15 +124,15 @@ spack:
         modules:
         - libfabric/1.20.1
       buildable: false
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
     cray-libsci:
       externals:
       - spec: cray-libsci@22.12.1.1
         modules:
         - cray-libsci/22.12.1.1
       buildable: false
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.1~cxx+fortran+hl~java+mpi+shared
@@ -153,7 +153,7 @@ spack:
       - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/crayclang/14.0
       buildable: false
-{% endif %}
+{%- endif %}
 
   compilers:
   - compiler:

--- a/mache/spack/templates/frontier_craycray_mpich.csh
+++ b/mache/spack/templates/frontier_craycray_mpich.csh
@@ -17,12 +17,12 @@ module load \
 module rm \
     darshan-runtime &> /dev/null
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     cray-hdf5-parallel/1.12.2.1 \
     cray-netcdf-hdf5parallel/4.9.0.1 \
     cray-parallel-netcdf/1.12.3.1
-{% endif %}
+{%- endif %}
 
 setenv HDF5_ROOT ""
 setenv MPICH_GPU_SUPPORT_ENABLED "0"
@@ -35,9 +35,9 @@ setenv NTASKS_PER_GPU " "
 setenv GPU_BIND_ARGS " "
 setenv PKG_CONFIG_PATH "/lustre/orion/cli115/world-shared/frontier/3rdparty/protobuf/21.6/crayclang-15.0.1/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 setenv NETCDF_PATH "${NETCDF_DIR}"
 setenv NETCDF_C_PATH "${NETCDF_DIR}"
 setenv NETCDF_FORTRAN_PATH "${NETCDF_DIR}"
 setenv PNETCDF_PATH "${PNETCDF_DIR}"
-{% endif %}
+{%- endif %}

--- a/mache/spack/templates/frontier_craycray_mpich.sh
+++ b/mache/spack/templates/frontier_craycray_mpich.sh
@@ -17,12 +17,12 @@ module load \
 module rm \
     darshan-runtime &> /dev/null
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     cray-hdf5-parallel/1.12.2.1 \
     cray-netcdf-hdf5parallel/4.9.0.1 \
     cray-parallel-netcdf/1.12.3.1
-{% endif %}
+{%- endif %}
 
 export HDF5_ROOT=""
 export MPICH_GPU_SUPPORT_ENABLED="0"
@@ -35,9 +35,9 @@ export NTASKS_PER_GPU=" "
 export GPU_BIND_ARGS=" "
 export PKG_CONFIG_PATH="/lustre/orion/cli115/world-shared/frontier/3rdparty/protobuf/21.6/crayclang-15.0.1/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 export NETCDF_PATH="${NETCDF_DIR}"
 export NETCDF_C_PATH="${NETCDF_DIR}"
 export NETCDF_FORTRAN_PATH="${NETCDF_DIR}"
 export PNETCDF_PATH="${PNETCDF_DIR}"
-{% endif %}
+{%- endif %}

--- a/mache/spack/templates/frontier_craycray_mpich.yaml
+++ b/mache/spack/templates/frontier_craycray_mpich.yaml
@@ -1,23 +1,27 @@
+{%- set compiler = "cce@15.0.1" %}
+{%- set mpi = "cray-mpich@8.1.26" %}
 spack:
   specs:
-  - cray-mpich
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - cray-libsci
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: when_possible
   packages:
     all:
-      compiler: [cce@15.0.1]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [cray-mpich@8.1.26]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [cray-libsci@22.12.1.1]
 {%- endif %}
@@ -112,7 +116,7 @@ spack:
       buildable: false
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.26
+      - spec: {{ mpi }}%{{ compiler }}
         modules:
         - libunwind/1.5.0
         - libfabric/1.15.2.0
@@ -156,7 +160,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: cce@15.0.1
+      spec: {{ compiler }}
       paths:
         cc: cc
         cxx: CC

--- a/mache/spack/templates/frontier_craycray_mpich.yaml
+++ b/mache/spack/templates/frontier_craycray_mpich.yaml
@@ -1,15 +1,15 @@
 spack:
   specs:
   - cray-mpich
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - cray-libsci
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: when_possible
@@ -18,9 +18,9 @@ spack:
       compiler: [cce@15.0.1]
       providers:
         mpi: [cray-mpich@8.1.26]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [cray-libsci@22.12.1.1]
-{% endif %}
+{%- endif %}
     autoconf:
       externals:
       - spec: autoconf@2.69
@@ -124,15 +124,15 @@ spack:
         modules:
         - libfabric/1.15.2.0
       buildable: false
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
     cray-libsci:
       externals:
       - spec: cray-libsci@22.12.1.1
         modules:
         - cray-libsci/22.12.1.1
       buildable: false
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.1~cxx+fortran+hl~java+mpi+shared
@@ -153,7 +153,7 @@ spack:
       - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/crayclang/14.0
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: cce@15.0.1

--- a/mache/spack/templates/frontier_craygnu-hipcc_mpich.csh
+++ b/mache/spack/templates/frontier_craygnu-hipcc_mpich.csh
@@ -16,12 +16,12 @@ module load \
 module rm \
     darshan-runtime &> /dev/null
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     cray-hdf5-parallel/1.14.3.3 \
     cray-netcdf-hdf5parallel/4.9.0.15 \
     cray-parallel-netcdf/1.12.3.15
-{% endif %}
+{%- endif %}
 
 setenv HDF5_ROOT ""
 setenv MPICH_GPU_SUPPORT_ENABLED "0"
@@ -37,9 +37,9 @@ setenv GPUS_PER_NODE "--gpus-per-node=8"
 setenv GPU_BIND_ARGS "--gpu-bind=closest"
 setenv PKG_CONFIG_PATH "/lustre/orion/cli115/world-shared/frontier/3rdparty/protobuf/21.6/gcc-native-13.2/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 setenv NETCDF_PATH "${NETCDF_DIR}"
 setenv NETCDF_C_PATH "${NETCDF_DIR}"
 setenv NETCDF_FORTRAN_PATH "${NETCDF_DIR}"
 setenv PNETCDF_PATH "${PNETCDF_DIR}"
-{% endif %}
+{%- endif %}

--- a/mache/spack/templates/frontier_craygnu-hipcc_mpich.sh
+++ b/mache/spack/templates/frontier_craygnu-hipcc_mpich.sh
@@ -16,12 +16,12 @@ module load \
 module rm \
     darshan-runtime &> /dev/null
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     cray-hdf5-parallel/1.14.3.3 \
     cray-netcdf-hdf5parallel/4.9.0.15 \
     cray-parallel-netcdf/1.12.3.15
-{% endif %}
+{%- endif %}
 
 export HDF5_ROOT=""
 export MPICH_GPU_SUPPORT_ENABLED="0"
@@ -37,9 +37,9 @@ export GPUS_PER_NODE="--gpus-per-node=8"
 export GPU_BIND_ARGS="--gpu-bind=closest"
 export PKG_CONFIG_PATH="/lustre/orion/cli115/world-shared/frontier/3rdparty/protobuf/21.6/gcc-native-13.2/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 export NETCDF_PATH="${NETCDF_DIR}"
 export NETCDF_C_PATH="${NETCDF_DIR}"
 export NETCDF_FORTRAN_PATH="${NETCDF_DIR}"
 export PNETCDF_PATH="${PNETCDF_DIR}"
-{% endif %}
+{%- endif %}

--- a/mache/spack/templates/frontier_craygnu-hipcc_mpich.yaml
+++ b/mache/spack/templates/frontier_craygnu-hipcc_mpich.yaml
@@ -2,15 +2,15 @@ spack:
   specs:
   - gcc
   - cray-mpich
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - cray-libsci
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: when_possible
@@ -19,9 +19,9 @@ spack:
       compiler: [gcc@13.2]
       providers:
         mpi: [cray-mpich@8.1.31]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [cray-libsci@24.11.0]
-{% endif %}
+{%- endif %}
     autoconf:
       externals:
       - spec: autoconf@2.69
@@ -148,15 +148,15 @@ spack:
         modules:
         - libfabric/1.22.0
       buildable: false
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
     cray-libsci:
       externals:
       - spec: cray-libsci@24.11.0
         modules:
         - cray-libsci/24.11.0
       buildable: false
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.1~cxx+fortran+hl~java+mpi+shared
@@ -177,7 +177,7 @@ spack:
       - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/GNU/9.1
       buildable: false
-{% endif %}
+{%- endif %}
 
   compilers:
   - compiler:

--- a/mache/spack/templates/frontier_craygnu-hipcc_mpich.yaml
+++ b/mache/spack/templates/frontier_craygnu-hipcc_mpich.yaml
@@ -1,24 +1,28 @@
+{%- set compiler = "gcc@13.2" %}
+{%- set mpi = "cray-mpich@8.1.31" %}
 spack:
   specs:
-  - gcc
-  - cray-mpich
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - cray-libsci
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: when_possible
   packages:
     all:
-      compiler: [gcc@13.2]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [cray-mpich@8.1.31]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [cray-libsci@24.11.0]
 {%- endif %}
@@ -115,7 +119,7 @@ spack:
       # despite complaints about redundancy, this needs to be here to prevent
       # spack from trying to build gcc
       externals:
-      - spec: gcc@13.2
+      - spec: {{ compiler }}
         modules:
         - Core/25.03
         - PrgEnv-gnu
@@ -136,7 +140,7 @@ spack:
       buildable: false
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.31
+      - spec: {{ mpi }}%{{ compiler }}
         modules:
         - libfabric/1.22.0
         - libunwind/1.8.1
@@ -181,7 +185,7 @@ spack:
 
   compilers:
   - compiler:
-      spec: gcc@13.2
+      spec: {{ compiler }}
       paths:
         cc: cc
         cxx: CC

--- a/mache/spack/templates/frontier_craygnu-mphipcc_mpich.csh
+++ b/mache/spack/templates/frontier_craygnu-mphipcc_mpich.csh
@@ -16,12 +16,12 @@ module load \
 module rm \
     darshan-runtime &> /dev/null
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     cray-hdf5-parallel/1.14.3.3 \
     cray-netcdf-hdf5parallel/4.9.0.15 \
     cray-parallel-netcdf/1.12.3.15
-{% endif %}
+{%- endif %}
 
 setenv HDF5_ROOT ""
 setenv MPICH_GPU_SUPPORT_ENABLED "0"
@@ -37,9 +37,9 @@ setenv GPUS_PER_NODE "--gpus-per-node=8"
 setenv GPU_BIND_ARGS "--gpu-bind=closest"
 setenv PKG_CONFIG_PATH "/lustre/orion/cli115/world-shared/frontier/3rdparty/protobuf/21.6/gcc-native-13.2/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 setenv NETCDF_PATH "${NETCDF_DIR}"
 setenv NETCDF_C_PATH "${NETCDF_DIR}"
 setenv NETCDF_FORTRAN_PATH "${NETCDF_DIR}"
 setenv PNETCDF_PATH "${PNETCDF_DIR}"
-{% endif %}
+{%- endif %}

--- a/mache/spack/templates/frontier_craygnu-mphipcc_mpich.sh
+++ b/mache/spack/templates/frontier_craygnu-mphipcc_mpich.sh
@@ -16,12 +16,12 @@ module load \
 module rm \
     darshan-runtime &> /dev/null
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     cray-hdf5-parallel/1.14.3.3 \
     cray-netcdf-hdf5parallel/4.9.0.15 \
     cray-parallel-netcdf/1.12.3.15
-{% endif %}
+{%- endif %}
 
 export HDF5_ROOT=""
 export MPICH_GPU_SUPPORT_ENABLED="0"
@@ -37,9 +37,9 @@ export GPUS_PER_NODE="--gpus-per-node=8"
 export GPU_BIND_ARGS="--gpu-bind=closest"
 export PKG_CONFIG_PATH="/lustre/orion/cli115/world-shared/frontier/3rdparty/protobuf/21.6/gcc-native-13.2/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 export NETCDF_PATH="${NETCDF_DIR}"
 export NETCDF_C_PATH="${NETCDF_DIR}"
 export NETCDF_FORTRAN_PATH="${NETCDF_DIR}"
 export PNETCDF_PATH="${PNETCDF_DIR}"
-{% endif %}
+{%- endif %}

--- a/mache/spack/templates/frontier_craygnu-mphipcc_mpich.yaml
+++ b/mache/spack/templates/frontier_craygnu-mphipcc_mpich.yaml
@@ -2,15 +2,15 @@ spack:
   specs:
   - gcc
   - cray-mpich
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - cray-libsci
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: when_possible
@@ -19,9 +19,9 @@ spack:
       compiler: [gcc@13.2]
       providers:
         mpi: [cray-mpich@8.1.31]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [cray-libsci@24.11.0]
-{% endif %}
+{%- endif %}
     autoconf:
       externals:
       - spec: autoconf@2.69
@@ -148,15 +148,15 @@ spack:
         modules:
         - libfabric/1.22.0
       buildable: false
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
     cray-libsci:
       externals:
       - spec: cray-libsci@24.11.0
         modules:
         - cray-libsci/24.11.0
       buildable: false
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.1~cxx+fortran+hl~java+mpi+shared
@@ -177,7 +177,7 @@ spack:
       - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/GNU/9.1
       buildable: false
-{% endif %}
+{%- endif %}
 
   compilers:
   - compiler:

--- a/mache/spack/templates/frontier_craygnu-mphipcc_mpich.yaml
+++ b/mache/spack/templates/frontier_craygnu-mphipcc_mpich.yaml
@@ -1,24 +1,28 @@
+{%- set compiler = "gcc@13.2" %}
+{%- set mpi = "cray-mpich@8.1.31" %}
 spack:
   specs:
-  - gcc
-  - cray-mpich
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - cray-libsci
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: when_possible
   packages:
     all:
-      compiler: [gcc@13.2]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [cray-mpich@8.1.31]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [cray-libsci@24.11.0]
 {%- endif %}
@@ -115,7 +119,7 @@ spack:
       # despite complaints about redundancy, this needs to be here to prevent
       # spack from trying to build gcc
       externals:
-      - spec: gcc@13.2
+      - spec: {{ compiler }}
         modules:
         - Core/25.03
         - PrgEnv-gnu
@@ -136,7 +140,7 @@ spack:
       buildable: false
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.31
+      - spec: {{ mpi }}%{{ compiler }}
         modules:
         - libfabric/1.22.0
         - libunwind/1.8.1
@@ -181,7 +185,7 @@ spack:
 
   compilers:
   - compiler:
-      spec: gcc@13.2
+      spec: {{ compiler }}
       paths:
         cc: cc
         cxx: CC

--- a/mache/spack/templates/frontier_craygnu_mpich.csh
+++ b/mache/spack/templates/frontier_craygnu_mpich.csh
@@ -14,12 +14,12 @@ module load \
 module rm \
     darshan-runtime &> /dev/null
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     cray-hdf5-parallel/1.14.3.3 \
     cray-netcdf-hdf5parallel/4.9.0.15 \
     cray-parallel-netcdf/1.12.3.15
-{% endif %}
+{%- endif %}
 
 setenv HDF5_ROOT ""
 setenv MPICH_GPU_SUPPORT_ENABLED "0"
@@ -32,9 +32,9 @@ setenv NTASKS_PER_GPU " "
 setenv GPU_BIND_ARGS " "
 setenv PKG_CONFIG_PATH "/lustre/orion/cli115/world-shared/frontier/3rdparty/protobuf/21.6/gcc-native-13.2/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 setenv NETCDF_PATH "${NETCDF_DIR}"
 setenv NETCDF_C_PATH "${NETCDF_DIR}"
 setenv NETCDF_FORTRAN_PATH "${NETCDF_DIR}"
 setenv PNETCDF_PATH "${PNETCDF_DIR}"
-{% endif %}
+{%- endif %}

--- a/mache/spack/templates/frontier_craygnu_mpich.sh
+++ b/mache/spack/templates/frontier_craygnu_mpich.sh
@@ -14,12 +14,12 @@ module load \
 module rm \
     darshan-runtime &> /dev/null
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load \
     cray-hdf5-parallel/1.14.3.3 \
     cray-netcdf-hdf5parallel/4.9.0.15 \
     cray-parallel-netcdf/1.12.3.15
-{% endif %}
+{%- endif %}
 
 export HDF5_ROOT=""
 export MPICH_GPU_SUPPORT_ENABLED="0"
@@ -32,9 +32,9 @@ export NTASKS_PER_GPU=" "
 export GPU_BIND_ARGS=" "
 export PKG_CONFIG_PATH="/lustre/orion/cli115/world-shared/frontier/3rdparty/protobuf/21.6/gcc-native-13.2/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 export NETCDF_PATH="${NETCDF_DIR}"
 export NETCDF_C_PATH="${NETCDF_DIR}"
 export NETCDF_FORTRAN_PATH="${NETCDF_DIR}"
 export PNETCDF_PATH="${PNETCDF_DIR}"
-{% endif %}
+{%- endif %}

--- a/mache/spack/templates/frontier_craygnu_mpich.yaml
+++ b/mache/spack/templates/frontier_craygnu_mpich.yaml
@@ -2,15 +2,15 @@ spack:
   specs:
   - gcc
   - cray-mpich
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - cray-libsci
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: when_possible
@@ -19,9 +19,9 @@ spack:
       compiler: [gcc@13.2]
       providers:
         mpi: [cray-mpich@8.1.31]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [cray-libsci@23.02.1.1]
-{% endif %}
+{%- endif %}
     autoconf:
       externals:
       - spec: autoconf@2.69
@@ -146,15 +146,15 @@ spack:
         modules:
         - libfabric/1.22.0
       buildable: false
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
     cray-libsci:
       externals:
       - spec: cray-libsci@24.11.0
         modules:
         - cray-libsci/24.11.0
       buildable: false
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.1~cxx+fortran+hl~java+mpi+shared
@@ -175,7 +175,7 @@ spack:
       - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/GNU/9.1
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: gcc@13.2

--- a/mache/spack/templates/frontier_craygnu_mpich.yaml
+++ b/mache/spack/templates/frontier_craygnu_mpich.yaml
@@ -1,24 +1,28 @@
+{%- set compiler = "gcc@13.2" %}
+{%- set mpi = "cray-mpich@8.1.31" %}
 spack:
   specs:
-  - gcc
-  - cray-mpich
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - cray-libsci
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: when_possible
   packages:
     all:
-      compiler: [gcc@13.2]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [cray-mpich@8.1.31]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [cray-libsci@23.02.1.1]
 {%- endif %}
@@ -115,7 +119,7 @@ spack:
       # despite complaints about redundancy, this needs to be here to prevent
       # spack from trying to build gcc
       externals:
-      - spec: gcc@13.2
+      - spec: {{ compiler }}
         modules:
         - Core/25.03
         - PrgEnv-gnu
@@ -134,7 +138,7 @@ spack:
       buildable: false
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.31
+      - spec: {{ mpi }}%{{ compiler }}
         modules:
         - libfabric/1.22.0
         - libunwind/1.8.1
@@ -178,7 +182,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: gcc@13.2
+      spec: {{ compiler }}
       paths:
         cc: cc
         cxx: CC

--- a/mache/spack/templates/pm-cpu_gnu_mpich.csh
+++ b/mache/spack/templates/pm-cpu_gnu_mpich.csh
@@ -29,18 +29,18 @@ module load PrgEnv-gnu/8.5.0 \
             libfabric/1.20.1 \
             cray-mpich/8.1.28 \
             cmake/3.24.3
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \
             cray-parallel-netcdf/1.12.3.9
-{% endif %}
+{%- endif %}
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 setenv NETCDF_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
 setenv NETCDF_C_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
 setenv NETCDF_FORTRAN_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
 setenv PNETCDF_PATH $CRAY_PARALLEL_NETCDF_PREFIX
-{% endif %}
+{%- endif %}
 setenv MPICH_ENV_DISPLAY 1
 setenv MPICH_VERSION_DISPLAY 1
 setenv MPICH_MPIIO_DVS_MAXNODES 1

--- a/mache/spack/templates/pm-cpu_gnu_mpich.sh
+++ b/mache/spack/templates/pm-cpu_gnu_mpich.sh
@@ -29,18 +29,18 @@ module load PrgEnv-gnu/8.5.0 \
             libfabric/1.20.1 \
             cray-mpich/8.1.28 \
             cmake/3.24.3
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \
             cray-parallel-netcdf/1.12.3.9
-{% endif %}
+{%- endif %}
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 export NETCDF_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
 export NETCDF_C_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
 export NETCDF_FORTRAN_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
 export PNETCDF_PATH=$CRAY_PARALLEL_NETCDF_PREFIX
-{% endif %}
+{%- endif %}
 export MPICH_ENV_DISPLAY=1
 export MPICH_VERSION_DISPLAY=1
 export MPICH_MPIIO_DVS_MAXNODES=1

--- a/mache/spack/templates/pm-cpu_gnu_mpich.yaml
+++ b/mache/spack/templates/pm-cpu_gnu_mpich.yaml
@@ -3,12 +3,12 @@ spack:
   - gcc
   - cray-mpich
   - cray-libsci
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: when_possible
@@ -130,7 +130,7 @@ spack:
         modules:
         - cray-libsci/23.12.5
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.9~cxx+fortran+hl~java+mpi+shared
@@ -151,7 +151,7 @@ spack:
       - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.9/gnu/12.3
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: gcc@12.3

--- a/mache/spack/templates/pm-cpu_gnu_mpich.yaml
+++ b/mache/spack/templates/pm-cpu_gnu_mpich.yaml
@@ -1,22 +1,26 @@
+{%- set compiler = "gcc@12.3" %}
+{%- set mpi = "cray-mpich@8.1.28" %}
 spack:
   specs:
-  - gcc
-  - cray-mpich
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
   - cray-libsci
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: when_possible
   packages:
     all:
-      compiler: [gcc@12.3]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [cray-mpich@8.1.28]
+        mpi: [{{ mpi }}%{{ compiler }}]
         lapack: [cray-libsci@23.12.5]
         blas: [cray-libsci@23.12.5]
     bzip2:
@@ -103,7 +107,7 @@ spack:
       buildable: false
     gcc:
       externals:
-      - spec: gcc@12.3
+      - spec: {{ compiler }}
         modules:
         - PrgEnv-gnu/8.5.0
         - gcc-native/12.3
@@ -119,7 +123,7 @@ spack:
       buildable: false
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.28
+      - spec: {{ mpi }}%{{ compiler }}
         modules:
         - libfabric/1.20.1
         - cray-mpich/8.1.28
@@ -154,7 +158,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: gcc@12.3
+      spec: {{ compiler }}
       paths:
         cc: cc
         cxx: CC

--- a/mache/spack/templates/pm-cpu_intel_mpich.csh
+++ b/mache/spack/templates/pm-cpu_intel_mpich.csh
@@ -28,18 +28,18 @@ module load PrgEnv-intel/8.5.0 \
             craype/2.7.30 \
             libfabric/1.20.1 \
             cray-mpich/8.1.28
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \
             cray-parallel-netcdf/1.12.3.9
-{% endif %}
+{%- endif %}
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 setenv NETCDF_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
 setenv NETCDF_C_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
 setenv NETCDF_FORTRAN_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
 setenv PNETCDF_PATH $CRAY_PARALLEL_NETCDF_PREFIX
-{% endif %}
+{%- endif %}
 setenv MPICH_ENV_DISPLAY 1
 setenv MPICH_VERSION_DISPLAY 1
 setenv MPICH_MPIIO_DVS_MAXNODES 1

--- a/mache/spack/templates/pm-cpu_intel_mpich.sh
+++ b/mache/spack/templates/pm-cpu_intel_mpich.sh
@@ -28,18 +28,18 @@ module load PrgEnv-intel/8.5.0 \
             craype/2.7.30 \
             libfabric/1.20.1 \
             cray-mpich/8.1.28
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \
             cray-parallel-netcdf/1.12.3.9
-{% endif %}
+{%- endif %}
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 export NETCDF_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
 export NETCDF_C_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
 export NETCDF_FORTRAN_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
 export PNETCDF_PATH=$CRAY_PARALLEL_NETCDF_PREFIX
-{% endif %}
+{%- endif %}
 export MPICH_ENV_DISPLAY=1
 export MPICH_VERSION_DISPLAY=1
 export MPICH_MPIIO_DVS_MAXNODES=1

--- a/mache/spack/templates/pm-cpu_intel_mpich.yaml
+++ b/mache/spack/templates/pm-cpu_intel_mpich.yaml
@@ -2,12 +2,12 @@ spack:
   specs:
   - intel
   - cray-mpich
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: when_possible
@@ -124,7 +124,7 @@ spack:
         modules:
         - cray-libsci/23.12.5
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.9~cxx+fortran+hl~java+mpi+shared
@@ -145,7 +145,7 @@ spack:
       - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.9/intel/2023.2
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: intel@2023.2.0

--- a/mache/spack/templates/pm-cpu_intel_mpich.yaml
+++ b/mache/spack/templates/pm-cpu_intel_mpich.yaml
@@ -1,21 +1,26 @@
+{%- set compiler = "intel@2023.2.0" %}
+{%- set mpi = "cray-mpich@8.1.28" %}
 spack:
   specs:
-  - intel
-  - cray-mpich
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
+  - cray-libsci
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: when_possible
   packages:
     all:
-      compiler: [intel@2023.2.0]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [cray-mpich@8.1.28]
+        mpi: [{{ mpi }}%{{ compiler }}]
         lapack: [cray-libsci@23.12.5]
         blas: [cray-libsci@23.12.5]
     bzip2:
@@ -102,7 +107,7 @@ spack:
       buildable: false
     intel:
       externals:
-      - spec: intel@2023.2.0
+      - spec: {{ compiler }}
         modules:
         - PrgEnv-intel/8.5.0
         - intel/2023.2.0
@@ -113,7 +118,7 @@ spack:
       buildable: false
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.28
+      - spec: {{ mpi }}%{{ compiler }}
         modules:
         - cray-mpich/8.1.28
         - libfabric/1.20.1
@@ -148,7 +153,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: intel@2023.2.0
+      spec: {{ compiler }}
       paths:
         cc: cc
         cxx: CC

--- a/mache/spack/templates/pm-cpu_nvidia_mpich.csh
+++ b/mache/spack/templates/pm-cpu_nvidia_mpich.csh
@@ -29,18 +29,18 @@ module load PrgEnv-nvidia \
             libfabric/1.20.1 \
             cray-mpich/8.1.28 \
             cmake/3.24.3
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \
             cray-parallel-netcdf/1.12.3.9
-{% endif %}
+{%- endif %}
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 setenv NETCDF_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
 setenv NETCDF_C_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
 setenv NETCDF_FORTRAN_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
 setenv PNETCDF_PATH $CRAY_PARALLEL_NETCDF_PREFIX
-{% endif %}
+{%- endif %}
 setenv MPICH_ENV_DISPLAY 1
 setenv MPICH_VERSION_DISPLAY 1
 setenv MPICH_MPIIO_DVS_MAXNODES 1

--- a/mache/spack/templates/pm-cpu_nvidia_mpich.sh
+++ b/mache/spack/templates/pm-cpu_nvidia_mpich.sh
@@ -29,18 +29,18 @@ module load PrgEnv-nvidia \
             libfabric/1.20.1 \
             cray-mpich/8.1.28 \
             cmake/3.24.3
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \
             cray-parallel-netcdf/1.12.3.9
-{% endif %}
+{%- endif %}
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 export NETCDF_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
 export NETCDF_C_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
 export NETCDF_FORTRAN_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
 export PNETCDF_PATH=$CRAY_PARALLEL_NETCDF_PREFIX
-{% endif %}
+{%- endif %}
 export MPICH_ENV_DISPLAY=1
 export MPICH_VERSION_DISPLAY=1
 export MPICH_MPIIO_DVS_MAXNODES=1

--- a/mache/spack/templates/pm-cpu_nvidia_mpich.yaml
+++ b/mache/spack/templates/pm-cpu_nvidia_mpich.yaml
@@ -1,21 +1,25 @@
+{%- set compiler = "nvhpc@24.5" %}
+{%- set mpi = "cray-mpich@8.1.28" %}
 spack:
   specs:
-  - cray-mpich
+  - {{ mpi }}%{{ compiler }}
   - cray-libsci
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: when_possible
   packages:
     all:
-      compiler: [nvhpc@24.5]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [cray-mpich@8.1.28]
+        mpi: [{{ mpi }}%{{ compiler }}]
         lapack: [cray-libsci@23.12.5]
         blas: [cray-libsci@23.12.5]
     bzip2:
@@ -102,7 +106,7 @@ spack:
       buildable: false
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.28
+      - spec: {{ mpi }}%{{ compiler }}
         modules:
         - libfabric/1.20.1
         - cray-mpich/8.1.28
@@ -137,7 +141,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: nvhpc@24.5
+      spec: {{ compiler }}
       paths:
         cc: /opt/nvidia/hpc_sdk/Linux_x86_64/24.5/compilers/bin/nvc
         cxx: /opt/nvidia/hpc_sdk/Linux_x86_64/24.5/compilers/bin/nvc++

--- a/mache/spack/templates/pm-cpu_nvidia_mpich.yaml
+++ b/mache/spack/templates/pm-cpu_nvidia_mpich.yaml
@@ -2,12 +2,12 @@ spack:
   specs:
   - cray-mpich
   - cray-libsci
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: when_possible
@@ -113,7 +113,7 @@ spack:
         modules:
         - cray-libsci/23.12.5
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.9~cxx+fortran+hl~java+mpi+shared
@@ -134,7 +134,7 @@ spack:
       - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.9/nvidia/23.3
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: nvhpc@24.5

--- a/mache/spack/templates/pm-gpu_gnugpu_mpich.csh
+++ b/mache/spack/templates/pm-gpu_gnugpu_mpich.csh
@@ -30,18 +30,18 @@ module load PrgEnv-gnu/8.5.0 \
             craype/2.7.30 \
             cray-mpich/8.1.28 \
             cmake/3.24.3
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \
             cray-parallel-netcdf/1.12.3.9
-{% endif %}
+{%- endif %}
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 setenv NETCDF_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
 setenv NETCDF_C_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
 setenv NETCDF_FORTRAN_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
 setenv PNETCDF_PATH $CRAY_PARALLEL_NETCDF_PREFIX
-{% endif %}
+{%- endif %}
 setenv MPICH_ENV_DISPLAY 1
 setenv MPICH_VERSION_DISPLAY 1
 setenv MPICH_MPIIO_DVS_MAXNODES 1

--- a/mache/spack/templates/pm-gpu_gnugpu_mpich.sh
+++ b/mache/spack/templates/pm-gpu_gnugpu_mpich.sh
@@ -30,18 +30,18 @@ module load PrgEnv-gnu/8.5.0 \
             craype/2.7.30 \
             cray-mpich/8.1.28 \
             cmake/3.24.3
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \
             cray-parallel-netcdf/1.12.3.9
-{% endif %}
+{%- endif %}
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 export NETCDF_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
 export NETCDF_C_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
 export NETCDF_FORTRAN_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
 export PNETCDF_PATH=$CRAY_PARALLEL_NETCDF_PREFIX
-{% endif %}
+{%- endif %}
 export MPICH_ENV_DISPLAY=1
 export MPICH_MPIIO_DVS_MAXNODES=1
 export MPICH_VERSION_DISPLAY=1

--- a/mache/spack/templates/pm-gpu_gnugpu_mpich.yaml
+++ b/mache/spack/templates/pm-gpu_gnugpu_mpich.yaml
@@ -1,22 +1,26 @@
+{%- set compiler = "gcc@12.3" %}
+{%- set mpi = "cray-mpich@8.1.28" %}
 spack:
   specs:
-  - gcc
-  - cray-mpich
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
   - cray-libsci
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: when_possible
   packages:
     all:
-      compiler: [gcc@12.3]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [cray-mpich@8.1.28]
+        mpi: [{{ mpi }}%{{ compiler }}]
         lapack: [cray-libsci@23.12.5]
     bzip2:
       externals:
@@ -102,7 +106,7 @@ spack:
       buildable: false
     gcc:
       externals:
-      - spec: gcc@12.3
+      - spec: {{ compiler }}
         modules:
         - PrgEnv-gnu/8.5.0
         - gcc-native/12.3
@@ -131,7 +135,7 @@ spack:
       buildable: false
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.28
+      - spec: {{ mpi }}%{{ compiler }}
         prefix: /opt/cray/pe/mpich/8.1.28/ofi/gnu/12.3
       buildable: false
     cray-libsci:
@@ -164,7 +168,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: gcc@12.3
+      spec: {{ compiler }}
       paths:
         cc: cc
         cxx: CC

--- a/mache/spack/templates/pm-gpu_gnugpu_mpich.yaml
+++ b/mache/spack/templates/pm-gpu_gnugpu_mpich.yaml
@@ -3,12 +3,12 @@ spack:
   - gcc
   - cray-mpich
   - cray-libsci
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: when_possible
@@ -140,7 +140,7 @@ spack:
         modules:
         - cray-libsci/23.12.5
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.9~cxx+fortran+hl~java+mpi+shared
@@ -161,7 +161,7 @@ spack:
       - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.9/gnu/12.3
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: gcc@12.3

--- a/mache/spack/templates/pm-gpu_nvidiagpu_mpich.csh
+++ b/mache/spack/templates/pm-gpu_nvidiagpu_mpich.csh
@@ -31,18 +31,18 @@ module load PrgEnv-nvidia \
             craype/2.7.30 \
             cray-mpich/8.1.28 \
             cmake/3.24.3
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \
             cray-parallel-netcdf/1.12.3.9
-{% endif %}
+{%- endif %}
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 setenv NETCDF_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
 setenv NETCDF_C_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
 setenv NETCDF_FORTRAN_PATH $CRAY_NETCDF_HDF5PARALLEL_PREFIX
 setenv PNETCDF_PATH $CRAY_PARALLEL_NETCDF_PREFIX
-{% endif %}
+{%- endif %}
 setenv MPICH_ENV_DISPLAY 1
 setenv MPICH_VERSION_DISPLAY 1
 setenv MPICH_MPIIO_DVS_MAXNODES 1

--- a/mache/spack/templates/pm-gpu_nvidiagpu_mpich.sh
+++ b/mache/spack/templates/pm-gpu_nvidiagpu_mpich.sh
@@ -31,18 +31,18 @@ module load PrgEnv-nvidia \
             craype/2.7.30 \
             cray-mpich/8.1.28 \
             cmake/3.24.3
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \
             cray-parallel-netcdf/1.12.3.9
-{% endif %}
+{%- endif %}
 
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
 export NETCDF_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
 export NETCDF_C_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
 export NETCDF_FORTRAN_PATH=$CRAY_NETCDF_HDF5PARALLEL_PREFIX
 export PNETCDF_PATH=$CRAY_PARALLEL_NETCDF_PREFIX
-{% endif %}
+{%- endif %}
 export MPICH_ENV_DISPLAY=1
 export MPICH_VERSION_DISPLAY=1
 export MPICH_MPIIO_DVS_MAXNODES=1

--- a/mache/spack/templates/pm-gpu_nvidiagpu_mpich.yaml
+++ b/mache/spack/templates/pm-gpu_nvidiagpu_mpich.yaml
@@ -2,12 +2,12 @@ spack:
   specs:
   - cray-mpich
   - cray-libsci
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: when_possible
@@ -124,7 +124,7 @@ spack:
         modules:
         - cray-libsci/23.12.5
       buildable: false
-{% if e3sm_hdf5_netcdf %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.12.2.9~cxx+fortran+hl~java+mpi+shared
@@ -145,7 +145,7 @@ spack:
       - spec: netcdf-fortran@4.5.3
         prefix: /opt/cray/pe/netcdf-hdf5parallel/4.9.0.9/nvidia/23.3
       buildable: false
-{% endif %}
+{%- endif %}
   compilers:
   - compiler:
       spec: nvhpc@24.5

--- a/mache/spack/templates/pm-gpu_nvidiagpu_mpich.yaml
+++ b/mache/spack/templates/pm-gpu_nvidiagpu_mpich.yaml
@@ -1,21 +1,25 @@
+{%- set compiler = "nvhpc@24.5" %}
+{%- set mpi = "cray-mpich@8.1.28" %}
 spack:
   specs:
-  - cray-mpich
+  - {{ mpi }}%{{ compiler }}
   - cray-libsci
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: when_possible
   packages:
     all:
-      compiler: [nvhpc@24.5]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [cray-mpich@8.1.28]
+        mpi: [{{ mpi }}%{{ compiler }}]
         lapack: [cray-libsci@23.12.5]
     bzip2:
       externals:
@@ -113,7 +117,7 @@ spack:
       buildable: false
     cray-mpich:
       externals:
-      - spec: cray-mpich@8.1.28
+      - spec: {{ mpi }}%{{ compiler }}
         modules:
         - libfabric/1.20.1
         - cray-mpich/8.1.28
@@ -148,7 +152,7 @@ spack:
 {%- endif %}
   compilers:
   - compiler:
-      spec: nvhpc@24.5
+      spec: {{ compiler }}
       paths:
         cc: /opt/nvidia/hpc_sdk/Linux_x86_64/24.5/compilers/bin/nvc
         cxx: /opt/nvidia/hpc_sdk/Linux_x86_64/24.5/compilers/bin/nvc++

--- a/mache/spack/templates/ruby_intel_mvapich2.yaml
+++ b/mache/spack/templates/ruby_intel_mvapich2.yaml
@@ -1,22 +1,26 @@
+{%- set compiler = "intel@2021.6.0" %}
+{%- set mpi = "mvapich2@2.3.7" %}
 spack:
   specs:
-  - intel
-  - mvapich2
+  - {{ compiler }}
+  - {{ mpi }}%{{ compiler }}
 {%- if e3sm_lapack %}
   - intel-oneapi-mkl
 {%- endif %}
 {%- if e3sm_hdf5_netcdf %}
-  - hdf5
-  - netcdf-c
-  - netcdf-fortran
-  - parallel-netcdf
+  - "hdf5%{{ compiler }}"
+  - "netcdf-c%{{ compiler }}"
+  - "netcdf-fortran%{{ compiler }}"
+  - "parallel-netcdf%{{ compiler }}"
 {%- endif %}
-{{ specs }}
+{%- for spec in specs %}
+  - "{{ spec }}%{{ compiler }}"
+{%- endfor %}
   concretizer:
     unify: true
   compilers:
   - compiler:
-      spec: intel@=2021.6.0
+      spec: {{ compiler }}
       paths:
         cc: /usr/tce/packages/intel-classic/intel-classic-2021.6.0-magic/bin/icc
         cxx: /usr/tce/packages/intel-classic/intel-classic-2021.6.0-magic/bin/icpc
@@ -45,15 +49,15 @@ spack:
       extra_rpaths: []
   packages:
     all:
-      compiler: [intel@2021.6.0]
+      compiler: [{{ compiler }}]
       providers:
-        mpi: [mvapich2@2.3.7]
+        mpi: [{{ mpi }}%{{ compiler }}]
 {%- if e3sm_lapack %}
         lapack: [intel-oneapi-mkl@2022.1.0]
 {%- endif %}
     intel:
       externals:
-      - spec: intel@2021.6.0
+      - spec: {{ compilers}}
         modules:
         - StdEnv
         - intel-classic/2021.6.0-magic
@@ -188,7 +192,7 @@ spack:
       buildable: false
     mvapich2:
       externals:
-      - spec: mvapich2@2.3.7~cuda~debug+regcache+wrapperrpath ch3_rank_bits=32 file_systems=lustre,nfs,ufs
+      - spec: {{ mpi }}%{{ compiler }}~cuda~debug+regcache+wrapperrpath ch3_rank_bits=32 file_systems=lustre,nfs,ufs
           process_managers=hydra threads=multiple
         modules:
         - mvapich2/2.3.7

--- a/mache/spack/templates/ruby_intel_mvapich2.yaml
+++ b/mache/spack/templates/ruby_intel_mvapich2.yaml
@@ -2,15 +2,15 @@ spack:
   specs:
   - intel
   - mvapich2
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
   - intel-oneapi-mkl
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
   - hdf5
   - netcdf-c
   - netcdf-fortran
   - parallel-netcdf
-{% endif %}
+{%- endif %}
 {{ specs }}
   concretizer:
     unify: true
@@ -48,9 +48,9 @@ spack:
       compiler: [intel@2021.6.0]
       providers:
         mpi: [mvapich2@2.3.7]
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
         lapack: [intel-oneapi-mkl@2022.1.0]
-{% endif %}
+{%- endif %}
     intel:
       externals:
       - spec: intel@2021.6.0
@@ -277,15 +277,15 @@ spack:
       - spec: tar@1.30
         prefix: /usr
       buildable: false
-{% if e3sm_lapack %}
+{%- if e3sm_lapack %}
     intel-oneapi-mkl:
       externals:
       - spec: intel-oneapi-mkl@2022.1.0
         modules:
         - mkl-interfaces/2022.1.0
       buildable: false
-{% endif %}
-{% if e3sm_hdf5_netcdf %}
+{%- endif %}
+{%- if e3sm_hdf5_netcdf %}
     hdf5:
       externals:
       - spec: hdf5@1.14.0+cxx+fortran+hl~java+mpi~szip+threadsafe+tools api=v18
@@ -310,6 +310,6 @@ spack:
         modules:
         - parallel-netcdf/1.12.3
       buildable: false
-{% endif %}
+{%- endif %}
   config:
     install_missing_compilers: false

--- a/mache/version.py
+++ b/mache/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (1, 30, 0)
+__version_info__ = (1, 31, 0)
 __version__ = '.'.join(str(vi) for vi in __version_info__)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge makes several changes to spack support, needed for or motivated by adding support for Aurora.  These changes include:
* Switching `specs` in spack templates to be lists, rather than a single string.  This allows us to append requirements like compilers to each spec if needed.
* Updating comments in machine files to be more accurate
* Updating templates to hide jinja set, if/else, for, etc. statements rather than leaving frustrating blank lines
* Adds `compiler` and `mpi` jinja variables to each spack template
* Makes sure nearly all specs depend on `%{{ compiler }}` for safety

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->