### PR TITLE
Switch pre-commit update workflow to use conda

### DIFF
--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -20,13 +20,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up Conda Environment
+        uses: mamba-org/setup-micromamba@v2
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          environment-name: pre_commit_dev
+          init-shell: bash
+          condarc: |
+            channel_priority: strict
+            channels: 
+                - conda-forge
+          create-args: >-
+            python=${{ env.PYTHON_VERSION }}
 
-      - name: Install pre-commit
-        run: pip install pre-commit
+      - name: Install pre-commit and gh
+        # permissions issue with 2.76.0
+        run: |
+          conda install -y pre-commit "gh !=2.76.0"
+          gh --version
 
       - name: Apply and commit updates
         run: |

--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -9,6 +9,7 @@ on:
     # 4. Entry: Month of the year when the process will be started [1-12]
     # 5. Entry: Weekday when the process will be started [0-6] [0 is Sunday]
     - cron: '0 8 * * 3'
+  workflow_dispatch:
 
 env:
   UP_TO_DATE: false

--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -9,6 +9,7 @@ on:
     # 4. Entry: Month of the year when the process will be started [1-12]
     # 5. Entry: Weekday when the process will be started [0-6] [0 is Sunday]
     - cron: '0 8 * * 3'
+  # Allow manual triggering of the workflow
   workflow_dispatch:
 
 env:
@@ -34,10 +35,10 @@ jobs:
             python=${{ env.PYTHON_VERSION }}
 
       - name: Install pre-commit and gh
-        # permissions issue with 2.76.0
         run: |
           eval "$(micromamba shell hook --shell bash)"
           micromamba activate pre_commit_dev
+          # permissions issue with gh 2.76.0
           conda install -y pre-commit "gh !=2.76.0"
           gh --version
 
@@ -77,7 +78,7 @@ jobs:
           --title "Update pre-commit and its dependencies" \
           --body "This PR was auto-generated to update pre-commit and its dependencies." \
           --head update-pre-commit-deps \
-          --reviewer altheaden,xylar \
+          --reviewer altheaden,xylar,andrewdnolan \
           --label ci
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -28,7 +28,7 @@ jobs:
           init-shell: bash
           condarc: |
             channel_priority: strict
-            channels: 
+            channels:
                 - conda-forge
           create-args: >-
             python=${{ env.PYTHON_VERSION }}
@@ -36,11 +36,15 @@ jobs:
       - name: Install pre-commit and gh
         # permissions issue with 2.76.0
         run: |
+          eval "$(micromamba shell hook --shell bash)"
+          micromamba activate pre_commit_dev
           conda install -y pre-commit "gh !=2.76.0"
           gh --version
 
       - name: Apply and commit updates
         run: |
+          eval "$(micromamba shell hook --shell bash)"
+          micromamba activate pre_commit_dev
           git clone https://github.com/E3SM-Project/mache.git update-pre-commit-deps
           cd update-pre-commit-deps
           # Configure git using GitHub Actions credentials.
@@ -66,6 +70,8 @@ jobs:
       - name: Make PR and add reviewers and labels
         if: ${{ env.UP_TO_DATE == 'false' }}
         run: |
+          eval "$(micromamba shell hook --shell bash)"
+          micromamba activate pre_commit_dev
           cd update-pre-commit-deps
           gh pr create \
           --title "Update pre-commit and its dependencies" \


### PR DESCRIPTION
This allows us to install `gh` ourselves and avoid a buggy version (2.76.0)

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

