### PR TITLE
Make recurisve permission updates optional

### DIFF
--- a/mache/permissions.py
+++ b/mache/permissions.py
@@ -14,6 +14,7 @@ def update_permissions(  # noqa: C901
     group_writable=False,
     other_readable=True,
     workers=4,
+    recursive=True,
 ):
     """
     Update the group that a directory belongs to along with the "group" and
@@ -39,6 +40,9 @@ def update_permissions(  # noqa: C901
 
     workers : int, optional
         Number of threads to parallelize across
+
+    recursive : bool, optional
+        Whether to traverse the path(s) provided recursively
     """
 
     if isinstance(base_paths, str):
@@ -68,7 +72,7 @@ def update_permissions(  # noqa: C901
     mask = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
 
     for path in paths:
-        print(f'Updating file permissions for: {path}')
+        print(f'Updating file permissions (recursively) for: {path}')
 
         # start by updating the top level path (file or directory)
         _update(
@@ -82,6 +86,9 @@ def update_permissions(  # noqa: C901
 
         # iterate over the path recursively, only if it's a direcotry
         if path.is_file():
+            continue
+        # only iterate directories recursively if requested
+        elif not recursive:
             continue
 
         paths_iter = (p for p in Path(path).rglob('*'))


### PR DESCRIPTION
This PR makes recursively traversing the path provided (if it's a directory) optional. 

Given the current automatic recursion, as part of unified deployments we see: 
```
Updating file permissions for: /global/common/software/e3sm/anaconda_envs/test_e3sm_unified_1.12.0rc3_pm-cpu.csh                                                                          
Updating file permissions for: /global/common/software/e3sm/anaconda_envs/test_e3sm_unified_1.12.0rc3_pm-cpu.sh                                                                           
Updating file permissions for: /global/common/software/e3sm/anaconda_envs/e3smu_1_12_0rc3/pm-cpu   
```

Without the ability to toggle the recursion, we have no way to update the permissions for the:
```
 /global/common/software/e3sm/anaconda_envs/e3smu_1_12_0rc3
```
directory. We don't want to traverse that directory recursively, because some machines share a file system and there will be multiple machine entries within there. This allows us to update, without iterating over all the machine directories within there. 
<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [ ] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

