### PR TITLE
Fix python >=3.6 compatibility in deploy and bootstrap

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -16,6 +16,27 @@ env:
   PYTHON_VERSION: "3.14"
 
 jobs:
+  python36-compat:
+    name: python 3.6 compatibility (deploy/bootstrap)
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.6
+    timeout-minutes: 5
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          cancel_others: ${{ env.CANCEL_OTHERS }}
+          paths_ignore: ${{ env.PATHS_IGNORE }}
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        uses: actions/checkout@v6
+
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+        name: Validate deploy/bootstrap parse on Python 3.6
+        run: |
+          python -m py_compile mache/deploy/bootstrap.py mache/deploy/templates/deploy.py.j2
+
   pre-commit-hooks:
     name: lint with pre-commit
     runs-on: ubuntu-latest

--- a/mache/deploy/bootstrap.py
+++ b/mache/deploy/bootstrap.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Dict  # noqa: F401
+from typing import Dict, List  # noqa: F401
 
 CONDA_PLATFORM_MAP = {
     ('linux', 'x86_64'): 'linux-64',
@@ -793,8 +793,8 @@ def _copy_mache_pixi_toml(*, dest_pixi_toml, source_repo_dir, python_version):
 def _write_bootstrap_pixi_toml_with_local_source(
     *,
     pixi_toml_path: Path,
-    channels: list[str],
-    dependencies: dict[str, str],
+    channels: List[str],
+    dependencies: Dict[str, str],
     python_version: str,
 ) -> None:
     """Write a slim bootstrap pixi manifest for a local mache source tree.


### PR DESCRIPTION
This is needed for deployment to work on HPC (e.g. Perlmutter) where the default python is mighty old.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [ ] Tests pass and new features are covered by tests

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

