### PR TITLE
Change `pre-commit` hook ID from `ruff` to `ruff-check`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,11 +30,11 @@ repos:
     rev: v0.12.0
     hooks:
       # Sort the imports
-      - id: ruff
+      - id: ruff-check
         name: ruff-sort-imports
         args: [--select, I, --fix]
       # Run the linter.
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       # Run the formatter.
       - id: ruff-format


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
The `pre-commit` hook used to be `ruff` but it changed to `ruff-check`, resulting in a message about the legacy alias. This updates the hook to the current `ruff-check` format.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

