### PR TITLE
Remove support for python 3.9

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -61,7 +61,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     steps:
       - id: skip_check

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -14,11 +14,11 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python >=3.10
     - pip
     - setuptools >=60
   run:
-    - python >=3.9
+    - python >=3.10
     - importlib_resources
     - jinja2
     - lxml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,9 @@ authors = [
 description = "A package for providing configuration data related to E3SM supported machines."
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     # these are only for searching/browsing projects on PyPI
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
We're dropping support for python 3.9 because Conda has also dropped their support for 3.9.
<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] PR description includes a summary and any relevant issue references
- [ ] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

