### PR TITLE
Add documentation on creating releases

### DIFF
--- a/docs/developers_guide/releasing.md
+++ b/docs/developers_guide/releasing.md
@@ -1,0 +1,141 @@
+# Releasing a New Version
+
+This document describes the steps for maintainers to tag and release a new
+version of `mache`, and to update the conda-forge feedstock.
+
+## Version Bump and Dependency Updates
+
+1. **Update the Version Number**
+
+   - Manually update the version number in the following files:
+     - `mache/version.py`
+     - `conda/meta.yaml`
+
+   - Make sure the version follows [semantic versioning](https://semver.org/).
+     For release candidates, use versions like `1.31.0rc1`.
+
+2. **Check and Update Dependencies**
+
+   - Ensure that dependencies and their constraints are up-to-date and
+     consistent in:
+     - `conda/meta.yaml` (for the conda-forge release)
+     - `pyproject.toml` (for PyPI; used for sanity checks)
+     - `dev-spec.txt` (development dependencies; should be a superset)
+
+   - Use the GitHub "Compare" feature to check for dependency changes between
+     releases:
+     https://github.com/E3SM-Project/mache/compare
+
+3. **Make a PR and merge it**
+
+   - Open a PR for the version bump and dependency changes and merge once
+     approved.
+
+## Tagging and Publishing a Release Candidate
+
+4. **Tagging a Release Candidate**
+
+   - For release candidates, **do not create a GitHub release page**. Just
+     create a tag from the command line:
+
+     - Make sure your changes are merged into `main` or your own update branch
+       (e.g. `update-to-1.31.0`) and your local repo is up to date.
+
+     - Tag the release candidate (e.g., `1.31.0rc1`):
+
+       ```bash
+       git checkout main
+       git fetch --all -p
+       git reset --hard origin/main
+       git tag 1.31.0rc1
+       git push origin 1.31.0rc1
+       ```
+
+       (Replace `1.31.0rc1` with your actual version, and `main` with your
+       branch if needed.)
+
+     **Note:** This will only create a tag. No release page will be created on
+     GitHub.
+
+## Updating the conda-forge Feedstock for a Release Candidate
+
+5. **Manual Feedstock Update (Required for Release Candidates)**
+
+   - The conda-forge feedstock does **not** update automatically for release
+     candidates.
+   - You must always create a PR manually, and it must target the `dev`
+     branch of the feedstock.
+
+   Steps:
+
+   - Download the release tarball:
+
+     ```bash
+     wget https://github.com/E3SM-Project/mache/archive/refs/tags/<version>.tar.gz
+     ```
+
+   - Compute the SHA256 checksum:
+
+     ```bash
+     shasum -a 256 <version>.tar.gz
+     ```
+
+   - In the `meta.yaml` of the feedstock recipe:
+     - Set `{% set version = "<version>" %}`
+     - Set the new `sha256` value
+     - Update dependencies if needed
+
+   - Commit, push to a new branch, and open a PR **against the `dev` branch**
+     of the feedstock:
+     https://github.com/conda-forge/mache-feedstock
+
+   - Follow any instructions in the PR template and merge once approved
+
+## Releasing a Stable Version
+
+6. **Publishing a Stable Release**
+
+   - For stable releases, create a GitHub release page as follows:
+
+     - Go to https://github.com/E3SM-Project/mache/releases
+     - Click "Draft a new release"
+     - Enter a tag (e.g., `1.31.0`)
+     - Set the release title to the version prefixed with `v` (e.g., `v1.31.0`)
+     - Generate or manually write release notes
+     - Click "Publish release"
+
+## Updating the conda-forge Feedstock for a Stable Release
+
+7. **Automatic Feedstock Update (Preferred Method)**
+
+   - Wait for the `regro-cf-autotick-bot` to open a PR at:
+     https://github.com/conda-forge/mache-feedstock
+
+   - This may take several hours to a day.
+
+   - Review the PR:
+     - Confirm the version bump and dependency changes
+     - Merge once CI checks pass
+
+   **Note:** If you are impatient, you can accelerate this process by creating
+   a bot issue at: https://github.com/conda-forge/mache-feedstock/issues with
+   the subject `@conda-forge-admin, please update version`. This will open a
+   new PR with the version within a few minutes.
+
+   - If the bot PR does not appear or is too slow, you may update manually (see
+     the manual steps for release candidates above, but target the `main`
+     branch of the feedstock).
+
+## Post Release Actions
+
+8. **Verify and Announce**
+
+   - Install the package in a clean environment to test:
+
+     ```bash
+     conda create -n test-mache -c conda-forge mache=<version>
+     ```
+
+   - Optionally announce the release on relevant communication channels
+
+   - Update any documentation or release notes as needed

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,5 +22,6 @@ developers_guide/contributing
 developers_guide/adding_new_machine
 developers_guide/spack
 developers_guide/building_docs
+developers_guide/releasing
 developers_guide/api
 ```


### PR DESCRIPTION
This pull request introduces a new section in the developer documentation to guide maintainers through the process of releasing new versions of the `mache` package. It includes detailed steps for version bumping, tagging, publishing, and updating the conda-forge feedstock for both release candidates and stable releases.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] Developer's Guide has been updated if needed

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

