### PR TITLE
Use system module for cmake on Compy

### DIFF
--- a/mache/spack/templates/compy_intel_impi.yaml
+++ b/mache/spack/templates/compy_intel_impi.yaml
@@ -36,6 +36,11 @@ spack:
       - spec: bzip2@1.0.6
         prefix: /usr
       buildable: false
+    cmake:
+      externals:
+      - spec: cmake@3.26.0
+        prefix: /share/apps/cmake/3.26.0
+      buildable: false
     curl:
       externals:
       - spec: curl@7.29.0


### PR DESCRIPTION
This avoids trying to build it with spack.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

