### PR TITLE
Implement two-token method in `pre-commit` CI

### DIFF
--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -44,7 +44,7 @@ jobs:
           # The second command will fail if no changes were present, so we ignore it
           git commit -m "Update pre-commit dependencies" || ( echo "UP_TO_DATE=true" >> "$GITHUB_ENV")
 
-      - name: Push Changes
+      - name: Push Changes with github-actions bot
         if: ${{ env.UP_TO_DATE == 'false' }}
         uses: ad-m/github-push-action@master
         with:
@@ -55,7 +55,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Make PR and add reviewers and labels
+      - name: Create PR with github-actions bot
         if: ${{ env.UP_TO_DATE == 'false' }}
         run: |
           cd update-pre-commit-deps
@@ -68,3 +68,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Add reviewers and labels with PAT
+        if: ${{ env.UP_TO_DATE == 'false' }}
+        run: |
+          cd update-pre-commit-deps
+
+          gh pr edit --add-label ci
+
+          IFS=',' read -ra reviewers <<< "${REVIEWERS}"
+          for reviewer in "${reviewers[@]}"; do
+            echo "Adding reviewer: $reviewer"
+            gh pr edit --add-reviewer "$reviewer"
+          done
+
+        env:
+          REVIEWERS: ${{ env.REVIEWERS }}
+          GH_TOKEN: ${{ secrets.GH_CLI_TOKEN }}

--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -59,6 +59,10 @@ jobs:
         if: ${{ env.UP_TO_DATE == 'false' }}
         run: |
           cd update-pre-commit-deps
+          # Close any existing PR and replace with most up-to-date changes
+          gh pr close update-pre-commit-deps \
+          --comment "This PR was closed to create a new, updated PR." || \
+          echo "No existing PR to close and replace."
           gh pr create \
           --title "Update pre-commit and its dependencies" \
           --body "This PR was auto-generated to update pre-commit and its dependencies." \

--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -21,32 +21,18 @@ jobs:
   auto-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
-      - name: Set up Conda Environment
-        uses: mamba-org/setup-micromamba@v2
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          environment-name: pre_commit_dev
-          init-shell: bash
-          condarc: |
-            channel_priority: strict
-            channels:
-                - conda-forge
-          create-args: >-
-            python=${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install pre-commit and gh
-        run: |
-          eval "$(micromamba shell hook --shell bash)"
-          micromamba activate pre_commit_dev
-          # permissions issue with gh 2.76.0
-          conda install -y pre-commit "gh !=2.76.0"
-          gh --version
+      - name: Install pre-commit
+        run: pip install pre-commit
 
       - name: Apply and commit updates
         run: |
-          eval "$(micromamba shell hook --shell bash)"
-          micromamba activate pre_commit_dev
           git clone https://github.com/E3SM-Project/mache.git update-pre-commit-deps
           cd update-pre-commit-deps
           # Configure git using GitHub Actions credentials.
@@ -72,8 +58,6 @@ jobs:
       - name: Make PR and add reviewers and labels
         if: ${{ env.UP_TO_DATE == 'false' }}
         run: |
-          eval "$(micromamba shell hook --shell bash)"
-          micromamba activate pre_commit_dev
           cd update-pre-commit-deps
           gh pr create \
           --title "Update pre-commit and its dependencies" \


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR just implements the two-token solution @xylar discovered that fixes the permissions errors we're seeing with the pre-commit update job.
<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] PR description includes a summary and any relevant issue references
- [x] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

