### PR TITLE
Add pre_publish and post_publish hooks

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,5 +6,8 @@ Follow the repository's automated style configuration in
 - Keep changes consistent with existing Polaris patterns.
 - For Python, follow the path-specific instructions in
   `.github/instructions/python.instructions.md`.
+- pre-commit on changed files is required before finishing; if sandboxed
+  execution fails, request escalation and do not close the task until it has
+  run or the user declines.
 - Prefer changes that pass the configured pre-commit hooks without
   adding ignores or suppressions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ These instructions apply to the whole repository unless a deeper
 
 ## Validation
 
-- Run relevant pre-commit hooks on changed files before finishing when
-  practical.
+- pre-commit on changed files is required before finishing; if sandboxed
+  execution fails, request escalation and do not close the task until it has
+  run or the user declines.
 - Prefer fixing lint and formatting issues rather than suppressing them.

--- a/docs/users_guide/deploy.md
+++ b/docs/users_guide/deploy.md
@@ -408,7 +408,10 @@ Known hook stages are:
 - `post_pixi`
 - `pre_spack`
 - `post_spack`
-- `post_deploy`
+- `pre_publish`
+- `post_publish`
+
+`post_deploy` is a deprecated alias for `pre_publish`.
 
 For debugging, each executed hook also writes a JSON snapshot to
 `deploy_tmp/hooks/<stage>_context.json`. Set `hooks.log_context: true` in

--- a/docs/users_guide/deploy.md
+++ b/docs/users_guide/deploy.md
@@ -410,6 +410,11 @@ Known hook stages are:
 - `post_spack`
 - `post_deploy`
 
+For debugging, each executed hook also writes a JSON snapshot to
+`deploy_tmp/hooks/<stage>_context.json`. Set `hooks.log_context: true` in
+`deploy/config.yaml.j2` if you want the same snapshot mirrored into the deploy
+log as well.
+
 Hooks can also drive generic pixi dependency overrides. For example, a
 downstream repository can omit `git` on a machine whose host OS is too old for
 the current conda-forge `git` builds:

