### PR TITLE
Make pixi environment less fragile

### DIFF
--- a/docs/developers_guide/contributing.md
+++ b/docs/developers_guide/contributing.md
@@ -36,8 +36,12 @@ activate it in your current shell. To use tools from the environment (like
     ```bash
     pixi install
     pixi shell
-    python -m pip install --no-deps --no-build-isolation -e .
     ```
+
+    The default Pixi environment includes `mache` in editable mode for local
+    development. The versioned CI environments (`py310`-`py314`) deliberately
+    omit that editable dependency and install it explicitly with
+    `pip install -e .` after `pixi install`.
 
 2. **Install pre-commit hooks:**
     ```bash

--- a/docs/developers_guide/quick_start.md
+++ b/docs/developers_guide/quick_start.md
@@ -22,16 +22,17 @@ activate it in your current shell. To use tools from the environment (like
 `python`), either run commands with `pixi run ...` or start a subshell with
 `pixi shell`.
 
-To work on `mache`, you should install the development version in an isolated environment:
+To work on `mache`, you should install the development version in an isolated
+environment:
 
 ```bash
-pixi install
 pixi shell
-python -m pip install --no-deps --no-build-isolation -e .
 ```
 
-This creates a Pixi environment based on the root `pixi.toml` and then installs
-`mache` in editable mode.
+This creates the default Pixi environment from the root `pixi.toml` and
+includes `mache` in editable mode for local development. The versioned CI
+environments (`py310`-`py314`) intentionally skip this editable install and add
+it explicitly with `pip install -e .` in CI after `pixi install`.
 
 (dev-code-styling)=
 
@@ -97,4 +98,3 @@ Make sure all tests pass before submitting a pull request.
 - Document public functions and classes.
 
 For more details, see the [contributing guide](contributing.md).
-

--- a/pixi.toml
+++ b/pixi.toml
@@ -36,7 +36,7 @@ sphinx = ">=7.0.0"
 sphinx_rtd_theme = "*"
 myst-parser = "*"
 
-[pypi-dependencies]
+[feature.dev.pypi-dependencies]
 mache = { path = ".", editable = true }
 
 # Features and environments for CI
@@ -56,6 +56,7 @@ python = "3.13.*"
 python = "3.14.*"
 
 [environments]
+default = ["dev"]
 py310 = ["py310"]
 py311 = ["py311"]
 py312 = ["py312"]


### PR DESCRIPTION
We don't need to use the automatic pip install of mache itself in CI.  We'll just use it in the default developer environment.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] Tests pass and new features are covered by tests

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

