### PR TITLE
Update instructions on how to update the mache version in downstream software

### DIFF
--- a/docs/design/mache_deploy.md
+++ b/docs/design/mache_deploy.md
@@ -369,6 +369,13 @@ When a target software updates its pinned `mache` version:
 The `mache deploy update` command updates only `deploy.py` and
 `deploy/cli_spec.json`.
 
+The intended upgrade workflow is therefore:
+
+1. `./deploy.py --bootstrap-only --mache-version <new_version>`
+2. `mache deploy update --software <software> --mache-version <new_version>`
+   inside the bootstrap environment
+3. manual edit of `deploy/pins.cfg` so the pinned `mache` version matches
+
 ---
 
 ## Package Organization

--- a/docs/developers_guide/deploy.md
+++ b/docs/developers_guide/deploy.md
@@ -157,6 +157,13 @@ If you expand the set of files refreshed by `mache deploy update`, do so very
 carefully. Overwriting target-owned files is likely to destroy downstream
 customization.
 
+This also means version-bump documentation must be explicit: downstream users
+should bootstrap the new release with
+`./deploy.py --bootstrap-only --mache-version <new_version>`, run
+`mache deploy update --mache-version <new_version>` inside that bootstrap
+environment, and then update `deploy/pins.cfg` manually. Today, preserving
+target ownership of `deploy/pins.cfg` is more important than auto-rewriting it.
+
 ## The command-line contract from the maintainer side
 
 The runtime CLI surface is defined by `mache/deploy/templates/cli_spec.json.j2`

--- a/docs/users_guide/deploy.md
+++ b/docs/users_guide/deploy.md
@@ -323,6 +323,19 @@ If you pass `--bootstrap-only`, the process stops here and leaves you with an
 interactive environment that can run `mache deploy update` or `mache deploy
 run` manually.
 
+This mode is especially useful when a downstream repository wants to adopt a
+new `mache` release. In that case, bootstrap the new release explicitly so the
+temporary environment contains the new `mache` code:
+
+```bash
+./deploy.py --bootstrap-only --mache-version 2.2.0
+pixi shell -m deploy_tmp/bootstrap_pixi/pixi.toml
+mache deploy update --software polaris --mache-version 2.2.0
+```
+
+After that, update `deploy/pins.cfg` manually so `[pixi] mache = 2.2.0`
+matches the regenerated `deploy/cli_spec.json`, then exit the bootstrap shell.
+
 ### Phase 3: `mache deploy run`
 
 The runtime deploy phase is where the actual target-software environment is
@@ -421,16 +434,24 @@ version of `mache`.
 
 The usual sequence is:
 
-1. Install or bootstrap the `mache` version you want to use.
-2. Update `deploy/pins.cfg`, especially `[pixi] mache = ...`.
-3. Run:
+1. Bootstrap the new release explicitly:
 
    ```bash
+   ./deploy.py --bootstrap-only --mache-version 2.2.0
+   ```
+
+2. Enter the bootstrap environment and regenerate the generated files with the
+   same version:
+
+   ```bash
+   pixi shell -m deploy_tmp/bootstrap_pixi/pixi.toml
    mache deploy update --repo-root . --software polaris --mache-version 2.2.0
    ```
 
-4. Review the diffs in `deploy.py` and `deploy/cli_spec.json`.
-5. Adjust repository-owned files such as `deploy/config.yaml.j2` only if the
+3. Update `deploy/pins.cfg`, especially `[pixi] mache = 2.2.0`.
+4. Exit the bootstrap shell.
+5. Review the diffs in `deploy.py` and `deploy/cli_spec.json`.
+6. Adjust repository-owned files such as `deploy/config.yaml.j2` only if the
    new `mache` release expects new settings or supports new behavior.
 
 Important limitation:
@@ -438,6 +459,9 @@ Important limitation:
 - `mache deploy update` does not rewrite `deploy/pins.cfg`,
   `deploy/config.yaml.j2`, `deploy/pixi.toml.j2`, `deploy/spack.yaml.j2`, or
   `deploy/hooks.py`.
+- `./deploy.py --bootstrap-only --mache-version <new_version>` is the safest
+  way to make sure the bootstrap environment and downloaded `bootstrap.py`
+  come from the new release instead of the old pin.
 
 That is intentional. Those files are treated as target-repository owned and
 should not be replaced automatically.

--- a/mache/deploy/templates/deploy.py.j2
+++ b/mache/deploy/templates/deploy.py.j2
@@ -52,9 +52,16 @@ def main():
     _validate_fork_branch_pair(args)
 
     using_fork = getattr(args, 'mache_fork', None) is not None
+    requested_mache_version = str(
+        getattr(args, 'mache_version', '') or ''
+    ).strip()
 
     if not using_fork:
         _validate_cli_spec_matches_pins(cli_spec, pinned_mache_version)
+
+    bootstrap_mache_version = pinned_mache_version
+    if not using_fork and requested_mache_version:
+        bootstrap_mache_version = requested_mache_version
 
     # remove tmp dir
     if os.path.exists(DEPLOY_TMP_DIR):
@@ -63,7 +70,7 @@ def main():
     os.makedirs(DEPLOY_TMP_DIR)
 
     bootstrap_url = _bootstrap_url(
-        mache_version=pinned_mache_version,
+        mache_version=bootstrap_mache_version,
         mache_fork=getattr(args, 'mache_fork', None),
         mache_branch=getattr(args, 'mache_branch', None),
     )
@@ -109,11 +116,19 @@ def main():
     if args.bootstrap_only:
         pixi_exe = _get_pixi_executable(getattr(args, 'pixi', None))
         bootstrap_dir = os.path.join(DEPLOY_TMP_DIR, 'bootstrap_pixi')
+        update_cmd = f'mache deploy update --software {software}'
+        if requested_mache_version:
+            update_cmd = (
+                f'{update_cmd} --mache-version '
+                f'{shlex.quote(requested_mache_version)}'
+            )
         print(
             '\nBootstrap environment is ready. To use it interactively:\n'
             f'  pixi shell -m {bootstrap_dir}/pixi.toml\n\n'
             'Then, you can run:\n'
-            f'  mache deploy update --software {software}\n'
+            f'  {update_cmd}\n'
+            'After update, edit deploy/pins.cfg to set [pixi] mache to the '
+            'new version.\n'
             f'  exit\n'
         )
 


### PR DESCRIPTION
We make clear that downstream developers need to specify `--mache-version` when they create the bootstrap environment used to update mache.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] User's Guide has been updated if needed
- [x] Developer's Guide has been updated if needed
- [x] Documentation [builds](https://docs.e3sm.org/mache/main/developers_guide/building_docs.html) cleanly and changes look as expected
- [x] Tests pass and new features are covered by tests

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