--- a/mache/deploy/bootstrap.py
+++ b/mache/deploy/bootstrap.py
@@ -80,7 +80,81 @@ def check_call(
         The result of the command. When ``capture_output`` is True, the
         combined output is available as ``result.stdout``.
     """
+    _validate_check_call_kwargs(
+        capture_output=capture_output,
+        quiet=quiet,
+        popen_kwargs=popen_kwargs,
+    )
 
+    # Determine whether stdout is text or bytes (match subprocess defaults,
+    # but keep this wrapper text-friendly by default).
+    text, popen_kwargs = _normalize_popen_text_kwargs(popen_kwargs)
+    bufsize = popen_kwargs.get('bufsize', 1 if text else 0)
+    print_command = _format_check_call_message(
+        commands=commands, popen_kwargs=popen_kwargs
+    )
+
+    os.makedirs(os.path.dirname(os.path.abspath(log_filename)), exist_ok=True)
+
+    log_mode = 'a' if text else 'ab'
+    log_encoding = 'utf-8' if text else None
+
+    _write_check_call_message(
+        log_filename=log_filename,
+        text=text,
+        log_mode=log_mode,
+        log_encoding=log_encoding,
+        print_command=print_command,
+    )
+
+    if not quiet:
+        print(print_command)
+
+    base_popen_kwargs = _build_check_call_popen_kwargs(
+        commands=commands,
+        text=text,
+        bufsize=bufsize,
+        popen_kwargs=popen_kwargs,
+    )
+
+    if capture_output or not quiet:
+        process, stdout_data = _run_check_call_with_streaming(
+            commands=commands,
+            log_filename=log_filename,
+            log_mode=log_mode,
+            log_encoding=log_encoding,
+            quiet=quiet,
+            capture_output=capture_output,
+            text=text,
+            base_popen_kwargs=base_popen_kwargs,
+        )
+    else:
+        process = _run_check_call_with_log_only(
+            commands=commands,
+            log_filename=log_filename,
+            log_mode=log_mode,
+            log_encoding=log_encoding,
+            base_popen_kwargs=base_popen_kwargs,
+        )
+        stdout_data = None
+
+    result = subprocess.CompletedProcess(
+        args=commands,
+        returncode=process.returncode,
+        stdout=stdout_data,
+        stderr=None,
+    )
+
+    if check and process.returncode != 0:
+        raise subprocess.CalledProcessError(
+            process.returncode, commands, output=stdout_data
+        )
+
+    return result
+
+
+def _validate_check_call_kwargs(*, capture_output, quiet, popen_kwargs):
+    """Validate combinations of wrapper and subprocess kwargs."""
     if capture_output and (
         'stdout' in popen_kwargs
         or 'stderr' in popen_kwargs
@@ -100,41 +174,45 @@ def check_call(
             'logging/tee behavior.'
         )
 
-    # Determine whether stdout is text or bytes (match subprocess defaults,
-    # but keep this wrapper text-friendly by default).
-    text, popen_kwargs = _normalize_popen_text_kwargs(popen_kwargs)
-    bufsize = popen_kwargs.get('bufsize', 1 if text else 0)
 
-    # Echo the commands being run (like a lightweight trace) so the log is
-    # self-contained and debuggable.
-    # Keep nested quoted commands intact (e.g. bash -c '... && ...').
+def _format_check_call_message(*, commands, popen_kwargs):
+    """Format the command banner logged before subprocess execution."""
+    working_dir = popen_kwargs.get('cwd')
+    if working_dir is None:
+        working_dir = os.getcwd()
+    else:
+        working_dir = os.fspath(working_dir)
+
+    print_command = _format_check_call_command(commands)
+    return (
+        f'\n Running from:\n   {working_dir}\n Running:\n   {print_command}\n'
+    )
+
+
+def _format_check_call_command(commands):
+    """Render commands for readable logging without changing execution."""
     if isinstance(commands, str):
         command_list = _split_shell_on_andand(commands)
         if command_list:
-            print_command = '\n   '.join(command_list)
-        else:
-            print_command = commands
-    else:
-        print_command = ' '.join(shlex.quote(str(arg)) for arg in commands)
-    print_command = f'\n Running:\n   {print_command}\n'
+            return '\n   '.join(command_list)
+        return commands
 
-    os.makedirs(os.path.dirname(os.path.abspath(log_filename)), exist_ok=True)
+    return ' '.join(shlex.quote(str(arg)) for arg in commands)
 
-    log_mode = 'a' if text else 'ab'
-    log_encoding = 'utf-8' if text else None
 
-    # append to log file
+def _write_check_call_message(
+    *, log_filename, text, log_mode, log_encoding, print_command
+):
+    """Write the command banner to the log file."""
     with open(log_filename, log_mode, encoding=log_encoding) as log_file:
         if text:
             log_file.write(print_command + '\n')
         else:
             log_file.write((print_command + '\n').encode('utf-8'))
 
-    if not quiet:
-        print(print_command)
 
-    stdout_data = None
-
+def _build_check_call_popen_kwargs(*, commands, text, bufsize, popen_kwargs):
+    """Build the Popen kwargs used by check_call()."""
     base_popen_kwargs = {
         'universal_newlines': text,
         'bufsize': bufsize,
@@ -148,82 +226,115 @@ def check_call(
         )
     else:
         base_popen_kwargs.setdefault('shell', False)
-    # Allow callers to override defaults.
+
     base_popen_kwargs.update(popen_kwargs)
+    return base_popen_kwargs
 
-    if capture_output or not quiet:
-        # We'll stream stdout ourselves so we can tee to the log and terminal
-        # and optionally capture output.
-        base_popen_kwargs.setdefault('stdout', subprocess.PIPE)
-        base_popen_kwargs.setdefault('stderr', subprocess.STDOUT)
 
-        with open(log_filename, log_mode, encoding=log_encoding) as log_file:
-            process = subprocess.Popen(commands, **base_popen_kwargs)
+def _run_check_call_with_streaming(
+    *,
+    commands,
+    log_filename,
+    log_mode,
+    log_encoding,
+    quiet,
+    capture_output,
+    text,
+    base_popen_kwargs,
+):
+    """Run a subprocess while teeing output to the log and terminal."""
+    popen_kwargs = base_popen_kwargs.copy()
+    popen_kwargs.setdefault('stdout', subprocess.PIPE)
+    popen_kwargs.setdefault('stderr', subprocess.STDOUT)
 
-            assert process.stdout is not None
-            captured_chunks = []
+    with open(log_filename, log_mode, encoding=log_encoding) as log_file:
+        process = subprocess.Popen(commands, **popen_kwargs)
+        stdout_data = _stream_check_call_output(
+            process=process,
+            log_file=log_file,
+            quiet=quiet,
+            capture_output=capture_output,
+            text=text,
+        )
+        process.wait()
 
-            for chunk in process.stdout:
-                # chunk is str (text=True) or bytes (text=False)
-                if capture_output:
-                    captured_chunks.append(chunk)
+    return process, stdout_data
 
-                if text:
-                    log_file.write(chunk)
-                    log_file.flush()
-                    if not quiet:
-                        sys.stdout.write(chunk)
-                        sys.stdout.flush()
-                else:
-                    if isinstance(chunk, str):
-                        chunk_bytes = chunk.encode('utf-8')
-                    else:
-                        chunk_bytes = chunk
 
-                    log_file.write(chunk_bytes)
-                    log_file.flush()
-                    if not quiet:
-                        sys.stdout.buffer.write(chunk_bytes)
-                        sys.stdout.buffer.flush()
+def _run_check_call_with_log_only(
+    *, commands, log_filename, log_mode, log_encoding, base_popen_kwargs
+):
+    """Run a subprocess with stdout directed only to the log file."""
+    popen_kwargs = base_popen_kwargs.copy()
+    popen_kwargs.setdefault('stdout', None)
+    popen_kwargs.setdefault('stderr', subprocess.STDOUT)
 
-            process.wait()
+    with open(log_filename, log_mode, encoding=log_encoding) as log_file:
+        popen_kwargs['stdout'] = log_file
+        process = subprocess.Popen(commands, **popen_kwargs)
+        process.wait()
 
+    return process
+
+
+def _stream_check_call_output(
+    *, process, log_file, quiet, capture_output, text
+):
+    """Stream subprocess output to the log and optionally capture it."""
+    assert process.stdout is not None
+
+    captured_chunks = []
+    for chunk in process.stdout:
         if capture_output:
-            if text:
-                stdout_data = ''.join(
-                    chunk if isinstance(chunk, str) else chunk.decode('utf-8')
-                    for chunk in captured_chunks
-                )
-            else:
-                stdout_bytes = b''.join(
-                    chunk.encode('utf-8') if isinstance(chunk, str) else chunk
-                    for chunk in captured_chunks
-                )
-                # Keep this wrapper text-friendly: even when text=False, decode
-                # captured output so stdout_data remains str.
-                stdout_data = stdout_bytes.decode('utf-8', errors='replace')
-    else:
-        # Fast path: let the subprocess write directly to the log.
-        base_popen_kwargs.setdefault('stdout', None)
-        base_popen_kwargs.setdefault('stderr', subprocess.STDOUT)
-        with open(log_filename, log_mode, encoding=log_encoding) as log_file:
-            base_popen_kwargs['stdout'] = log_file
-            process = subprocess.Popen(commands, **base_popen_kwargs)
-            process.wait()
-
-    result = subprocess.CompletedProcess(
-        args=commands,
-        returncode=process.returncode,
-        stdout=stdout_data,
-        stderr=None,
-    )
-
-    if check and process.returncode != 0:
-        raise subprocess.CalledProcessError(
-            process.returncode, commands, output=stdout_data
+            captured_chunks.append(chunk)
+        _write_streamed_output(
+            chunk=chunk,
+            log_file=log_file,
+            quiet=quiet,
+            text=text,
         )
 
-    return result
+    if not capture_output:
+        return None
+
+    return _decode_captured_chunks(captured_chunks, text=text)
+
+
+def _write_streamed_output(*, chunk, log_file, quiet, text):
+    """Write one streamed subprocess chunk to the log and terminal."""
+    if text:
+        log_file.write(chunk)
+        log_file.flush()
+        if not quiet:
+            sys.stdout.write(chunk)
+            sys.stdout.flush()
+        return
+
+    chunk_bytes = _to_bytes(chunk)
+    log_file.write(chunk_bytes)
+    log_file.flush()
+    if not quiet:
+        sys.stdout.buffer.write(chunk_bytes)
+        sys.stdout.buffer.flush()
+
+
+def _decode_captured_chunks(captured_chunks, *, text):
+    """Normalize captured subprocess output to str."""
+    if text:
+        return ''.join(
+            chunk if isinstance(chunk, str) else chunk.decode('utf-8')
+            for chunk in captured_chunks
+        )
+
+    stdout_bytes = b''.join(_to_bytes(chunk) for chunk in captured_chunks)
+    return stdout_bytes.decode('utf-8', errors='replace')
+
+
+def _to_bytes(chunk):
+    """Normalize a subprocess output chunk to bytes."""
+    if isinstance(chunk, str):
+        return chunk.encode('utf-8')
+    return chunk
 
 
 def check_call_with_retries(

--- a/mache/deploy/hooks.py
+++ b/mache/deploy/hooks.py
@@ -31,15 +31,24 @@ from typing import Any, Callable
 HookCallable = Callable[['DeployContext'], Any]
 
 
-KNOWN_HOOK_STAGES: tuple[str, ...] = (
+HOOK_STAGE_ORDER: tuple[str, ...] = (
     # pixi lifecycle (preferred names)
     'pre_pixi',
     'post_pixi',
     # future spack lifecycle
     'pre_spack',
     'post_spack',
-    # always last (on success by default)
-    'post_deploy',
+    # publication lifecycle
+    'pre_publish',
+    'post_publish',
+)
+
+DEPRECATED_HOOK_STAGE_ALIASES: dict[str, str] = {
+    'post_deploy': 'pre_publish',
+}
+
+KNOWN_HOOK_STAGES: tuple[str, ...] = HOOK_STAGE_ORDER + tuple(
+    DEPRECATED_HOOK_STAGE_ALIASES
 )
 
 
@@ -179,7 +188,8 @@ def load_hooks(
                post_pixi: "post_pixi"      # optional
                pre_spack: "pre_spack"      # optional
                post_spack: "post_spack"    # optional
-               post_deploy: "post_deploy"  # optional
+               pre_publish: "pre_publish"  # optional
+               post_publish: "post_publish"  # optional
 
         If the ``hooks`` section is missing, hooks are considered disabled.
 
@@ -241,6 +251,11 @@ def load_hooks(
             )
         )
 
+    entrypoints_cfg = _normalize_entrypoints_config(
+        entrypoints_cfg=entrypoints_cfg,
+        logger=logger,
+    )
+
     repo_root_abs = os.path.abspath(os.path.expanduser(str(repo_root)))
     hooks_path = os.path.abspath(os.path.join(repo_root_abs, file_rel))
 
@@ -252,7 +267,7 @@ def load_hooks(
     module = _load_module_from_path(hooks_path=hooks_path)
 
     resolved: dict[str, HookCallable] = {}
-    for stage in KNOWN_HOOK_STAGES:
+    for stage in HOOK_STAGE_ORDER:
         func_name = entrypoints_cfg.get(stage)
         if func_name is None:
             continue
@@ -291,6 +306,55 @@ def load_hooks(
         entrypoints=resolved,
         log_context=log_context,
     )
+
+
+def _normalize_entrypoints_config(
+    *,
+    entrypoints_cfg: dict[str, Any],
+    logger: logging.Logger,
+) -> dict[str, str]:
+    normalized: dict[str, str] = {}
+
+    for stage in HOOK_STAGE_ORDER:
+        func_name = _normalize_entrypoint_name(entrypoints_cfg.get(stage))
+        if func_name is not None:
+            normalized[stage] = func_name
+
+    for alias, canonical_stage in DEPRECATED_HOOK_STAGE_ALIASES.items():
+        alias_func_name = _normalize_entrypoint_name(
+            entrypoints_cfg.get(alias)
+        )
+        if alias_func_name is None:
+            continue
+
+        if canonical_stage in normalized:
+            raise ValueError(
+                'hooks.entrypoints.'
+                f'{alias} is a deprecated alias for '
+                f'hooks.entrypoints.{canonical_stage}; '
+                'do not configure both.'
+            )
+
+        logger.warning(
+            'hooks.entrypoints.%s is deprecated; use '
+            'hooks.entrypoints.%s instead.',
+            alias,
+            canonical_stage,
+        )
+        normalized[canonical_stage] = alias_func_name
+
+    return normalized
+
+
+def _normalize_entrypoint_name(value: Any) -> str | None:
+    if value is None:
+        return None
+
+    func_name = str(value).strip()
+    if not func_name:
+        return None
+
+    return func_name
 
 
 def _load_module_from_path(*, hooks_path: str) -> ModuleType:

--- a/mache/deploy/hooks.py
+++ b/mache/deploy/hooks.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import json
 import logging
 import os
 import uuid
@@ -78,11 +79,14 @@ class HookRegistry:
 
     file_path: str | None
     entrypoints: dict[str, HookCallable]
+    log_context: bool = False
 
     def run_hook(self, stage: str, context: DeployContext) -> None:
         """Run a hook stage if it is defined.
 
         If a hook returns a mapping, it is merged into ``context.runtime``.
+        After the hook finishes, a JSON snapshot of the context is written
+        under ``deploy_tmp/hooks`` to aid debugging.
         """
 
         func = self.entrypoints.get(stage)
@@ -99,18 +103,41 @@ class HookRegistry:
             func_name,
         )
 
+        runtime_before = _json_ready(context.runtime)
+        result: Any = None
+        error: Exception | None = None
+
         try:
             result = func(context)
         except Exception as exc:  # pragma: no cover (covered indirectly)
+            error = exc
+
+        if isinstance(result, dict) and result:
+            _deep_update(context.runtime, result)
+
+        snapshot = _build_context_snapshot(
+            stage=stage,
+            context=context,
+            file_path=file_display,
+            func_name=func_name,
+            runtime_before=runtime_before,
+            hook_result=result,
+            error=error,
+        )
+        _persist_context_snapshot(
+            stage=stage,
+            context=context,
+            snapshot=snapshot,
+            log_context=self.log_context,
+        )
+
+        if error is not None:
             raise RuntimeError(
                 (
                     f'Hook failed: stage={stage} func={func_name} '
                     f'file={file_display}'
                 )
-            ) from exc
-
-        if isinstance(result, dict) and result:
-            _deep_update(context.runtime, result)
+            ) from error
 
 
 def _deep_update(dst: dict[str, Any], src: dict[str, Any]) -> None:
@@ -146,6 +173,7 @@ def load_hooks(
 
            hooks:
              file: "deploy/hooks.py"  # default
+             log_context: false        # optional
              entrypoints:
                pre_pixi: "pre_pixi"        # optional
                post_pixi: "post_pixi"      # optional
@@ -191,6 +219,10 @@ def load_hooks(
         file_rel = 'deploy/hooks.py'
     if not isinstance(file_rel, str):
         raise ValueError('hooks.file must be a string')
+
+    log_context = hooks_cfg.get('log_context', False)
+    if not isinstance(log_context, bool):
+        raise ValueError('hooks.log_context must be a boolean')
 
     entrypoints_cfg = hooks_cfg.get('entrypoints', {})
     if entrypoints_cfg is None:
@@ -254,7 +286,11 @@ def load_hooks(
             hooks_path,
         )
 
-    return HookRegistry(file_path=hooks_path, entrypoints=resolved)
+    return HookRegistry(
+        file_path=hooks_path,
+        entrypoints=resolved,
+        log_context=log_context,
+    )
 
 
 def _load_module_from_path(*, hooks_path: str) -> ModuleType:
@@ -280,3 +316,104 @@ def configparser_to_nested_dict(
     for section in cfg.sections():
         out[section] = {k: cfg.get(section, k) for k in cfg[section]}
     return out
+
+
+def _build_context_snapshot(
+    *,
+    stage: str,
+    context: DeployContext,
+    file_path: str,
+    func_name: str,
+    runtime_before: Any,
+    hook_result: Any,
+    error: Exception | None,
+) -> dict[str, Any]:
+    """Build a JSON-friendly context snapshot for hook debugging."""
+
+    snapshot: dict[str, Any] = {
+        'stage': stage,
+        'status': 'failed' if error is not None else 'ok',
+        'file': file_path,
+        'function': func_name,
+        'context': {
+            'software': context.software,
+            'machine': context.machine,
+            'repo_root': context.repo_root,
+            'deploy_dir': context.deploy_dir,
+            'work_dir': context.work_dir,
+            'config': _json_ready(context.config),
+            'pins': _json_ready(context.pins),
+            'machine_config': configparser_to_nested_dict(
+                context.machine_config
+            ),
+            'args': _json_ready(vars(context.args)),
+            'runtime_before': runtime_before,
+            'runtime_after': _json_ready(context.runtime),
+        },
+    }
+
+    if hook_result is not None:
+        snapshot['hook_result'] = _json_ready(hook_result)
+
+    if error is not None:
+        snapshot['error'] = {
+            'type': type(error).__name__,
+            'message': str(error),
+        }
+
+    return snapshot
+
+
+def _persist_context_snapshot(
+    *,
+    stage: str,
+    context: DeployContext,
+    snapshot: dict[str, Any],
+    log_context: bool,
+) -> None:
+    """Write and optionally log a hook context snapshot."""
+
+    snapshot_dir = os.path.join(context.work_dir, 'hooks')
+    snapshot_path = os.path.join(snapshot_dir, f'{stage}_context.json')
+
+    try:
+        os.makedirs(snapshot_dir, exist_ok=True)
+        with open(snapshot_path, 'w', encoding='utf-8') as handle:
+            json.dump(snapshot, handle, indent=2, sort_keys=True)
+            handle.write('\n')
+    except OSError as exc:  # pragma: no cover - unlikely filesystem error
+        context.logger.warning(
+            'Failed to write hook context snapshot stage=%s path=%s: %s',
+            stage,
+            snapshot_path,
+            exc,
+        )
+        return
+
+    context.logger.info(
+        'Wrote hook context snapshot stage=%s path=%s',
+        stage,
+        snapshot_path,
+    )
+    if log_context:
+        context.logger.info(
+            'Hook context snapshot stage=%s\n%s',
+            stage,
+            json.dumps(snapshot, indent=2, sort_keys=True),
+        )
+
+
+def _json_ready(value: Any) -> Any:
+    """Convert a value into a JSON-friendly structure."""
+
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, os.PathLike):
+        return os.fspath(value)
+    if isinstance(value, dict):
+        return {str(key): _json_ready(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, set):
+        return [_json_ready(item) for item in sorted(value, key=repr)]
+    return repr(value)

--- a/mache/deploy/run.py
+++ b/mache/deploy/run.py
@@ -107,7 +107,7 @@ def run_deploy(args: argparse.Namespace) -> None:
     work_dir = os.path.join(repo_root, 'deploy_tmp')
 
     # Hooks are optional and only run during `mache deploy run`.
-    # Behavior: `post_deploy` is invoked only on success.
+    # Publication hooks are invoked only on success.
     hook_registry = load_hooks(
         config=config,
         repo_root=repo_root,
@@ -379,7 +379,7 @@ def run_deploy(args: argparse.Namespace) -> None:
     )
     ctx.runtime['load_scripts'] = load_script_paths
 
-    hook_registry.run_hook('post_deploy', ctx)
+    hook_registry.run_hook('pre_publish', ctx)
 
     shared_artifacts = create_shared_deploy_artifacts(
         config=config,
@@ -415,6 +415,8 @@ def run_deploy(args: argparse.Namespace) -> None:
         world_readable=world_readable,
         logger=logger,
     )
+
+    hook_registry.run_hook('post_publish', ctx)
 
 
 def _get_deploy_logger(*, log_filename: str, quiet: bool) -> logging.Logger:

--- a/mache/deploy/templates/config.yaml.j2.j2
+++ b/mache/deploy/templates/config.yaml.j2.j2
@@ -304,6 +304,7 @@ jigsaw:
 #
 # hooks:
 #   file: "deploy/hooks.py"   # default
+#   log_context: false        # optional; mirror JSON snapshots into the log
 #   entrypoints:
 #     pre_pixi: "pre_pixi"        # optional
 #     post_pixi: "post_pixi"      # optional

--- a/mache/deploy/templates/config.yaml.j2.j2
+++ b/mache/deploy/templates/config.yaml.j2.j2
@@ -192,7 +192,7 @@ shared:
 
   # Optional extra shared directories/files to include in mache's
   # post-deploy permission update step. This is helpful when a downstream
-  # post_deploy hook creates additional shared artifacts that mache itself
+  # pre_publish hook creates additional shared artifacts that mache itself
   # does not create.
   managed_directories: []
   managed_files: []
@@ -310,4 +310,5 @@ jigsaw:
 #     post_pixi: "post_pixi"      # optional
 #     pre_spack: "pre_spack"      # optional
 #     post_spack: "post_spack"    # optional
-#     post_deploy: "post_deploy"  # optional
+#     pre_publish: "pre_publish"  # optional
+#     post_publish: "post_publish"  # optional

--- a/mache/deploy/templates/hooks.py.j2
+++ b/mache/deploy/templates/hooks.py.j2
@@ -12,7 +12,8 @@ To enable, add a `hooks` section like:
     entrypoints:
       pre_pixi: "pre_pixi"      # optional
       post_pixi: "post_pixi"    # optional
-      post_deploy: "post_deploy"  # optional
+      pre_publish: "pre_publish"  # optional
+      post_publish: "post_publish"  # optional
 
 After each configured hook runs, `mache` writes a JSON snapshot of the
 post-hook context to `deploy_tmp/hooks/<stage>_context.json`.
@@ -134,7 +135,13 @@ def post_pixi(ctx: DeployContext) -> None:
         f.write(f"post_pixi ran for {ctx.software}\n")
 
 
-def post_deploy(ctx: DeployContext) -> None:
-    """Run after deployment completes successfully."""
+def pre_publish(ctx: DeployContext) -> None:
+    """Run before shared publishing and deploy permission updates."""
 
-    ctx.logger.info("post_deploy hook: deployment finished")
+    ctx.logger.info("pre_publish hook: local deployment is ready")
+
+
+def post_publish(ctx: DeployContext) -> None:
+    """Run after shared publishing and deploy permission updates succeed."""
+
+    ctx.logger.info("post_publish hook: published deployment finished")

--- a/mache/deploy/templates/hooks.py.j2
+++ b/mache/deploy/templates/hooks.py.j2
@@ -8,10 +8,14 @@ To enable, add a `hooks` section like:
 
   hooks:
     file: "deploy/hooks.py"  # default
+    log_context: false       # optional; also emit JSON snapshots in the log
     entrypoints:
       pre_pixi: "pre_pixi"      # optional
       post_pixi: "post_pixi"    # optional
       post_deploy: "post_deploy"  # optional
+
+After each configured hook runs, `mache` writes a JSON snapshot of the
+post-hook context to `deploy_tmp/hooks/<stage>_context.json`.
 
 Custom CLI flags added in `deploy/custom_cli_spec.json` are available on
 `ctx.args` when their route includes `"run"`.

--- a/tests/test_deploy_bootstrap.py
+++ b/tests/test_deploy_bootstrap.py
@@ -88,6 +88,31 @@ def test_check_call_list_commands_use_direct_popen_without_shell(
     assert 'executable' not in recorded['kwargs']
 
 
+def test_check_call_logs_effective_working_directory(
+    monkeypatch, tmp_path: Path
+):
+    working_dir = tmp_path / 'workdir'
+    working_dir.mkdir()
+
+    def fake_popen(commands, **kwargs):
+        return _FakeProcess(stdout=['hello\n'])
+
+    monkeypatch.setattr(bootstrap.subprocess, 'Popen', fake_popen)
+
+    log_filename = tmp_path / 'bootstrap.log'
+    bootstrap.check_call(
+        ['pixi', 'install'],
+        str(log_filename),
+        quiet=True,
+        capture_output=True,
+        cwd=working_dir,
+    )
+
+    log_text = log_filename.read_text(encoding='utf-8')
+    assert f' Running from:\n   {working_dir}\n' in log_text
+    assert ' Running:\n   pixi install\n' in log_text
+
+
 def test_build_pixi_env_unsets_nested_pixi_variables(monkeypatch):
     monkeypatch.setenv('PIXI_PROJECT_MANIFEST', 'manifest')
     monkeypatch.setenv('PIXI_PROJECT_ROOT', 'root')

--- a/tests/test_deploy_hooks.py
+++ b/tests/test_deploy_hooks.py
@@ -1,5 +1,7 @@
 import argparse
 import configparser
+import io
+import json
 import logging
 from pathlib import Path
 
@@ -87,11 +89,37 @@ def test_load_hooks_loads_and_runs(tmp_path: Path):
     reg.run_hook('pre_pixi', ctx)
     assert ctx.runtime['project']['version'] == 'v1.2.3'
     assert ctx.runtime['pixi']['mpi'] == 'openmpi'
+    pre_pixi_context_path = (
+        tmp_path / 'deploy_tmp' / 'hooks' / 'pre_pixi_context.json'
+    )
+    pre_pixi_snapshot = json.loads(
+        pre_pixi_context_path.read_text(encoding='utf-8')
+    )
+    assert pre_pixi_snapshot['status'] == 'ok'
+    assert pre_pixi_snapshot['context']['runtime_before'] == {}
+    assert pre_pixi_snapshot['context']['runtime_after'] == {
+        'pixi': {'mpi': 'openmpi'},
+        'project': {'version': 'v1.2.3'},
+    }
+    assert pre_pixi_snapshot['hook_result'] == {
+        'pixi': {'mpi': 'openmpi'},
+        'project': {'version': 'v1.2.3'},
+    }
 
     reg.run_hook('post_pixi', ctx)
     assert (tmp_path / 'deploy_tmp' / 'ran.txt').read_text(
         encoding='utf-8'
     ) == 'ok'
+    post_pixi_snapshot = json.loads(
+        (
+            tmp_path / 'deploy_tmp' / 'hooks' / 'post_pixi_context.json'
+        ).read_text(encoding='utf-8')
+    )
+    assert post_pixi_snapshot['status'] == 'ok'
+    assert post_pixi_snapshot['context']['runtime_after'] == {
+        'pixi': {'mpi': 'openmpi'},
+        'project': {'version': 'v1.2.3'},
+    }
 
 
 def test_load_hooks_missing_entrypoint_function_raises(tmp_path: Path):
@@ -107,3 +135,89 @@ def test_load_hooks_missing_entrypoint_function_raises(tmp_path: Path):
 
     with pytest.raises(AttributeError):
         load_hooks(config=cfg, repo_root=str(tmp_path), logger=_logger('t4'))
+
+
+def test_load_hooks_logs_context_when_enabled(tmp_path: Path):
+    (tmp_path / 'deploy').mkdir(parents=True)
+    (tmp_path / 'deploy' / 'hooks.py').write_text(
+        'def pre_pixi(ctx):\n    return {"project": {"version": "v9.9.9"}}\n',
+        encoding='utf-8',
+    )
+
+    cfg = {
+        'hooks': {
+            'file': 'deploy/hooks.py',
+            'log_context': True,
+            'entrypoints': {'pre_pixi': 'pre_pixi'},
+        }
+    }
+
+    log_stream = io.StringIO()
+    logger = logging.getLogger('t5')
+    logger.setLevel(logging.INFO)
+    logger.handlers = [logging.StreamHandler(log_stream)]
+    logger.propagate = False
+
+    reg = load_hooks(config=cfg, repo_root=str(tmp_path), logger=logger)
+    ctx = DeployContext(
+        software='demo',
+        machine=None,
+        repo_root=str(tmp_path),
+        deploy_dir=str(tmp_path / 'deploy'),
+        work_dir=str(tmp_path / 'deploy_tmp'),
+        config=cfg,
+        pins={},
+        machine_config=configparser.ConfigParser(),
+        args=argparse.Namespace(),
+        logger=logger,
+    )
+
+    reg.run_hook('pre_pixi', ctx)
+
+    log_text = log_stream.getvalue()
+    assert 'Hook context snapshot stage=pre_pixi' in log_text
+    assert '"runtime_after": {' in log_text
+    assert '"version": "v9.9.9"' in log_text
+
+
+def test_load_hooks_writes_failure_snapshot(tmp_path: Path):
+    (tmp_path / 'deploy').mkdir(parents=True)
+    (tmp_path / 'deploy' / 'hooks.py').write_text(
+        'def pre_pixi(ctx):\n    raise ValueError("boom")\n',
+        encoding='utf-8',
+    )
+
+    cfg = {
+        'hooks': {
+            'file': 'deploy/hooks.py',
+            'entrypoints': {'pre_pixi': 'pre_pixi'},
+        }
+    }
+
+    logger = _logger('t6')
+    reg = load_hooks(config=cfg, repo_root=str(tmp_path), logger=logger)
+    ctx = DeployContext(
+        software='demo',
+        machine=None,
+        repo_root=str(tmp_path),
+        deploy_dir=str(tmp_path / 'deploy'),
+        work_dir=str(tmp_path / 'deploy_tmp'),
+        config=cfg,
+        pins={},
+        machine_config=configparser.ConfigParser(),
+        args=argparse.Namespace(),
+        logger=logger,
+    )
+
+    with pytest.raises(RuntimeError, match='Hook failed: stage=pre_pixi'):
+        reg.run_hook('pre_pixi', ctx)
+
+    snapshot_path = tmp_path / 'deploy_tmp' / 'hooks' / 'pre_pixi_context.json'
+    snapshot = json.loads(snapshot_path.read_text(encoding='utf-8'))
+    assert snapshot['status'] == 'failed'
+    assert snapshot['context']['runtime_before'] == {}
+    assert snapshot['context']['runtime_after'] == {}
+    assert snapshot['error'] == {
+        'type': 'ValueError',
+        'message': 'boom',
+    }

--- a/tests/test_deploy_hooks.py
+++ b/tests/test_deploy_hooks.py
@@ -221,3 +221,79 @@ def test_load_hooks_writes_failure_snapshot(tmp_path: Path):
         'type': 'ValueError',
         'message': 'boom',
     }
+
+
+def test_load_hooks_maps_post_deploy_alias_to_pre_publish(tmp_path: Path):
+    (tmp_path / 'deploy').mkdir(parents=True)
+    (tmp_path / 'deploy' / 'hooks.py').write_text(
+        "def post_deploy(ctx):\n    ctx.runtime['alias_ran'] = True\n",
+        encoding='utf-8',
+    )
+
+    logger = logging.getLogger('t7')
+    logger.setLevel(logging.INFO)
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    logger.handlers = [handler]
+    logger.propagate = False
+
+    reg = load_hooks(
+        config={
+            'hooks': {
+                'file': 'deploy/hooks.py',
+                'entrypoints': {'post_deploy': 'post_deploy'},
+            }
+        },
+        repo_root=str(tmp_path),
+        logger=logger,
+    )
+
+    assert 'pre_publish' in reg.entrypoints
+    assert 'post_deploy' not in reg.entrypoints
+    assert 'deprecated' in stream.getvalue()
+
+    ctx = DeployContext(
+        software='demo',
+        machine=None,
+        repo_root=str(tmp_path),
+        deploy_dir=str(tmp_path / 'deploy'),
+        work_dir=str(tmp_path / 'deploy_tmp'),
+        config={},
+        pins={},
+        machine_config=configparser.ConfigParser(),
+        args=argparse.Namespace(),
+        logger=logger,
+    )
+
+    reg.run_hook('pre_publish', ctx)
+    assert ctx.runtime['alias_ran'] is True
+
+
+def test_load_hooks_rejects_post_deploy_and_pre_publish_together(
+    tmp_path: Path,
+):
+    (tmp_path / 'deploy').mkdir(parents=True)
+    (tmp_path / 'deploy' / 'hooks.py').write_text(
+        'def old_name(ctx):\n'
+        '    return None\n'
+        '\n'
+        'def new_name(ctx):\n'
+        '    return None\n',
+        encoding='utf-8',
+    )
+
+    cfg = {
+        'hooks': {
+            'file': 'deploy/hooks.py',
+            'entrypoints': {
+                'post_deploy': 'old_name',
+                'pre_publish': 'new_name',
+            },
+        }
+    }
+
+    with pytest.raises(
+        ValueError,
+        match='deprecated alias for hooks.entrypoints.pre_publish',
+    ):
+        load_hooks(config=cfg, repo_root=str(tmp_path), logger=_logger('t8'))

--- a/tests/test_deploy_run.py
+++ b/tests/test_deploy_run.py
@@ -694,6 +694,184 @@ def test_resolve_toolchain_pairs_uses_machine_config_with_machine():
     assert pairs == [('gnu', 'mpich')]
 
 
+def test_run_deploy_runs_post_publish_after_publish_steps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+
+    events: list[str] = []
+
+    class _FakeHookRegistry:
+        def run_hook(self, stage, _ctx):
+            events.append(stage)
+
+    logger = deploy_run.logging.getLogger('test-run-deploy-hook-order')
+    logger.handlers = [deploy_run.logging.NullHandler()]
+    logger.propagate = False
+
+    monkeypatch.setattr(deploy_run, 'check_location', lambda: None)
+    monkeypatch.setattr(
+        deploy_run,
+        '_read_pins',
+        lambda _path: configparser.ConfigParser(),
+    )
+    monkeypatch.setattr(
+        deploy_run,
+        'get_conda_platform_and_system',
+        lambda: ('linux-64', 'linux'),
+    )
+    monkeypatch.setattr(
+        deploy_run,
+        '_render_config_yaml',
+        lambda _path, _replacements: {
+            'project': {'software': 'demo'},
+            'pixi': {
+                'install_dev_software': False,
+            },
+            'spack': {'deploy': False, 'supported': False},
+            'jigsaw': {'enabled': False},
+        },
+    )
+    monkeypatch.setattr(
+        deploy_run,
+        '_get_machine_and_config',
+        lambda **_kwargs: (None, configparser.ConfigParser()),
+    )
+    monkeypatch.setattr(
+        deploy_run,
+        '_get_deploy_logger',
+        lambda **_kwargs: logger,
+    )
+    monkeypatch.setattr(deploy_run, '_is_deploy_enabled', lambda _config: True)
+    monkeypatch.setattr(
+        deploy_run,
+        'load_hooks',
+        lambda **_kwargs: _FakeHookRegistry(),
+    )
+    monkeypatch.setattr(
+        deploy_run, '_get_pixi_executable', lambda _pixi: '/tmp/pixi'
+    )
+    monkeypatch.setattr(
+        deploy_run, '_resolve_pixi_prefix', lambda **_kwargs: '/tmp/prefix'
+    )
+    monkeypatch.setattr(
+        deploy_run, '_resolve_toolchain_pairs', lambda **_kwargs: []
+    )
+    monkeypatch.setattr(
+        deploy_run, '_resolve_software_version', lambda **_kwargs: '1.0.0'
+    )
+    monkeypatch.setattr(
+        deploy_run, '_resolve_runtime_version_cmd', lambda **_kwargs: None
+    )
+    monkeypatch.setattr(
+        deploy_run,
+        '_resolve_load_script_branch_path',
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        deploy_run,
+        '_resolve_load_script_pixi_exe',
+        lambda **_kwargs: {'mode': 'path', 'path': ''},
+    )
+    monkeypatch.setattr(
+        deploy_run, '_resolve_pixi_mpi', lambda **_kwargs: (None, None)
+    )
+    monkeypatch.setattr(
+        deploy_run, '_resolve_login_pixi_env', lambda **_kwargs: None
+    )
+    monkeypatch.setattr(
+        deploy_run, '_resolve_pixi_python_version', lambda **_kwargs: '3.12'
+    )
+    monkeypatch.setattr(
+        deploy_run, '_resolve_pixi_channels', lambda **_kwargs: ['conda-forge']
+    )
+    monkeypatch.setattr(
+        deploy_run,
+        '_resolve_pixi_extra_dependencies',
+        lambda **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        deploy_run,
+        '_resolve_pixi_omit_dependencies',
+        lambda **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        deploy_run, '_deploy_target_pixi_env', lambda **_kwargs: None
+    )
+    monkeypatch.setattr(
+        deploy_run, '_maybe_deploy_jigsaw', lambda **_kwargs: None
+    )
+    monkeypatch.setattr(
+        deploy_run, 'get_effective_spack_config', lambda **_kwargs: {}
+    )
+    monkeypatch.setattr(
+        deploy_run, 'spack_should_deploy_for_run', lambda **_kwargs: False
+    )
+    monkeypatch.setattr(
+        deploy_run, 'spack_disabled_for_run', lambda **_kwargs: False
+    )
+    monkeypatch.setattr(
+        deploy_run, 'load_existing_spack_envs', lambda **_kwargs: []
+    )
+    monkeypatch.setattr(
+        deploy_run,
+        'load_existing_spack_software_env',
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        deploy_run,
+        '_write_load_scripts',
+        lambda **_kwargs: ['load_demo.sh'],
+    )
+
+    def _fake_create_shared_deploy_artifacts(**_kwargs):
+        events.append('create_shared')
+        return SharedDeployArtifacts(managed_dirs=[], managed_files=[])
+
+    def _fake_apply_deploy_permissions(**_kwargs):
+        events.append('apply_permissions')
+
+    monkeypatch.setattr(
+        deploy_run,
+        'create_shared_deploy_artifacts',
+        _fake_create_shared_deploy_artifacts,
+    )
+    monkeypatch.setattr(
+        deploy_run,
+        '_resolve_deploy_permissions',
+        lambda **_kwargs: ('deployers', True),
+    )
+    monkeypatch.setattr(
+        deploy_run,
+        '_apply_deploy_permissions',
+        _fake_apply_deploy_permissions,
+    )
+
+    deploy_run.run_deploy(
+        argparse.Namespace(
+            quiet=True,
+            pixi='/tmp/pixi',
+            mache_version='1.0.0',
+            mache_fork=None,
+            mache_branch=None,
+            recreate=False,
+            deploy_spack=False,
+            no_spack=False,
+        )
+    )
+
+    assert events == [
+        'pre_pixi',
+        'post_pixi',
+        'pre_spack',
+        'post_spack',
+        'pre_publish',
+        'create_shared',
+        'apply_permissions',
+        'post_publish',
+    ]
+
+
 def test_resolve_deploy_permissions_prefers_runtime_then_config_then_machine():
     machine_config = configparser.ConfigParser()
     machine_config.add_section('deploy')


### PR DESCRIPTION
Deprecate post_deploy hook.

We need the `post_publish` hook for testing after shared environments are published. We may sometimes need the `pre_publish` hook for creating files on which permissions need to be changed.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] User's Guide has been updated if needed
- [ ] Documentation [builds](https://docs.e3sm.org/mache/main/developers_guide/building_docs.html) cleanly and changes look as expected
- [x] Tests pass and new features are covered by tests
- [x] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

