### PR TITLE
Add option for pre_conda shell script

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 include mache/cime_machine_config/*.xml
 include mache/machines/*.cfg
+include mache/machines/pre_conda/*.sh
+include mache/machines/pre_conda/*.csh
 include mache/spack/templates/*.yaml
 include mache/spack/templates/*.template
 include mache/spack/templates/*.sh

--- a/mache/machines/pre_conda/__init__.py
+++ b/mache/machines/pre_conda/__init__.py
@@ -1,0 +1,23 @@
+from importlib.resources import read_text
+
+
+def load_pre_conda_script(machine, ext):
+    """
+    Return the contents of a shell script to prepend before loading conda
+
+    Parameters
+    ----------
+    machine : str
+        The name of the machine to load the script for.
+    ext : str
+        The file extension of the script, either 'sh' or 'csh'.
+
+    Returns
+    -------
+    str
+        The contents of the shell script.
+    """
+    try:
+        return read_text('mache.machines.pre_conda', f'{machine}.{ext}')
+    except FileNotFoundError:
+        return ''

--- a/mache/machines/pre_conda/polaris.csh
+++ b/mache/machines/pre_conda/polaris.csh
@@ -1,0 +1,1 @@
+module unload xalt

--- a/mache/machines/pre_conda/polaris.sh
+++ b/mache/machines/pre_conda/polaris.sh
@@ -1,0 +1,1 @@
+module unload xalt


### PR DESCRIPTION
This is needed for E3SM-Unified activation scripts on ALCF Polaris because its `xalt` module interferes with even the most basic `conda` operations such as `conda activate`.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [ ] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

