### PR TITLE
Fix `mache.deploy` version detection

### DIFF
--- a/conda/recipe/recipe.yaml
+++ b/conda/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: mache
-  version: "3.7.0"
+  version: "3.7.1"
 
 package:
   name: ${{ name|lower }}
@@ -51,7 +51,7 @@ tests:
 about:
   license: BSD-3-Clause
   license_file: LICENSE
-  summary: A package for providing configuration data relate to E3SM supported machines
+  summary: A package for providing configuration data related to E3SM supported machines
   homepage: https://github.com/E3SM-Project/mache
   repository: https://github.com/E3SM-Project/mache
   documentation: https://docs.e3sm.org/mache/

--- a/mache/deploy/bootstrap.py
+++ b/mache/deploy/bootstrap.py
@@ -390,6 +390,11 @@ def build_pixi_env(base_env=None):
     env = dict(os.environ if base_env is None else base_env)
     for var in PIXI_ENV_VARS_TO_UNSET:
         env.pop(var, None)
+    # Default PIXI_CACHE_DIR to /tmp to avoid noisy warnings when the home
+    # directory is on a network/parallel filesystem (common on HPC).
+    if 'PIXI_CACHE_DIR' not in env:
+        user = env.get('USER') or env.get('LOGNAME') or 'pixi'
+        env['PIXI_CACHE_DIR'] = f'/tmp/pixi-cache-{user}'
     return env
 
 

--- a/mache/deploy/run.py
+++ b/mache/deploy/run.py
@@ -1772,10 +1772,9 @@ def _pixi_install(
 
     _write_bootstrap_pixi_config(bootstrap_dir=Path(project_dir))
 
-    # Do not force cache/home locations here.
-    # - Users/site admins can set PIXI_HOME / RATTLER_CACHE_DIR /
-    #   PIXI_CACHE_DIR in shell startup or modulefiles.
-    # - Otherwise pixi uses its own defaults (typically under $HOME).
+    # build_pixi_env() sets PIXI_CACHE_DIR=/tmp/pixi-cache-<user> by default
+    # to suppress parallel-filesystem warnings on HPC. Users/admins can
+    # override it by setting PIXI_CACHE_DIR before invoking the deploy script.
     cmd = [pixi_exe, 'install']
     check_call(
         cmd,
@@ -1849,4 +1848,5 @@ def _install_software_in_dev_mode(
         cmd_install_software,
         log_filename=log_filename,
         quiet=quiet,
+        env=build_pixi_env(),
     )

--- a/mache/deploy/templates/load.sh.j2
+++ b/mache/deploy/templates/load.sh.j2
@@ -158,7 +158,7 @@ if [[ -n "${MACHE_DEPLOY_RUNTIME_VERSION_CMD:-}" ]]; then
     env -u PIXI_PROJECT_MANIFEST -u PIXI_PROJECT_ROOT \
       -u PIXI_ENVIRONMENT_NAME -u PIXI_IN_SHELL \
       "${PIXI}" run --as-is -m "${MACHE_DEPLOY_ACTIVE_PIXI_TOML}" -- \
-      bash -c "${MACHE_DEPLOY_RUNTIME_VERSION_CMD}" 2>&1
+      bash -c "${MACHE_DEPLOY_RUNTIME_VERSION_CMD}" 2>/dev/null
   )"
   status=$?
 

--- a/mache/deploy/templates/load.sh.j2
+++ b/mache/deploy/templates/load.sh.j2
@@ -114,6 +114,12 @@ export PIXI_TOML="${MACHE_DEPLOY_ACTIVE_PIXI_TOML}"
 export MACHE_DEPLOY_TARGET_LOAD_SNIPPET="${MACHE_DEPLOY_ACTIVE_TARGET_LOAD_SNIPPET}"
 export {{ software_upper }}_PIXI_MPI="${MACHE_DEPLOY_ACTIVE_PIXI_MPI}"
 
+# Default PIXI_CACHE_DIR to /tmp to suppress warnings when the home directory
+# is on a network/parallel filesystem (common on HPC machines).
+if [[ -z "${PIXI_CACHE_DIR:-}" ]]; then
+  export PIXI_CACHE_DIR="/tmp/pixi-cache-${USER}"
+fi
+
 _mache_deploy_active_env_prefix() {
   printf '%s\n' "${MACHE_DEPLOY_ACTIVE_PIXI_PREFIX}/.pixi/envs/default"
 }

--- a/mache/version.py
+++ b/mache/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (3, 7, 0)
+__version_info__ = (3, 7, 1)
 __version__ = '.'.join(str(vi) for vi in __version_info__)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This merge fixes two issues.

First, warnings were being detected instead of the actual version number in the version detection part of load scripts produced by `mache.deploy`:
```
> source load_compass_pm-cpu_gnu_mpich.sh
verifying deployed compass version...
ERROR: version mismatch for compass.
  Deployed: 2.0.0-alpha.1
  Runtime:  WARN cache for Repodata at /global/homes/h/hollyhan/.cache/rattler/cache/repodata is on a network/parallel filesystem (NFS/SMB/FUSE/BeeGFS/Lustre/GPFS/CephFS), redirected to /tmp/pixi-cache-hollyhan/repodata for this run. Set [cache.repodata] in config.toml or PIXI_CACHE_DIR to override, or [cache.netfs-redirect] = never to keep the original path.
```
The fix is to ignore stderr when running version detection.

Second, we do not want to get this warning from pixi in the first place. The fix there is to set `$PIXI_CACHE_DIR="/tmp/pixi-cache-${USER}` in various places to make sure the cache isn't on a parallel file system (exactly what pixi does after the warning it emits).

This is also good because the `~/.cache/rattler` directory was using huge amounts of space (20 GB in my case on Perlmutter).

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] Tests pass and new features are covered by tests
- [x] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

