### PR TITLE
Reorganize `mache.spack` for better modularization

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,14 +4,17 @@ Please add a description of what is accomplished in the PR here at the top:
 -->
 
 <!--
-Below are a few things we ask you or your reviewers to kindly check. 
+Below are a few things we ask you or your reviewers to kindly check.
 ***Remove checks that are not relevant by deleting the line(s) below.***
 -->
 Checklist
-* [ ] Developer's Guide has been updated
-* [ ] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
-* [ ] Documentation has been [built locally](https://docs.e3sm.org/mache/main/developers_guide/building_docs.html) and changes look as expected
-* [ ] `Testing` comment in the PR documents testing used to verify the changes
+- [ ] User's Guide has been updated if needed
+- [ ] Developer's Guide has been updated if needed
+- [ ] API documentation lists any new or modified class, method, or function
+- [ ] Documentation [builds](https://docs.e3sm.org/mache/main/developers_guide/building_docs.html) cleanly and changes look as expected
+- [ ] Tests pass and new features are covered by tests
+- [ ] PR description includes a summary and any relevant issue references
+- [ ] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes
 
 <!--
 Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,9 +64,9 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 intersphinx_mapping = {
     'geometric_features':
-        ('https://mpas-dev.github.io/geometric_features/stable', None),
+        ('https://mpas-dev.github.io/geometric_features/main', None),
     'matplotlib': ('https://matplotlib.org/stable', None),
-    'mpas_tools': ('https://mpas-dev.github.io/MPAS-Tools/stable', None),
+    'mpas_tools': ('https://mpas-dev.github.io/MPAS-Tools/master', None),
     'numpy': ('https://numpy.org/doc/stable', None),
     'python': ('https://docs.python.org', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),

--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -31,7 +31,7 @@ documentation.
 ## spack
 
 ```{eval-rst}
-.. currentmodule:: mache.spack.templates
+.. currentmodule:: mache.spack
 
 .. autosummary::
     :toctree: generated/

--- a/docs/developers_guide/contributing.md
+++ b/docs/developers_guide/contributing.md
@@ -63,10 +63,12 @@ If a pre-commit hook fails, fix the reported issues and recommit.
 
 ## Pull Request Checklist
 
+- [ ] User's Guide has been updated if needed
 - [ ] Developer's Guide has been updated if needed
 - [ ] API documentation lists any new or modified class, method, or function
 - [ ] Documentation builds cleanly and changes look as expected
 - [ ] Tests pass and new features are covered by tests
 - [ ] PR description includes a summary and any relevant issue references
+- [ ] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes
 
 Thank you for helping improve `mache`!

--- a/docs/developers_guide/contributing.md
+++ b/docs/developers_guide/contributing.md
@@ -1,0 +1,72 @@
+# Contributing to mache
+
+Thank you for your interest in contributing to `mache`! We welcome
+contributions of all kinds, including bug reports, feature requests, code, and
+documentation improvements.
+
+## How to Contribute
+
+- **Bug Reports & Feature Requests:**
+  Please use [GitHub Issues](https://github.com/E3SM-Project/mache/issues) to
+  report bugs or request features.
+
+- **Pull Requests:**
+  Fork the repository, create a new branch for your changes, and submit a pull
+  request (PR) to the `main` branch. Please provide a clear description of
+  your changes.
+
+## Development Environment
+
+1. **Set up an isolated environment:**
+    ```bash
+    conda config --add channels conda-forge
+    conda config --set channel_priority strict
+    conda create -y -n mache_dev --file spec-file.txt
+    conda activate mache_dev
+    python -m pip install --no-deps --no-build-isolation -e .
+    ```
+
+2. **Install pre-commit hooks:**
+    ```bash
+    pre-commit install
+    ```
+    This ensures code style and quality checks run automatically on each
+    commit.
+
+## Code Style and Linting
+
+- Follow [PEP8](https://peps.python.org/pep-0008/) and project code style.
+- The following tools are used (via [pre-commit](https://pre-commit.com/)):
+  - [ruff](https://docs.astral.sh/ruff/) for linting and formatting
+  - [flynt](https://github.com/ikamensh/flynt) for f-string conversion
+  - [mypy](https://mypy-lang.org/) for type checking
+
+If a pre-commit hook fails, fix the reported issues and recommit.
+
+## Testing
+
+- Add or update tests for new features or bug fixes.
+- Run the test suite before submitting a PR:
+    ```bash
+    pytest
+    ```
+
+## Documentation
+
+- Document all public functions and classes using docstrings.
+- Update the [API documentation](api.md) if you add or modify public APIs.
+- Build and preview the documentation locally:
+    ```bash
+    cd docs
+    DOCS_VERSION=test make clean versioned-html
+    ```
+
+## Pull Request Checklist
+
+- [ ] Developer's Guide has been updated if needed
+- [ ] API documentation lists any new or modified class, method, or function
+- [ ] Documentation builds cleanly and changes look as expected
+- [ ] Tests pass and new features are covered by tests
+- [ ] PR description includes a summary and any relevant issue references
+
+Thank you for helping improve `mache`!

--- a/docs/developers_guide/quick_start.md
+++ b/docs/developers_guide/quick_start.md
@@ -1,22 +1,13 @@
-# Quick Start
+# Quick Start for Developers
 
-`mache` (Machines for E3SM) is a package for providing configuration data
-related to E3SM supported machines.
+This guide is for contributors to `mache`. For general installation and usage,
+see the [User's Guide](../users_guide/quick_start.md).
 
 (dev-installing-mache)=
 
-## Installing mache
+## Setting up for Development
 
-You can install the latest release of `mache` from conda-forge:
-
-```bash
-conda config --add channels conda-forge
-conda config --set channel_priority strict
-conda install mache
-```
-
-If you need to install the latest development version, you can run the
-following in the root of the `mache` branch you are developing:
+To work on `mache`, you should install the development version in an isolated environment:
 
 ```bash
 conda config --add channels conda-forge
@@ -26,8 +17,7 @@ conda activate mache_dev
 python -m pip install --no-deps --no-build-isolation -e .
 ```
 
-To install the development version of `mache` in an existing
-environment, you can run:
+If you want to install into an existing environment:
 
 ```bash
 conda install --file spec-file.txt
@@ -36,38 +26,38 @@ python -m pip install --no-deps --no-build-isolation -e .
 
 (dev-code-styling)=
 
-## Code styling and linting
+## Code Styling and Linting
 
-`mache` uses `pre-commit` to lint incoming code when you make a commit (as
-long as you have your environment set up correctly), and on GitHub whenever you
-make a pull request to the `mache` repository. Linting makes sure your code
-follows the formatting guidelines of PEP8, and cleans up additional things like
-whitespace at the end of files.
-
-The first time you set up the `mache_dev` environment, you will need to set up
-`pre-commit`. This is done by running:
+`mache` uses [`pre-commit`](https://pre-commit.com/) to enforce code style and
+quality. After setting up your environment, run:
 
 ```bash
 pre-commit install
 ```
 
-You only need to do this once when you create the `mache_dev` environment. If
-you create a new version of `mache_dev`, then you will need to run it again.
+This only needs to be done once per environment. `pre-commit` will
+automatically check and format your code on each commit. If it makes changes,
+review and re-commit as needed. Some issues (like inconsistent variable types)
+may require manual fixes.
 
-When you run `git commit <filename>`, `pre-commit` will automatically lint your
-code before committing. Some formatting will be updated by `pre-commit`
-automatically, in which case it will terminate the commit and inform you of the
-change. Then you can run `git commit <filename>` again to continue the linting
-process until your commit is successful. Some changes need to be made manually,
-such as inconsistent variable types. When this happens, you must update the
-file to `pre-commit`'s standards, and then attempt to re-commit the file.
+Internally, `pre-commit` uses:
 
-Internally, `pre-commit`  uses [ruff](https://docs.astral.sh/ruff/) to check
-PEP8 compliance, as well as sort, check and format imports,
-[flynt](https://github.com/ikamensh/flynt) to change any format strings to
-f-strings, and [mypy](https://mypy-lang.org/) to check for consistent variable
-types. An example error might be:
+- [ruff](https://docs.astral.sh/ruff/) for PEP8 compliance and import formatting,
+- [flynt](https://github.com/ikamensh/flynt) to convert format strings to
+  f-strings,
+- [mypy](https://mypy-lang.org/) for type checking.
 
+Example error:
+
+```bash
+example.py:77:1: E302 expected 2 blank lines, found 1
+```
+
+In this case, add a blank line after line 77 and try again.
+
+You may also use an IDE with a PEP8 style checker, such as [PyCharm](https://www.jetbrains.com/pycharm/). See
+[this tutorial](https://www.jetbrains.com/help/pycharm/tutorial-code-quality-assistance-tips-and-tricks.html)
+for tips.
 ```bash
 example.py:77:1: E302 expected 2 blank lines, found 1
 ```
@@ -76,230 +66,26 @@ For this example, we would just add an additional blank line after line 77 and
 try the commit again to make sure we've resolved the issue.
 
 You may also find it useful to use an IDE with a PEP8 style checker built in,
-such as [PyCharm](https://www.jetbrains.com/pycharm/). See
-[this tutorial](https://www.jetbrains.com/help/pycharm/tutorial-code-quality-assistance-tips-and-tricks.html)
-for some tips on checking code style in PyCharm.
+such as [VS Code](https://code.visualstudio.com/). See
+[Formatting Python in VS Code](https://code.visualstudio.com/docs/python/formatting)
+for some tips on checking code style in VS Code.
 
-(dev-example-usage)=
+## Running Tests
 
-## Example usage
-
-```python
-#!/usr/bin/env python
-from mache import MachineInfo, discover_machine
-
-machine_info = MachineInfo()
-print(machine_info)
-diags_base = machine_info.config.get('diagnostics', 'base_path')
-machine = discover_machine()
-```
-
-This loads machine info the current machine, prints it (see below) and
-retrieves a config option specific to that machine. The
-`discover_machine()` function can also be used to detect which machine
-you are on, as shown.
-
-As an example, the result of `print(machine_info)` is:
-
-```
-Machine: anvil
-  E3SM Supported Machine: True
-  Compilers: intel, gnu
-  MPI libraries: impi, openmpi, mvapich
-  OS: LINUX
-
-E3SM-Unified:
-  E3SM-Unified is not currently loaded
-  Base path: /lcrc/soft/climate/e3sm-unified
-
-Diagnostics:
-  Base path: /lcrc/group/e3sm/diagnostics
-
-Config options:
-  [e3sm_unified]
-    group = cels
-    compiler = intel
-    mpi = impi
-    base_path = /lcrc/soft/climate/e3sm-unified
-
-  [diagnostics]
-    base_path = /lcrc/group/e3sm/diagnostics
-
-  [web_portal]
-    base_path = /lcrc/group/e3sm/public_html
-    base_url = https://web.lcrc.anl.gov/public/e3sm/
-
-  [parallel]
-    system = slurm
-    parallel_executable = srun
-    cores_per_node = 36
-    account = condo
-    partitions = acme-small, acme-medium, acme-large
-    qos = regular, acme_high
-```
-
-If you are on the login node of one of the following E3SM supported
-machines, you don't need to provide the machine name. It can be
-discovered automatically when you create a `MachineInfo()` object or
-call `discover_machine()`. It will be recognized from the host name or the
-local environment:
-
-- andes
-- aurora
-- anvil
-- chicoma-cpu
-- chrysalis
-- compy
-- dane
-- frontier
-- pm-cpu
-- polaris
-- ruby
-
-
-If you are on a compute node or want info about a machine you're not
-currently on, give the `machine` name in all lowercase.
-
-(dev-attributes)=
-
-## Attributes
-
-The attributes currently available are:
-
-machine : str
-
-: The name of an E3SM supported machine
-
-config : configparser.ConfigParser
-
-: Config options for this machine
-
-e3sm_supported : bool
-
-: Whether this machine supports running E3SM itself, and therefore has a list
-of compilers, MPI libraries, and the modules needed to load them
-
-compilers : list
-
-: A list of compilers for this machine if `e3sm_supported == True`
-
-mpilibs : list
-
-: A list of MPI libraries for this machine if `e3sm_supported == True`
-
-os : str
-
-: The machine's operating system if `e3sm_supported == True`
-
-e3sm_unified_mpi : {'nompi', 'system', None}
-
-: Which MPI type is included in the E3SM-Unified environment (if one is loaded)
-
-e3sm_unified_base : str
-
-: The base path where E3SM-Unified and its activation scripts are installed if
-`e3sm_unified` is not `None`
-
-e3sm_unified_activation : str
-
-: The activation script used to activate E3SM-Unified if `e3sm_unified` is not
-`None`
-
-diagnostics_base : str
-
-: The base directory for diagnostics data
-
-web_portal_base : str
-
-: The base directory for the web portal
-
-web_portal_url : str
-
-: The base URL for the web portal
-
-username : str
-
-: The name of the current user, for use in web-portal directories. This value
-is also added to the `web_portal` and `username` option of the `config`
-attribute.
-
-## Syncing diagnostics
-
-`mache` can be used to synchronize diagnostics data (observational data
-sets, testing data, mapping files, region masks, etc.) either directly
-on LCRC or from LCRC to other supported machines.
-
-E3SM maintains a set of public diagnostics data (those that we have
-permission to share with any users of our software) on LCRC machines
-(Anvil and Chrysalis) in the directory:
-
-```
-/lcrc/group/e3sm/public_html/diagnostics/
-```
-
-A set of private diagnostics data (which we do not have permission to
-share outside the E3SM project) are stored at:
-
-```
-/lcrc/group/e3sm/diagnostics_private/
-```
-
-The `mache sync diags` command can be used to synchronize both sets of
-data with a shared diagnostics directory on each supported machine.
-
-Whenever possible, we log on to the E3SM machine and download the data
-from LCRC because this allows the synchronization tool to also update
-permissions once the data has been synchronized. This is the approach
-for all machines except for Frontier and Andes, which doesn't allow connections
-to LCRC because of Duo Mobile, and Los Alamos National Laboratory's Chicoma,
-which is behind a firewall that prevents this approach.
-
-### One-time setup
-
-To synchronize data from LCRC to other machines, you must first provide
-your SSH keys by going to the [Argonne
-Accounts](https://accounts.cels.anl.gov/) page, logging in, and adding
-the public ssh key for each machine. If you have not yet generated an
-SSH key for the destination machine, you will need to run:
+To run the test suite:
 
 ```bash
-ssh-keygen -t ed25519 -C "your_email@example.com"
+pytest
 ```
 
-This is the same procedure as for creating an SSH key for GitHub so if
-you have already done that process, you will not need a new SSH key for
-LCRC.
+Make sure all tests pass before submitting a pull request.
 
-### Syncing from LCRC
+## Contributing
 
-To synchronize diagnostics data from LCRC, simply run:
+- Follow PEP8 and project code style.
+- Use descriptive commit messages.
+- Add or update tests for new features or bug fixes.
+- Document public functions and classes.
 
-```bash
-mache sync diags from anvil -u <ac.user>
-```
-
-where `<ac.user>` is your account name on LCRC.
-
-## Syncing on LCRC
-
-To synchronize diagnostics on an LCRC machine, run:
-
-```bash
-mache sync diags from anvil
-```
-
-Make sure the machine after `from` is the same as the machine you are
-on, `anvil` in this example.
-
-### Syncing to machines with firewalls
-
-To synchronize diagnostics data to a machine with a firewall by using a
-tunnel, first log on to an LCRC machine, then run:
-
-```bash
-mache sync diags to chicoma-cpu -u <username>
-```
-
-where `<username>` is your account name on the non-LCRC machine
-(`chicoma-cpu` in this example).
+For more details, see the [contributing guide](contributing.md).
 

--- a/docs/developers_guide/spack.md
+++ b/docs/developers_guide/spack.md
@@ -1,0 +1,106 @@
+# Adding Spack Support for a New Machine
+
+This guide describes how to add support for a new machine to the `mache.spack`
+subpackage, focusing on the YAML configuration files for compilers and MPI
+libraries. For instructions on adding a new machine to mache in general
+(including non-spack configuration), see
+[Adding a New Machine to Mache](adding_new_machine.md).
+
+## Overview
+
+To enable Spack-based environments for a new machine, you will need to:
+
+1. Create one or more YAML template files in `mache/spack/templates/` for each
+   supported compiler and MPI library combination.
+2. Add system-provided (external) packages, saving time and prefenting build
+   failures if Spack attempts to build them from source.
+3. Optionally, provide shell script templates for module/environment setup if
+   needed.
+
+## YAML Template Files
+
+Each YAML file describes a Spack environment for a particular combination of compiler and MPI library. The filename convention is:
+
+```
+<machine>_<compiler>_<mpilib>.yaml
+```
+
+For example: `chicoma-cpu_gnu_mpich.yaml`
+
+These files are Jinja2 templates, allowing conditional inclusion of packages
+(e.g., HDF5/NetCDF, LAPACK) based on user options.
+
+### Typical External Packages
+
+On most HPC systems, the following packages are provided by the system and
+should be marked as `external` in the YAML:
+
+- Compilers (e.g., `gcc`, `intel`, `nvhpc`, `rocmcc`, `oneapi`)
+- MPI libraries (e.g., `cray-mpich`, `openmpi`, `mvapich2`, `intel-mpi`,
+  `mpich`)
+- BLAS/LAPACK libraries (e.g., `cray-libsci`, `intel-mkl`, `intel-oneapi-mkl`)
+- HDF5, NetCDF, and PNetCDF libraries (often as modules or in system paths)
+- Build tools: `cmake`, `gmake`, `autoconf`, `automake`, `libtool`, `m4`
+- Compression and utility libraries: `bzip2`, `xz`, `zlib`, `curl`, `openssl`,
+  `findutils`, `gettext`, `tar`, `perl`, `python`
+
+**Note:** The exact set of external packages may vary by machine. Consult existing YAML files for examples.
+
+### Finding Library Paths
+
+To specify an external package, you need its installation prefix and (optionally) the module name. You can find these by:
+
+- Using `which <executable>` or `echo $MODULEPATH` to find module paths
+- Checking the output of `module show <modulename>` for environment variables like `PATH`, `LD_LIBRARY_PATH`, or `PREFIX`
+- Consulting system documentation or sysadmins
+
+Example external package entry:
+
+```yaml
+cmake:
+  externals:
+  - spec: cmake@3.27.9
+    prefix: /sw/frontier/spack-envs/core-24.07/opt/gcc-7.5.0/cmake-3.27.9-pyxnvhiskwepbw5itqyipzyhhfw3yitk
+    modules:
+    - cmake/3.27.9
+  buildable: false
+```
+
+### Marking Packages as Non-Buildable
+
+For each external package, set `buildable: false` to prevent Spack from attempting to build it from source.
+
+### Providers
+
+Specify providers for `mpi` and `lapack` under the `all` section, e.g.:
+
+```yaml
+all:
+  compiler: [gcc@13.2]
+  providers:
+    mpi: [cray-mpich@8.1.31%gcc@13.2]
+    lapack: [cray-libsci@24.11.0]
+```
+
+## Shell Script Templates
+
+If the machine requires special module loads or environment variables not handled by Spack, add corresponding shell script templates:
+
+- `<machine>.sh` and/or `<machine>_<compiler>_<mpilib>.sh` for bash
+- `<machine>.csh` and/or `<machine>_<compiler>_<mpilib>.csh` for csh/tcsh
+
+These scripts are also Jinja2 templates and can use the same conditional logic as the YAML files.
+
+## Testing
+
+After adding or modifying YAML and shell script templates:
+
+1. Use the `make_spack_env` or `get_spack_script` functions in `mache.spack` to generate and test the environment.
+2. Confirm that all modules load and all external packages are correctly detected by Spack.
+3. Build and run a simple test application to verify the environment.
+
+## Further Reading
+
+- For the non-spack aspects of adding a new machine, see [Adding a New Machine to Mache](adding_new_machine.md).
+- For more details on Spack external packages, see the [Spack documentation on external packages](https://spack.readthedocs.io/en/latest/build_settings.html#external-packages).
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,17 +3,21 @@
 :width: 400 px
 ```
 
-(mache)=
+```{toctree}
+:caption: User's guide
+:maxdepth: 2
 
-# Mache
+users_guide/quick_start
+```
 
-A package for providing configuration data relate to E3SM supported machines.
+
 
 ```{toctree}
 :caption: Developer's guide
 :maxdepth: 2
 
 developers_guide/quick_start
+developers_guide/contributing
 developers_guide/adding_new_machine
 developers_guide/building_docs
 developers_guide/api

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,8 @@
 :maxdepth: 2
 
 users_guide/quick_start
+users_guide/spack/build
 ```
-
-
 
 ```{toctree}
 :caption: Developer's guide
@@ -19,7 +18,7 @@ users_guide/quick_start
 developers_guide/quick_start
 developers_guide/contributing
 developers_guide/adding_new_machine
+developers_guide/spack
 developers_guide/building_docs
 developers_guide/api
 ```
-

--- a/docs/users_guide/quick_start.md
+++ b/docs/users_guide/quick_start.md
@@ -1,0 +1,120 @@
+# Quick Start
+
+`mache` (Machines for E3SM) is a package for providing configuration data related to E3SM supported machines.
+
+## Installing mache
+
+You can install the latest release of `mache` from conda-forge:
+
+```bash
+conda config --add channels conda-forge
+conda config --set channel_priority strict
+conda install mache
+```
+
+## Example usage
+
+```python
+#!/usr/bin/env python
+from mache import MachineInfo, discover_machine
+
+machine_info = MachineInfo()
+print(machine_info)
+diags_base = machine_info.config.get('diagnostics', 'base_path')
+machine = discover_machine()
+```
+
+This loads machine info for the current machine, prints it, and retrieves a
+config option specific to that machine. The {py:func}`mache.discover_machine()`
+function can also be used to detect which machine you are on.
+
+As an example, the result of `print(machine_info)` is:
+
+```
+Machine: anvil
+  E3SM Supported Machine: True
+  Compilers: intel, gnu
+  MPI libraries: impi, openmpi, mvapich
+  OS: LINUX
+
+E3SM-Unified:
+  E3SM-Unified is not currently loaded
+  Base path: /lcrc/soft/climate/e3sm-unified
+
+Diagnostics:
+  Base path: /lcrc/group/e3sm/diagnostics
+
+Config options:
+  [e3sm_unified]
+    group = cels
+    compiler = intel
+    mpi = impi
+    base_path = /lcrc/soft/climate/e3sm-unified
+
+  [diagnostics]
+    base_path = /lcrc/group/e3sm/diagnostics
+
+  [web_portal]
+    base_path = /lcrc/group/e3sm/public_html
+    base_url = https://web.lcrc.anl.gov/public/e3sm/
+
+  [parallel]
+    system = slurm
+    parallel_executable = srun
+    cores_per_node = 36
+    account = condo
+    partitions = acme-small, acme-medium, acme-large
+    qos = regular, acme_high
+```
+
+If you are on the login node of one of the following E3SM supported machines,
+you don't need to provide the machine name. It can be discovered automatically:
+
+- andes
+- aurora
+- anvil
+- chicoma-cpu
+- chrysalis
+- compy
+- dane
+- frontier
+- pm-cpu
+- polaris
+- ruby
+
+If you are on a compute node or want info about a machine you're not currently on, give the `machine` name in all lowercase.
+
+## Public Functions
+
+The following public functions are available in the top-level `mache` package:
+
+- {py:class}`mache.MachineInfo`: Class for querying machine-specific
+  configuration and capabilities.
+- {py:func}`mache.discover_machine`: Function to detect the current machine
+  name.
+
+### MachineInfo attributes
+
+- `machine`: Name of the E3SM supported machine.
+- `config`: ConfigParser object with machine-specific options.
+- `e3sm_supported`: Whether this machine supports running E3SM.
+- `compilers`: List of compilers for this machine.
+- `mpilibs`: List of MPI libraries for this machine.
+- `os`: The machine's operating system.
+- `e3sm_unified_mpi`: Which MPI type is included in the E3SM-Unified
+  environment.
+- `e3sm_unified_base`: Base path for E3SM-Unified and activation scripts.
+- `e3sm_unified_activation`: Activation script for E3SM-Unified.
+- `diagnostics_base`: Base directory for diagnostics data.
+- `web_portal_base`: Base directory for the web portal.
+- `web_portal_url`: Base URL for the web portal.
+- `username`: The current user's name.
+
+### Additional utilities
+
+- {py:func}`mache.machines.get_supported_machines()`: Returns a sorted list of
+  supported machine names.
+- {py:func}`mache.io.download_file()`: Download a file from a URL to a local
+  path.
+
+For more details on these and other features, see the full user's guide.

--- a/docs/users_guide/spack/build.md
+++ b/docs/users_guide/spack/build.md
@@ -1,0 +1,209 @@
+# Building and Using Spack Environments with `mache.spack`
+
+This page documents the main public functions in `mache.spack` for building
+and using Spack environments, as leveraged by downstream packages such as
+[compass](https://github.com/MPAS-Dev/compass),
+[polaris](https://github.com/E3SM-Project/polaris), and
+[e3sm-unified](https://github.com/E3SM-Project/e3sm-unified).
+
+## Overview
+
+The `mache.spack` module provides three primary functions for Spack
+environment management:
+
+- [`make_spack_env`](#make_spack_env): Build a Spack environment for a given
+  machine, compiler, and MPI library.
+- [`get_spack_script`](#get_spack_script): Generate a shell script snippet to
+  activate a Spack environment.
+- [`get_modules_env_vars_and_mpi_compilers`](#get_modules_env_vars_and_mpi_compilers):
+  Query modules, environment variables, and MPI compiler wrappers for a given
+  configuration.
+
+These functions are typically called from bootstrap or deployment scripts in
+downstream packages.
+
+---
+
+## `make_spack_env`
+
+```python
+from mache.spack import make_spack_env
+```
+
+**Purpose:**
+Builds a Spack environment for a specified machine, compiler, and MPI library, using a set of package specs and optional configuration.
+
+**Typical usage in downstream packages:**
+
+- Called during environment setup (e.g., in
+  [compass](https://github.com/MPAS-Dev/compass/blob/main/conda/bootstrap.py)
+  [polaris](https://github.com/E3SM-Project/polaris/blob/main/deploy/bootstrap.py)
+  or [e3sm-unified](https://github.com/E3SM-Project/e3sm-unified/blob/main/e3sm_supported_machines/deploy_e3sm_unified.py)).
+- Used to automate the creation of a Spack environment with the correct
+  packages and configuration for the target HPC system.
+
+**Example usage:**
+
+```python
+make_spack_env(
+    spack_path=spack_base,
+    env_name=spack_env,
+    spack_specs=specs,
+    compiler=compiler,
+    mpi=mpi,
+    machine=machine,
+    config_file=machine_config,
+    include_e3sm_lapack=include_e3sm_lapack,
+    include_e3sm_hdf5_netcdf=e3sm_hdf5_netcdf,
+    yaml_template=yaml_template,
+    tmpdir=tmpdir,
+    spack_mirror=spack_mirror,
+    custom_spack=custom_spack
+)
+```
+
+**Key arguments:**
+
+- `spack_path`: Path to the Spack clone to use.
+- `env_name`: Name for the Spack environment.
+- `spack_specs`: List of package specs (e.g.,
+  `["hdf5@1.12.2+mpi", "netcdf-c@4.8.1"]`).
+- `compiler`, `mpi`: Compiler and MPI library names.
+- `machine`: Machine name (optional, auto-detected if not provided).
+- `config_file`: Path to a machine config file (optional).
+- `include_e3sm_lapack`, `include_e3sm_hdf5_netcdf`: Whether to include
+  E3SM-specific LAPACK or HDF5/NetCDF packages.
+- `yaml_template`: Path to a custom Jinja2 YAML template (optional).
+- `tmpdir`: Temporary directory for builds (optional).
+- `spack_mirror`: Path to a local Spack mirror (optional).
+- `custom_spack`: Additional Spack commands to run after environment creation
+  (optional).
+
+**Behavior:**
+
+- Writes a YAML file describing the environment.
+- Generates and runs a shell script to create the Spack environment.
+- Loads any required modules and sets up environment variables as needed.
+
+---
+
+## `get_spack_script`
+
+```python
+from mache.spack import get_spack_script
+```
+
+**Purpose:**
+Generates a shell script snippet to activate a Spack environment and load any required modules or environment variables.
+
+**Typical usage in downstream packages:**
+
+- Used to generate activation scripts for users (e.g., `load_compass.sh`,
+  `load_polaris.sh`, `load_e3sm_unified.sh`).
+- Ensures that the correct modules are loaded and the Spack environment is
+  activated in the user's shell.
+
+**Example usage:**
+
+```python
+spack_script = get_spack_script(
+    spack_path=spack_base,
+    env_name=spack_env,
+    compiler=compiler,
+    mpi=mpi,
+    shell='sh',  # or 'csh'
+    machine=machine,
+    config_file=machine_config,
+    include_e3sm_lapack=include_e3sm_lapack,
+    include_e3sm_hdf5_netcdf=e3sm_hdf5_netcdf,
+    yaml_template=yaml_template
+)
+```
+
+**Returns:**
+A string containing shell commands to:
+
+- Load required modules (if any).
+- Source the Spack setup script.
+- Activate the specified Spack environment.
+- Set any additional environment variables.
+
+**Usage in activation scripts:**
+
+```bash
+# Example in a load script
+{{ spack_script }}
+```
+
+---
+
+## `get_modules_env_vars_and_mpi_compilers`
+
+```python
+from mache.spack import get_modules_env_vars_and_mpi_compilers
+```
+
+**Purpose:**
+Returns the MPI compiler wrappers and a shell snippet to load modules and set environment variables for a given machine, compiler, and MPI library.
+
+**Typical usage in downstream packages:**
+
+- Used when building or installing packages that require knowledge of the correct MPI compiler wrappers (e.g., `mpicc`, `mpicxx`, `mpifc`).
+- Used to generate build scripts for additional software (e.g., building `mpi4py`, `ilamb`, or `esmpy` in `e3sm-unified`).
+
+**Example usage:**
+
+```python
+mpicc, mpicxx, mpifc, mod_env_commands = get_modules_env_vars_and_mpi_compilers(
+    machine=machine,
+    compiler=compiler,
+    mpi=mpi,
+    shell='sh',  # or 'csh'
+    include_e3sm_lapack=include_e3sm_lapack,
+    include_e3sm_hdf5_netcdf=e3sm_hdf5_netcdf,
+    yaml_template=yaml_template
+)
+```
+
+**Returns:**
+
+- `mpicc`: Name of the MPI C compiler wrapper (e.g., `mpicc` or `cc`).
+- `mpicxx`: Name of the MPI C++ compiler wrapper (e.g., `mpicxx` or `CC`).
+- `mpifc`: Name of the MPI Fortran compiler wrapper (e.g., `mpif90` or `ftn`).
+- `mod_env_commands`: Shell commands to load modules and set environment variables.
+
+**Usage in build scripts:**
+
+```bash
+{{ mod_env_commands }}
+# Now safe to use $mpicc, $mpicxx, $mpifc for building MPI-dependent software
+```
+
+---
+
+## Example: How Downstream Packages Use These Functions
+
+- **compass**:
+  Uses `make_spack_env` to build the Spack environment, then calls `get_spack_script` to generate activation scripts for users.
+  See: [`compass' conda/bootstrap.py`](https://github.com/MPAS-Dev/compass/blob/main/conda/bootstrap.py)
+
+- **polaris**:
+  Similar usage to `compass`, with additional logic for "soft" and "libs" Spack environments.
+  See: [`polaris' deploy/bootstrap.py`](https://github.com/E3SM-Project/polaris/blob/main/deploy/bootstrap.py)
+
+- **e3sm-unified**:
+  Uses all three functions to build Spack environments, generate activation scripts, and build additional packages (e.g., `mpi4py`, `ilamb`, `esmpy`) using the correct compilers and environment.
+  See: [`e3sm-unified's e3sm_supported_machines/bootstrap.py`](https://github.com/E3SM-Project/e3sm-unified/blob/main/e3sm_supported_machines/bootstrap.py)
+
+---
+
+## Notes
+
+- These functions are intended for use in deployment scripts, not for
+  interactive use.
+- The downstream package is responsible for determining the correct arguments
+  (machine, compiler, MPI, etc.) and for integrating the generated scripts
+  into their activation workflow.
+- For more details, see the source code and examples in the downstream
+  packages listed above.
+

--- a/mache/machine_info.py
+++ b/mache/machine_info.py
@@ -255,13 +255,15 @@ class MachineInfo:
         machines = next(root.iter('config_machines'))
 
         mach = None
-        found = False
-        for mach in machines:
-            if mach.tag == 'machine' and mach.attrib['MACH'] == machine:
-                found = True
+        for machine_xml in machines:
+            if (
+                machine_xml.tag == 'machine'
+                and machine_xml.attrib['MACH'] == machine
+            ):
+                mach = machine_xml
                 break
 
-        if not found:
+        if mach is None:
             # this is not an E3SM supported machine, so we're done
             self.e3sm_supported = False
             return

--- a/mache/spack/__init__.py
+++ b/mache/spack/__init__.py
@@ -42,57 +42,58 @@ def make_spack_env(
     custom_spack='',
 ):
     """
-    Clone the ``spack_for_mache_{{version}}`` branch from
-    `E3SM's spack clone <https://github.com/E3SM-Project/spack>`_ and build
-    a spack environment for the given machine, compiler and MPI library.
+    Build a Spack environment for a given machine, compiler, and MPI library.
+
+    This function automates the creation of a Spack environment with the
+    specified packages and configuration, including support for
+    machine-specific modules and environment variables.
 
     Parameters
     ----------
     spack_path : str
-        The base path where spack has been (or will be) cloned
+        Path to the Spack clone to use.
 
     env_name : str
-        The name of the spack environment to be created or recreated
+        Name for the Spack environment.
 
     spack_specs : list of str
-        A list of spack package specs to include in the environment
+        List of Spack package specs to include in the environment.
 
     compiler : str
-        One of the E3SM supported compilers for the ``machine``
+        Compiler name.
 
     mpi : str
-        One of the E3SM supported MPI libraries for the given ``compiler`` and
-        ``machine``
+        MPI library name.
 
     machine : str, optional
-        The name of an E3SM supported machine.  If none is given, the machine
-        will be detected automatically via the host name.
+        Machine name (auto-detected if not provided).
 
     config_file : str, optional
-        The name of a config file to load config options from.
+        Path to a machine config file.
 
     include_e3sm_lapack : bool, optional
-        Whether to include the same lapack (typically from MKL) as used in E3SM
+        Whether to include E3SM-specific LAPACK.
 
     include_e3sm_hdf5_netcdf : bool, optional
-        Whether to include the same hdf5, netcdf-c, netcdf-fortran and pnetcdf
-        as used in E3SM
+        Whether to include E3SM-specific HDF5/NetCDF packages.
 
     yaml_template : str, optional
-        A jinja template for a yaml file to be used for the environment instead
-        of the mache template.  This allows you to use compilers and other
-        modules that differ from E3SM.
+        Path to a custom Jinja2 YAML template.
 
     tmpdir : str, optional
-        A temporary directory for building spack packages
+        Temporary directory for builds.
 
     spack_mirror : str, optional
-        The absolute path to a local spack mirror (e.g. for files a given
-        machine isn't allowed to download)
+        Path to a local Spack mirror.
 
     custom_spack : str, optional
-        Spack commands to run at the end of the script after the environment
-        has been installed.
+        Additional Spack commands to run after environment creation.
+
+    Behavior
+    --------
+    - Writes a YAML file describing the environment.
+    - Generates and runs a shell script to create the Spack environment.
+    - Loads required modules and sets up environment variables as needed.
     """
 
     if machine is None:
@@ -194,52 +195,49 @@ def get_spack_script(
     yaml_template=None,
 ):
     """
-    Build a snippet of a load script for the given spack environment
+    Generate a shell script snippet to activate a Spack environment.
+
+    This function returns a string containing shell commands to load required
+    modules, source the Spack setup script, activate the specified Spack
+    environment, and set any additional environment variables.
 
     Parameters
     ----------
     spack_path : str
-        The base path where spack has been (or will be) cloned
+        Path to the Spack clone to use.
 
     env_name : str
-        The name of the spack environment to be created or recreated
+        Name of the Spack environment.
 
     compiler : str
-        One of the E3SM supported compilers for the ``machine``
+        Compiler name.
 
     mpi : str
-        One of the E3SM supported MPI libraries for the given ``compiler`` and
-        ``machine``
+        MPI library name.
 
     shell : {'sh', 'csh'}
-        Which shell the script is for
+        Shell type for the script.
 
     machine : str, optional
-        The name of an E3SM supported machine.  If none is given, the machine
-        will be detected automatically via the host name.
+        Machine name (auto-detected if not provided).
 
     config_file : str, optional
-        The name of a config file to load config options from.
+        Path to a machine config file.
 
     include_e3sm_lapack : bool, optional
-        Whether to include the same lapack (typically from MKL) as used in E3SM
+        Whether to include E3SM-specific LAPACK.
 
     include_e3sm_hdf5_netcdf : bool, optional
-        Whether to include the same hdf5, netcdf-c, netcdf-fortran and pnetcdf
-        as used in E3SM
+        Whether to include E3SM-specific HDF5/NetCDF packages.
 
     yaml_template : str, optional
-        A jinja template for a yaml file to be used for the environment instead
-        of the mache template.  This allows you to use compilers and other
-        modules that differ from E3SM.
+        Path to a custom Jinja2 YAML template.
 
     Returns
     -------
     load_script : str
-        A snippet of a shell script that will load the given spack
-        environment and add any additional steps required for using the
-        environment such as setting environment variables or loading modules
-        not handled by the spack environment directly
+        Shell commands to load modules, activate the Spack environment, and
+        set up the environment for use.
     """
 
     if machine is None:
@@ -319,51 +317,49 @@ def get_modules_env_vars_and_mpi_compilers(
     yaml_template=None,
 ):
     """
-    Get the non-spack modules, environment variables and compiler names for a
-    given machine, compiler and MPI library.
+    Query modules, environment variables, and MPI compiler wrappers for a given
+    machine, compiler, and MPI library.
+
+    This function returns the names of the MPI compiler wrappers and a shell
+    snippet to load modules and set environment variables needed for building
+    or running MPI-dependent software.
 
     Parameters
     ----------
+    machine : str
+        Machine name (auto-detected if not provided).
+
     compiler : str
-        One of the E3SM supported compilers for the ``machine``
+        Compiler name.
 
     mpi : str
-        One of the E3SM supported MPI libraries for the given ``compiler`` and
-        ``machine``
-
-    machine : str, optional
-        The name of an E3SM supported machine.  If none is given, the machine
-        will be detected automatically via the host name.
+        MPI library name.
 
     shell : {'sh', 'csh'}
-        Which shell the script is for
+        Shell type for the script.
 
     include_e3sm_lapack : bool, optional
-        Whether to include the same lapack (typically from MKL) as used in E3SM
+        Whether to include E3SM-specific LAPACK.
 
     include_e3sm_hdf5_netcdf : bool, optional
-        Whether to include the same hdf5, netcdf-c, netcdf-fortran and pnetcdf
-        as used in E3SM
+        Whether to include E3SM-specific HDF5/NetCDF packages.
 
     yaml_template : str, optional
-        A jinja template for a yaml file to be used for the environment instead
-        of the mache template.  This allows you to use compilers and other
-        modules that differ from E3SM.
+        Path to a custom Jinja2 YAML template.
 
     Returns
     -------
     mpicc : str
-        The MPI c compiler for this machine
+        Name of the MPI C compiler wrapper.
 
     mpicxx : str
-        The MPI c++ compiler for this machine
+        Name of the MPI C++ compiler wrapper.
 
     mpifc : str
-        The MPI Fortran compiler for this machine
+        Name of the MPI Fortran compiler wrapper.
 
     mod_env_commands : str
-        Modules and environment variables needed to set up the compilers, MPI
-        libraries and other dependencies like NetCDF and PNetCDF
+        Shell commands to load modules and set environment variables.
     """
 
     if machine is None:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR reorganizes the `mache.spack` package by breaking the functions which are currently in `mache.spack.__init__` to three separate files, `mache.spack.env`, `mache.spack.script`, and `mache.spack.shared`. This will allow for better modularization for changes we're expecting to make to the spack template creation process.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] API documentation in the Developer's Guide (`api.md`) has any new or modified class, method and/or functions listed
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

