### PR TITLE
Unload python or conda modules in mache.deploy load scripts

### DIFF
--- a/mache/deploy/templates/load.sh.j2
+++ b/mache/deploy/templates/load.sh.j2
@@ -201,6 +201,13 @@ eval "$(env -u PIXI_PROJECT_MANIFEST -u PIXI_PROJECT_ROOT \
   "${MACHE_DEPLOY_ACTIVE_PIXI_TOML}")"
 echo "   pixi env loaded."
 
+# Unload python/conda modules so that compiler module switches in the
+# spack or target load snippet cannot prepend a system python ahead of pixi.
+if command -v module >/dev/null 2>&1; then
+  module unload python >/dev/null 2>&1 || true
+  module unload conda >/dev/null 2>&1 || true
+fi
+
 # Spack activation (optional)
 {% if spack_activation -%}
 if [[ "${MACHE_DEPLOY_ACTIVE_ENV_KIND}" == "compute" ]]; then


### PR DESCRIPTION
This is needed so that compiler module switches in the spack or target load snippet cannot prepend a system python ahead of pixi.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] Tests pass and new features are covered by tests
- [x] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

