### PR TITLE
Fix support for non-E3SM machines

### DIFF
--- a/mache/spack/config_machines.py
+++ b/mache/spack/config_machines.py
@@ -142,7 +142,7 @@ def extract_spack_from_config_machines(
 
     Returns
     -------
-    script: str
+    script: str or None
         The generated shell script as a string.
     """
     config_filename = (
@@ -152,10 +152,7 @@ def extract_spack_from_config_machines(
 
     config = extract_machine_config(config_filename, machine, compiler, mpilib)
     if config is None:
-        raise ValueError(
-            f'No configuration found for machine={machine}, '
-            f'compiler={compiler}, mpilib={mpilib}'
-        )
+        return None
 
     script = config_to_shell_script(config, shell)
     if output is not None:

--- a/mache/spack/script.py
+++ b/mache/spack/script.py
@@ -75,11 +75,18 @@ def get_spack_script(
             f'spack env activate {env_name}'
         )
 
-    # start with the shell script from the config_machines.xml for the
-    # given machine, compiler, and mpi
-    load_script_template += '\n' + extract_spack_from_config_machines(
+    # add the shell script from the config_machines.xml for the
+    # given machine, compiler, and mpi, if any
+    spack_config_script = extract_spack_from_config_machines(
         machine, compiler, mpi, shell
     )
+    if spack_config_script is not None:
+        load_script_template += '\n' + spack_config_script
+    else:
+        print(
+            f'Warning: Could not find an E3SM supported config for '
+            f'machine={machine}, compiler={compiler}, mpi={mpi}'
+        )
 
     for shell_filename in [
         f'{machine}.{shell}',


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This pull request improves the robustness of the Spack script generation process by making the extraction of machine-specific configuration scripts more fault-tolerant. Instead of raising an exception when a configuration is missing, the code now returns `None` and issues a warning, allowing the process to continue gracefully.

**Error handling and script generation improvements:**

* Changed the return type of `extract_spack_from_config_machines` in `config_machines.py` to return `None` instead of raising a `ValueError` when no configuration is found. [[1]](diffhunk://#diff-cd48b17ef6a723a1c53c9841685b825ee18f160dadc52ac768b8b2cebcf1b4f6L145-R145) [[2]](diffhunk://#diff-cd48b17ef6a723a1c53c9841685b825ee18f160dadc52ac768b8b2cebcf1b4f6L155-R155)
* Updated `get_spack_script` in `script.py` to append the configuration script only if it is available, and to print a warning if not, instead of failing with an exception.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

