### PR TITLE
Specify cpus_per_task_flag for Aurora

### DIFF
--- a/mache/machines/aurora.cfg
+++ b/mache/machines/aurora.cfg
@@ -40,6 +40,9 @@ system = pbs
 # whether to use mpirun or srun to run a task
 parallel_executable = mpirun
 
+# the flag to `parallel_executable` to specify the number of cpus per task
+cpus_per_task_flag = --depth
+
 # cores per node on the machine (with hyperthreading)
 cores_per_node = 208
 


### PR DESCRIPTION
This is `--depth` for Aurora's `mpirun`, whereas it is commonly `-c` for other MPI implementations

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

