### PR TITLE
Fix chrysalis cores per node: 64 not 128

### DIFF
--- a/mache/machines/chrysalis.cfg
+++ b/mache/machines/chrysalis.cfg
@@ -60,10 +60,10 @@ partitions = compute, debug
 parallel_executable = srun --mpi=pmi2 -l
 
 # cpu cores per node (without hyperthreading)
-cores_per_node = 128
+cores_per_node = 64
 
 # the maximum number of MPI tasks per node
-max_mpi_tasks_per_node = 128
+max_mpi_tasks_per_node = 64
 
 # CPU binding (cores or threads)
 cpu_bind = cores


### PR DESCRIPTION
The same applies to max. MPI tasks per node.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] Tests pass and new features are covered by tests
- [x] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

