### PR TITLE
Add @andrewdnolan as dependabot reviewer and other minor CI changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,9 @@ updates:
     assignees:
       - "xylar"
       - "altheaden"
+      - "andrewdnolan"
     reviewers:
       - "xylar"
       - "altheaden"
+      - "andrewdnolan"
 

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -12,6 +12,8 @@ on:
 env:
   CANCEL_OTHERS: false
   PATHS_IGNORE: '["**/README.md", "**/docs/**"]'
+  # Static python version for setting up pre-commit linting
+  PYTHON_VERSION: "3.13"
 
 jobs:
   pre-commit-hooks:
@@ -30,10 +32,10 @@ jobs:
         uses: actions/checkout@v4
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
-        name: Set up Python 3.10
+        name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         id: file_changes

--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -15,6 +15,7 @@ on:
 env:
   UP_TO_DATE: false
   PYTHON_VERSION: "3.10"
+  REVIEWERS: "altheaden,xylar,andrewdnolan"
 
 jobs:
   auto-update:
@@ -78,7 +79,7 @@ jobs:
           --title "Update pre-commit and its dependencies" \
           --body "This PR was auto-generated to update pre-commit and its dependencies." \
           --head update-pre-commit-deps \
-          --reviewer altheaden,xylar,andrewdnolan \
+          --reviewer ${{ env.REVIEWERS }} \
           --label ci
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR follows #277 to do a little extra cleanup in CI workflows:
1. All static (non-matrix) versions of python used in CI have been updated to 3.13
2. `PYTHON_VERSION` is now defined in all workflow files for consistency
3. `REVIEWERS` variable is now used to list the reviewers instead of a magic string to make things more readable

I also added @andrewdnolan to the dependabot reviewers/assignees list.

@xylar Review checklist:
* [x] Add @andrewdnolan as maintainer (if he isn't already)
<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] PR description includes a summary and any relevant issue references
- [ ] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

