### PR TITLE
Make tmpdir if it does not exist

### DIFF
--- a/mache/spack/env.py
+++ b/mache/spack/env.py
@@ -140,6 +140,9 @@ def make_spack_env(
     with open(str(path)) as fp:
         template = Template(fp.read())
     if tmpdir is not None:
+        if not os.path.exists(tmpdir):
+            os.mkdir(tmpdir)
+
         modules = f'{modules}\nexport TMPDIR={tmpdir}'
 
     template_args = dict(


### PR DESCRIPTION
Spack will fail with a slightly complicated error message if it can not write to the `tmpdir` passed to the `mache.spack.make_spack_env` function (i.e. if the `tmpdir` does not already exist).


