### PR TITLE
Handle read-only shared pixi environments

### DIFF
--- a/mache/deploy/templates/load.sh.j2
+++ b/mache/deploy/templates/load.sh.j2
@@ -114,6 +114,32 @@ export PIXI_TOML="${MACHE_DEPLOY_ACTIVE_PIXI_TOML}"
 export MACHE_DEPLOY_TARGET_LOAD_SNIPPET="${MACHE_DEPLOY_ACTIVE_TARGET_LOAD_SNIPPET}"
 export {{ software_upper }}_PIXI_MPI="${MACHE_DEPLOY_ACTIVE_PIXI_MPI}"
 
+_mache_deploy_active_env_prefix() {
+  printf '%s\n' "${MACHE_DEPLOY_ACTIVE_PIXI_PREFIX}/.pixi/envs/default"
+}
+
+_mache_deploy_require_active_env() {
+  local active_env_prefix
+  local pixi_metadata
+
+  active_env_prefix="$(_mache_deploy_active_env_prefix)"
+  pixi_metadata="${active_env_prefix}/conda-meta/pixi"
+
+  if [[ ! -d "${active_env_prefix}" ]]; then
+    echo "ERROR: deployed pixi environment not found." >&2
+    echo "  Expected: ${active_env_prefix}" >&2
+    return 1
+  fi
+
+  if [[ ! -f "${pixi_metadata}" ]]; then
+    echo "ERROR: deployed pixi environment metadata not found." >&2
+    echo "  Expected: ${pixi_metadata}" >&2
+    return 1
+  fi
+}
+
+_mache_deploy_require_active_env || return 1
+
 # Optional: verify the deployed software version matches the runtime version.
 #
 # The probe command (if set) is executed in the target pixi environment via
@@ -131,7 +157,7 @@ if [[ -n "${MACHE_DEPLOY_RUNTIME_VERSION_CMD:-}" ]]; then
   probe_output="$(
     env -u PIXI_PROJECT_MANIFEST -u PIXI_PROJECT_ROOT \
       -u PIXI_ENVIRONMENT_NAME -u PIXI_IN_SHELL \
-      "${PIXI}" run -m "${MACHE_DEPLOY_ACTIVE_PIXI_TOML}" -- \
+      "${PIXI}" run --as-is -m "${MACHE_DEPLOY_ACTIVE_PIXI_TOML}" -- \
       bash -c "${MACHE_DEPLOY_RUNTIME_VERSION_CMD}" 2>&1
   )"
   status=$?
@@ -167,9 +193,12 @@ fi
 
 echo "loading ${MACHE_DEPLOY_ACTIVE_ENV_KIND} pixi env..."
 # Use `shell-hook` (not `pixi run`) so activation applies to this shell.
+# Shared deployments can be read-only for downstream users, so avoid any
+# lockfile or environment writes during activation.
 eval "$(env -u PIXI_PROJECT_MANIFEST -u PIXI_PROJECT_ROOT \
   -u PIXI_ENVIRONMENT_NAME -u PIXI_IN_SHELL \
-  "${PIXI}" shell-hook -s bash -m "${MACHE_DEPLOY_ACTIVE_PIXI_TOML}")"
+  "${PIXI}" shell-hook --as-is -s bash -m \
+  "${MACHE_DEPLOY_ACTIVE_PIXI_TOML}")"
 echo "   pixi env loaded."
 
 # Spack activation (optional)

--- a/tests/test_deploy_run.py
+++ b/tests/test_deploy_run.py
@@ -1,5 +1,6 @@
 import argparse
 import configparser
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -463,6 +464,54 @@ def test_write_load_script_uses_user_pixi_when_configured_for_path_lookup(
     )
     assert 'command -v pixi' in script_text
     assert 'Set PIXI to a pixi executable path' in script_text
+    assert '"${PIXI}" shell-hook --as-is -s bash -m' in script_text
+    assert '"${PIXI}" run --as-is -m' in script_text
+
+
+def test_load_script_fails_before_calling_pixi_when_env_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+
+    marker = tmp_path / 'pixi-called.txt'
+    pixi_exe = tmp_path / 'bin' / 'pixi'
+    pixi_exe.parent.mkdir(parents=True, exist_ok=True)
+    pixi_exe.write_text(
+        f'#!/bin/sh\nprintf called > {marker}\nexit 99\n',
+        encoding='utf-8',
+    )
+    pixi_exe.chmod(0o755)
+
+    compute_prefix = tmp_path / 'compute'
+    compute_prefix.mkdir()
+
+    script_path = deploy_run._write_load_script(
+        prefix=str(compute_prefix),
+        login_env=None,
+        pixi_exe=str(pixi_exe),
+        branch_path=str(tmp_path),
+        load_script_pixi_exe=_explicit_load_script_pixi(str(pixi_exe)),
+        software='e3sm-unified',
+        software_version='1.0.0',
+        runtime_version_cmd=None,
+        machine=None,
+        compute_pixi_mpi='nompi',
+        toolchain_compiler=None,
+        toolchain_mpi=None,
+        spack_library_view=None,
+        spack_activation='',
+    )
+
+    result = subprocess.run(
+        ['bash', '-lc', f'source {script_path!s}'],
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 1
+    assert 'deployed pixi environment not found' in result.stderr
+    assert str(compute_prefix / '.pixi' / 'envs' / 'default') in result.stderr
+    assert not marker.exists()
 
 
 def test_write_load_script_without_login_env_skips_compute_detection(


### PR DESCRIPTION
This requires adding an `--as-is` flag to pixi calls.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] Tests pass and new features are covered by tests
- [x] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

