### PR TITLE
Update configs for Chicoma

### DIFF
--- a/mache/spack/templates/chicoma-cpu_gnu_mpich.csh
+++ b/mache/spack/templates/chicoma-cpu_gnu_mpich.csh
@@ -40,7 +40,7 @@ module load PrgEnv-gnu/8.5.0 \
             craype-accel-host \
             craype/2.7.30 \
             cray-mpich/8.1.28 \
-            cmake/3.27.7
+            cmake/3.29.6
 {%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \

--- a/mache/spack/templates/chicoma-cpu_gnu_mpich.csh
+++ b/mache/spack/templates/chicoma-cpu_gnu_mpich.csh
@@ -1,10 +1,3 @@
-setenv http_proxy http://proxyout.lanl.gov:8080/
-setenv https_proxy http://proxyout.lanl.gov:8080/
-setenv ftp_proxy http://proxyout.lanl.gov:8080
-setenv HTTP_PROXY http://proxyout.lanl.gov:8080
-setenv HTTPS_PROXY http://proxyout.lanl.gov:8080
-setenv FTP_PROXY http://proxyout.lanl.gov:8080
-
 source /usr/share/lmod/lmod/init/csh
 
 module rm cray-hdf5-parallel \

--- a/mache/spack/templates/chicoma-cpu_gnu_mpich.sh
+++ b/mache/spack/templates/chicoma-cpu_gnu_mpich.sh
@@ -40,7 +40,7 @@ module load PrgEnv-gnu/8.5.0 \
             craype-accel-host \
             craype/2.7.30 \
             cray-mpich/8.1.28 \
-            cmake/3.27.7
+            cmake/3.29.6
 {%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \

--- a/mache/spack/templates/chicoma-cpu_gnu_mpich.sh
+++ b/mache/spack/templates/chicoma-cpu_gnu_mpich.sh
@@ -1,10 +1,3 @@
-export http_proxy=http://proxyout.lanl.gov:8080/
-export https_proxy=http://proxyout.lanl.gov:8080/
-export ftp_proxy=http://proxyout.lanl.gov:8080
-export HTTP_PROXY=http://proxyout.lanl.gov:8080
-export HTTPS_PROXY=http://proxyout.lanl.gov:8080
-export FTP_PROXY=http://proxyout.lanl.gov:8080
-
 source /usr/share/lmod/lmod/init/sh
 
 module rm cray-hdf5-parallel \

--- a/mache/spack/templates/chicoma-cpu_gnu_mpich.yaml
+++ b/mache/spack/templates/chicoma-cpu_gnu_mpich.yaml
@@ -29,8 +29,8 @@ spack:
       buildable: false
     cmake:
       externals:
-      - spec: cmake@3.27.7
-        prefix: /usr/projects/hpcsoft/tce/23-05/cos2-x86_64-cc80/packages/cmake/cmake-3.27.7/
+      - spec: cmake@3.29.6
+        prefix: /usr/projects/hpcsoft/tce/23-12/cos2-x86_64-cc80/packages/cmake/cmake-3.29.6/
       buildable: false
     curl:
       externals:

--- a/mache/spack/templates/chicoma-cpu_nvidia_mpich.csh
+++ b/mache/spack/templates/chicoma-cpu_nvidia_mpich.csh
@@ -1,10 +1,3 @@
-setenv http_proxy http://proxyout.lanl.gov:8080/
-setenv https_proxy http://proxyout.lanl.gov:8080/
-setenv ftp_proxy http://proxyout.lanl.gov:8080
-setenv HTTP_PROXY http://proxyout.lanl.gov:8080
-setenv HTTPS_PROXY http://proxyout.lanl.gov:8080
-setenv FTP_PROXY http://proxyout.lanl.gov:8080
-
 source /usr/share/lmod/lmod/init/csh
 
 
@@ -40,7 +33,7 @@ module load PrgEnv-nvidia/8.5.0 \
             craype-accel-host \
             craype/2.7.30 \
             cray-mpich/8.1.28 \
-            cmake/3.27.7
+            cmake/3.29.6
 {%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \

--- a/mache/spack/templates/chicoma-cpu_nvidia_mpich.sh
+++ b/mache/spack/templates/chicoma-cpu_nvidia_mpich.sh
@@ -1,10 +1,3 @@
-export http_proxy=http://proxyout.lanl.gov:8080/
-export https_proxy=http://proxyout.lanl.gov:8080/
-export ftp_proxy=http://proxyout.lanl.gov:8080
-export HTTP_PROXY=http://proxyout.lanl.gov:8080
-export HTTPS_PROXY=http://proxyout.lanl.gov:8080
-export FTP_PROXY=http://proxyout.lanl.gov:8080
-
 source /usr/share/lmod/lmod/init/sh
 
 module rm cray-hdf5-parallel \
@@ -39,7 +32,7 @@ module load PrgEnv-nvidia/8.5.0 \
             craype-accel-host \
             craype/2.7.30 \
             cray-mpich/8.1.28 \
-            cmake/3.27.7
+            cmake/3.29.6
 {%- if e3sm_hdf5_netcdf %}
 module load cray-hdf5-parallel/1.12.2.9 \
             cray-netcdf-hdf5parallel/4.9.0.9 \

--- a/mache/spack/templates/chicoma-cpu_nvidia_mpich.yaml
+++ b/mache/spack/templates/chicoma-cpu_nvidia_mpich.yaml
@@ -28,8 +28,8 @@ spack:
       buildable: false
     cmake:
       externals:
-      - spec: cmake@3.27.7
-        prefix: /usr/projects/hpcsoft/tce/23-05/cos2-x86_64-cc80/packages/cmake/cmake-3.27.7/
+      - spec: cmake@3.29.6
+        prefix: /usr/projects/hpcsoft/tce/23-12/cos2-x86_64-cc80/packages/cmake/cmake-3.29.6/
       buildable: false
     curl:
       externals:


### PR DESCRIPTION
Hey @xylar! I know `chicoma` isn't really a `mache` supported machine anymore, since the recharge model changes. But, Trevor has an allocation and needed a custom deployment of compass environments. 

As of April 28th, 2025 LANL no longer supports the proxy settings, and actually blocks traffic through them. So I've removed those from shell scripts. 

As of [#7230](https://github.com/E3SM-Project/E3SM/pull/7230) Chicoma has been updated to use cmake `3.29.6`, which is also update here. 

