### PR TITLE
Cache jigsaw builds across worktrees

### DIFF
--- a/docs/developers_guide/jigsaw.md
+++ b/docs/developers_guide/jigsaw.md
@@ -65,9 +65,51 @@ The build step:
 
 - Ensures `jigsaw-python` source is available, cloning it when necessary.
 - Computes a cache key from the source tree and selected Python/platform.
-- Reuses cached output under `.mache_cache/jigsaw` when valid.
+- Reuses cached output under the shared cache when valid.
 - Runs `rattler-build` through pixi or conda, depending on the selected
   backend.
+
+### Cache layout and invariants
+
+The cache is anchored at the clone that `repo_root` belongs to, found via
+`git rev-parse --git-common-dir`, so every git worktree of that clone shares
+one build. Outside a git checkout it falls back to `<repo_root>`, which is
+also where it lands for an original clone — so upgrading needs no migration.
+
+```
+<clone>/.mache_cache/jigsaw/     # shared: _get_jigsaw_shared_cache_dir()
+├── .lock                        # _jigsaw_cache_lock()
+├── tools/                       # _jigsaw_tools_dir()
+└── <cache_key>/                 # _jigsaw_slot_dir(), rattler-build output
+
+<repo_root>/.mache_cache/jigsaw/ # per-worktree: _get_jigsaw_workspace_dir()
+└── pixi-local/
+```
+
+Four invariants hold this together. Breaking any of them is a behavior
+change, not a refactor:
+
+1. **The cache key is worktree-agnostic.** It hashes the `jigsaw-python`
+   commit, its version, the Python version and the platform — nothing about
+   the containing checkout. Adding anything worktree-specific to it silently
+   un-shares the cache.
+2. **Slots are never deleted.** `channel_uri` names a slot, and that URI is
+   baked into the `pixi.toml` and `pixi.lock` of every environment deployed
+   from it, which outlive the deploy. Pruning slots would break those
+   environments long afterward, at their next solve. Slots are small; the
+   growth this permits is not worth that failure mode.
+3. **`tools/` is key-independent, and shared on purpose.** These environments
+   are the great majority of the cache's size and depend only on the platform.
+   Moving them inside a slot would restore most of the per-worktree
+   duplication that sharing the cache exists to remove.
+4. **`pixi-local` is per-`repo_root`, not per-clone.** It is a copy of the
+   source manifest, so it derives from the worktree rather than from the cache
+   key; sharing it would let one worktree clobber another's.
+
+Writes to the shared cache happen under an exclusive `flock`, since worktrees
+can deploy concurrently. The sentinel `<cache_key>/.jigsaw_cache_key` is
+written *after* the build finishes, so a slot mid-build never reads as a cache
+hit — that ordering is what lets the cache-hit path skip the lock entirely.
 
 The install step:
 
@@ -80,7 +122,8 @@ The install step:
 ### Pixi
 
 The pixi install path can either mutate a chosen manifest directly or work
-through a local copied manifest under `.mache_cache/jigsaw/pixi-local`.
+through a local copied manifest under
+`<repo_root>/.mache_cache/jigsaw/pixi-local`.
 
 The local-manifest path exists to avoid source-controlled manifest changes and
 to isolate JIGSAW from unrelated pixi environments when a project defines

--- a/docs/users_guide/jigsaw.md
+++ b/docs/users_guide/jigsaw.md
@@ -54,10 +54,10 @@ mache jigsaw install --pixi-local
 This keeps your source-controlled manifest unchanged.
 
 `--pixi-local` creates or refreshes a local manifest copy under
-`.mache_cache/jigsaw/pixi-local` and installs `jigsawpy` there. When the
-source manifest already defines pixi environments, `mache` also creates or
-reuses an isolated local `jigsaw` feature/environment to reduce solver
-conflicts.
+`<repo-root>/.mache_cache/jigsaw/pixi-local` and installs `jigsawpy` there.
+When the source manifest already defines pixi environments, `mache` also
+creates or reuses an isolated local `jigsaw` feature/environment to reduce
+solver conflicts.
 
 Useful pixi options are:
 
@@ -88,6 +88,54 @@ For most users, no additional options are required beyond:
 - `--repo-root`
 - `--quiet`
 
+## The build cache
+
+Building JIGSAW takes a couple of minutes, so `mache` caches the result and
+rebuilds only when something that affects the build changes: the
+`jigsaw-python` commit, its version, the Python version, or the platform.
+
+The cache belongs to the *clone*, not to the checkout you happen to be
+standing in. If you use a separate git worktree per branch — the workflow
+recommended by Polaris and Compass — every worktree of a clone shares one
+build, so only the first `./deploy.py` pays for it:
+
+```
+<clone>/.mache_cache/jigsaw/
+├── tools/         # environments used to run the build
+└── <cache_key>/   # one directory per distinct build
+```
+
+Builds that differ, for example because two branches pin different
+`jigsaw-python` commits, get their own directory and do not displace each
+other. `mache` never deletes these, so a build stays valid for as long as any
+environment you deployed from it. Each one is small (a few MB); the bulk of
+the cache is `tools/`, which is shared by every build.
+
+If two `./deploy.py` runs in different worktrees need the same build at the
+same time, they serialize on `<clone>/.mache_cache/jigsaw/.lock`. The second
+one waits, then finds the finished build and reuses it.
+
+To force a rebuild, delete the relevant `<cache_key>` directory. To reclaim
+everything, delete `<clone>/.mache_cache`, but note that this invalidates the
+local channel recorded in environments you have already deployed, which will
+need to be redeployed.
+
+### Reclaiming space after upgrading
+
+Before `mache` 3.8.0 the cache lived in each worktree, so a worktree-per-branch
+checkout accumulated a full copy — roughly 100 MB each — per branch. Those old
+caches are left in place rather than migrated, because environments deployed by
+older versions of `mache` still refer to them.
+
+Once you have redeployed a worktree, its old cache is safe to remove:
+
+```bash
+rm -rf <worktree>/.mache_cache/jigsaw/build
+```
+
+The first `./deploy.py` after upgrading rebuilds JIGSAW once per clone. Every
+worktree after that reuses it.
+
 ## Source requirements
 
 By default, `mache` looks for `jigsaw-python` under `./jigsaw-python` relative
@@ -107,6 +155,9 @@ If installation fails:
 1. Confirm you are in an active pixi or conda environment.
 2. Check that `jigsaw-python` is present at the expected path.
 3. Re-run with terminal output enabled and inspect the build logs under
-   `.mache_cache/jigsaw` or the deploy logs under `deploy_tmp/logs`.
+   `<clone>/.mache_cache/jigsaw/<cache_key>` or the deploy logs under
+   `deploy_tmp/logs`.
 4. For pixi, prefer `--pixi-local` if modifying the main manifest causes
    solver conflicts.
+5. If a deploy reports that it is waiting for the JIGSAW build lock and no
+   other build is running, remove `<clone>/.mache_cache/jigsaw/.lock`.

--- a/mache/jigsaw/__init__.py
+++ b/mache/jigsaw/__init__.py
@@ -48,6 +48,10 @@ PYTHON_VARIANTS = {
 JIGSAW_LOCK_TIMEOUT = 3600.0
 JIGSAW_LOCK_POLL = 2.0
 
+# Characters of the cache key used to name a build's cache directory. See
+# _jigsaw_slot_dir for why this is truncated rather than the full key.
+JIGSAW_SLOT_KEY_LEN = 16
+
 
 @dataclass(frozen=True)
 class JigsawBuildResult:
@@ -600,7 +604,12 @@ def _get_jigsaw_workspace_dir(*, repo_root: Path) -> Path:
 
 
 def _jigsaw_slot_dir(*, shared_root: Path, cache_key: str) -> Path:
-    return shared_root / cache_key
+    # The slot name is part of the build path, and rattler-build has to fit
+    # its build prefix inside conda's 255-character limit, so keep it short.
+    # The full key still lives in the slot's sentinel for exact matching;
+    # 16 hex characters (64 bits) is far more than enough to keep the
+    # handful of builds a clone ever holds from colliding.
+    return shared_root / cache_key[:JIGSAW_SLOT_KEY_LEN]
 
 
 def _jigsaw_tools_dir(*, shared_root: Path) -> Path:

--- a/mache/jigsaw/__init__.py
+++ b/mache/jigsaw/__init__.py
@@ -46,6 +46,7 @@ class JigsawBuildResult:
     cache_key: str
     cache_hit: bool
     jigsaw_version: str
+    cache_root: Path | None = None
 
 
 def deploy_jigsawpy(
@@ -103,8 +104,9 @@ def deploy_jigsawpy(
         used when possible.
     pixi_local : bool, optional
         If ``True`` and backend resolves to ``"pixi"``, install into a
-        local copied manifest under ``.mache_cache/jigsaw/pixi-local``
-        instead of mutating the source manifest directly.
+        local copied manifest under
+        ``<repo_root>/.mache_cache/jigsaw/pixi-local`` instead of mutating
+        the source manifest directly.
     conda_exe : str, optional
         Conda executable used when installing with backend ``"conda"``.
     conda_prefix : str, optional
@@ -155,6 +157,7 @@ def deploy_jigsawpy(
         pixi_manifest=pixi_manifest,
         pixi_feature=pixi_feature,
         pixi_local=pixi_local,
+        repo_root=repo_root,
         conda_exe=resolved_conda_exe,
         conda_prefix=conda_prefix,
     )
@@ -224,6 +227,7 @@ def install_jigsawpy_package(
     pixi_manifest: str | None = None,
     pixi_feature: str | None = None,
     pixi_local: bool = False,
+    repo_root: str = '.',
     conda_exe: str | None = None,
     conda_prefix: str | None = None,
 ) -> str:
@@ -252,8 +256,12 @@ def install_jigsawpy_package(
         Explicit pixi feature to target when using backend ``"pixi"``.
     pixi_local : bool, optional
         If ``True`` and backend resolves to ``"pixi"``, install into a
-        local copied manifest under ``.mache_cache/jigsaw/pixi-local``
-        instead of mutating the source manifest directly.
+        local copied manifest under
+        ``<repo_root>/.mache_cache/jigsaw/pixi-local`` instead of mutating
+        the source manifest directly.
+    repo_root : str
+        Root directory containing the target source tree, used to locate
+        the ``pixi-local`` manifest copy. Defaults to ``"."``.
     conda_exe : str, optional
         Conda executable used when backend resolves to ``"conda"``.
     conda_prefix : str, optional
@@ -285,6 +293,9 @@ def install_jigsawpy_package(
                 inferred_local_feature,
             ) = _prepare_local_pixi_manifest_copy(
                 pixi_manifest=pixi_manifest,
+                workspace_root=_get_jigsaw_workspace_dir(
+                    repo_root=Path(repo_root).resolve()
+                ),
             )
             if resolved_feature is None:
                 resolved_feature = inferred_local_feature
@@ -329,6 +340,10 @@ def build_jigsawpy_package(
     The function ensures the ``jigsaw-python`` source is available,
     computes a cache key, reuses cached output when valid, and otherwise
     runs ``rattler-build`` using the resolved backend.
+
+    The cache lives in the clone that ``repo_root`` belongs to, so every
+    git worktree of that clone shares one build. See
+    ``_get_jigsaw_shared_cache_dir``.
 
     Parameters
     ----------
@@ -381,40 +396,41 @@ def build_jigsawpy_package(
     )
 
     jigsaw_version = _get_jigsaw_version(jigsaw_python_dir)
-    output_dir = _get_jigsaw_cache_dir()
 
-    if _is_cached_jigsaw_build_valid(cache_key=cache_key):
+    shared_root = _get_jigsaw_shared_cache_dir(repo_root=repo_root_path)
+    slot_dir = _jigsaw_slot_dir(shared_root=shared_root, cache_key=cache_key)
+
+    cache_hit = _is_cached_jigsaw_build_valid(
+        slot_dir=slot_dir, cache_key=cache_key
+    )
+    if cache_hit:
         if not quiet:
-            print('Using cached JIGSAW build')
-        return JigsawBuildResult(
-            channel_uri=_get_local_channel_uri(output_dir=output_dir),
-            channel_dir=output_dir,
-            cache_key=cache_key,
-            cache_hit=True,
+            print(f'Using cached JIGSAW build: {slot_dir}')
+    else:
+        selected_backend = detect_install_backend(backend=backend)
+
+        _build_external_jigsaw(
+            backend=selected_backend,
+            pixi_exe=pixi_exe,
+            conda_exe=conda_exe,
+            jigsaw_python_dir=jigsaw_python_dir,
+            python_version=python_version,
             jigsaw_version=jigsaw_version,
+            log_filename=log_filename,
+            quiet=quiet,
+            slot_dir=slot_dir,
+            tools_dir=_jigsaw_tools_dir(shared_root=shared_root),
         )
 
-    selected_backend = detect_install_backend(backend=backend)
-
-    _build_external_jigsaw(
-        backend=selected_backend,
-        pixi_exe=pixi_exe,
-        conda_exe=conda_exe,
-        jigsaw_python_dir=jigsaw_python_dir,
-        python_version=python_version,
-        jigsaw_version=jigsaw_version,
-        log_filename=log_filename,
-        quiet=quiet,
-    )
-
-    _write_jigsaw_cache_key(cache_key=cache_key)
+        _write_jigsaw_cache_key(slot_dir=slot_dir, cache_key=cache_key)
 
     return JigsawBuildResult(
-        channel_uri=_get_local_channel_uri(output_dir=output_dir),
-        channel_dir=output_dir,
+        channel_uri=_get_local_channel_uri(output_dir=slot_dir),
+        channel_dir=slot_dir,
         cache_key=cache_key,
-        cache_hit=False,
+        cache_hit=cache_hit,
         jigsaw_version=jigsaw_version,
+        cache_root=shared_root,
     )
 
 
@@ -512,8 +528,8 @@ def _compute_jigsaw_cache_key(
     return digest.hexdigest()
 
 
-def _cache_key_path() -> Path:
-    return _get_jigsaw_cache_dir() / '.jigsaw_cache_key'
+def _cache_key_path(*, slot_dir: Path) -> Path:
+    return slot_dir / '.jigsaw_cache_key'
 
 
 def _find_git_clone_root(repo_root: Path) -> Path | None:
@@ -567,37 +583,40 @@ def _jigsaw_slot_dir(*, shared_root: Path, cache_key: str) -> Path:
 
 
 def _jigsaw_tools_dir(*, shared_root: Path) -> Path:
+    """
+    Tool environments that every build shares.
+
+    These depend on the platform rather than on the cache key, so they are
+    deliberately kept outside the per-key slots: they are by far the
+    largest thing in the cache, and duplicating them per key would undo
+    most of the benefit of sharing it.
+    """
     return shared_root / 'tools'
 
 
-def _get_jigsaw_cache_dir() -> Path:
-    return Path('.mache_cache/jigsaw').resolve()
-
-
-def _read_jigsaw_cache_key() -> str | None:
-    cache_path = _cache_key_path()
+def _read_jigsaw_cache_key(*, slot_dir: Path) -> str | None:
+    cache_path = _cache_key_path(slot_dir=slot_dir)
     if not cache_path.is_file():
         return None
     return cache_path.read_text(encoding='utf-8').strip() or None
 
 
-def _write_jigsaw_cache_key(*, cache_key: str) -> None:
-    cache_path = _cache_key_path()
+def _write_jigsaw_cache_key(*, slot_dir: Path, cache_key: str) -> None:
+    cache_path = _cache_key_path(slot_dir=slot_dir)
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     cache_path.write_text(f'{cache_key}\n', encoding='utf-8')
 
 
-def _is_cached_jigsaw_build_valid(*, cache_key: str) -> bool:
-    cached_key = _read_jigsaw_cache_key()
+def _is_cached_jigsaw_build_valid(*, slot_dir: Path, cache_key: str) -> bool:
+    cached_key = _read_jigsaw_cache_key(slot_dir=slot_dir)
     if cached_key != cache_key:
         return False
 
-    output_dir = _get_jigsaw_cache_dir()
-    if not output_dir.is_dir():
+    if not slot_dir.is_dir():
         return False
 
     platform_name, _ = _get_conda_platform_and_system()
-    repodata = output_dir / platform_name / 'repodata.json'
+    repodata = slot_dir / platform_name / 'repodata.json'
     return repodata.is_file()
 
 
@@ -698,6 +717,8 @@ def _build_external_jigsaw(
     jigsaw_python_dir: Path,
     log_filename: str,
     quiet: bool,
+    slot_dir: Path,
+    tools_dir: Path,
 ) -> None:
     print('Building JIGSAW')
 
@@ -705,7 +726,7 @@ def _build_external_jigsaw(
         raise ValueError(f'Unsupported python version: {python_version}')
 
     python_variant = PYTHON_VARIANTS.get(python_version)
-    build_root = (_get_jigsaw_cache_dir() / 'build').resolve()
+    build_root = (slot_dir / 'build').resolve()
     recipe_dir = build_root / 'recipe'
     variant_dir = build_root / 'variant'
     recipe_dir.mkdir(parents=True, exist_ok=True)
@@ -749,14 +770,14 @@ def _build_external_jigsaw(
     with open(variant_file, 'w', encoding='utf-8') as file_handle:
         file_handle.write(variant)
 
-    output_dir = _get_jigsaw_cache_dir()
+    output_dir = slot_dir
     output_dir.mkdir(parents=True, exist_ok=True)
 
     if backend == 'pixi':
         if not pixi_exe:
             raise ValueError('pixi_exe is required when backend="pixi".')
         pixi_toml = _write_build_manifest(
-            build_root=build_root,
+            build_root=tools_dir,
             platform_name=platform_name,
         )
         command = (
@@ -772,6 +793,7 @@ def _build_external_jigsaw(
             conda_exe=conda_exe,
             log_filename=log_filename,
             quiet=quiet,
+            tools_dir=tools_dir,
         )
         command = (
             f'{conda_runner} rattler-build build '
@@ -792,9 +814,10 @@ def _ensure_conda_rattler_build_env(
     conda_exe: str | None,
     log_filename: str,
     quiet: bool,
+    tools_dir: Path,
 ) -> str:
     conda = _resolve_conda_executable(conda_exe)
-    tool_prefix = _get_jigsaw_cache_dir() / 'build' / 'conda-rattler-build'
+    tool_prefix = tools_dir / 'conda-rattler-build'
     if not (tool_prefix / 'conda-meta').is_dir():
         tool_prefix.parent.mkdir(parents=True, exist_ok=True)
         command = (
@@ -843,12 +866,14 @@ def _resolve_pixi_manifest(pixi_manifest: str | None) -> str:
 
 
 def _prepare_local_pixi_manifest_copy(
-    *, pixi_manifest: str | None
+    *, pixi_manifest: str | None, workspace_root: Path
 ) -> tuple[str, str | None]:
     source_manifest = _resolve_pixi_manifest(pixi_manifest)
     source_path = Path(source_manifest)
 
-    local_dir = _get_jigsaw_cache_dir() / 'pixi-local'
+    # This copy derives from the source manifest, which is per-worktree,
+    # rather than from the cache key, so it stays out of the shared cache.
+    local_dir = workspace_root / 'pixi-local'
     local_dir.mkdir(parents=True, exist_ok=True)
 
     # pixi recognizes these manifest basenames.

--- a/mache/jigsaw/__init__.py
+++ b/mache/jigsaw/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import os
 import platform
@@ -8,6 +9,9 @@ import shlex
 import shutil
 import subprocess
 import sys
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
@@ -37,6 +41,12 @@ PYTHON_VARIANTS = {
     '3.13': '3.13.* *_cp313',
     '3.14': '3.14.* *_cp314',
 }
+
+# How long to wait for another process to finish building before giving up,
+# and how often to re-check while waiting, in seconds. A build takes a
+# couple of minutes; the timeout only needs to be comfortably longer.
+JIGSAW_LOCK_TIMEOUT = 3600.0
+JIGSAW_LOCK_POLL = 2.0
 
 
 @dataclass(frozen=True)
@@ -409,20 +419,31 @@ def build_jigsawpy_package(
     else:
         selected_backend = detect_install_backend(backend=backend)
 
-        _build_external_jigsaw(
-            backend=selected_backend,
-            pixi_exe=pixi_exe,
-            conda_exe=conda_exe,
-            jigsaw_python_dir=jigsaw_python_dir,
-            python_version=python_version,
-            jigsaw_version=jigsaw_version,
-            log_filename=log_filename,
-            quiet=quiet,
-            slot_dir=slot_dir,
-            tools_dir=_jigsaw_tools_dir(shared_root=shared_root),
-        )
+        with _jigsaw_cache_lock(shared_root=shared_root, quiet=quiet):
+            # Another worktree may have built this while we waited.
+            cache_hit = _is_cached_jigsaw_build_valid(
+                slot_dir=slot_dir, cache_key=cache_key
+            )
+            if cache_hit:
+                if not quiet:
+                    print(f'Using cached JIGSAW build: {slot_dir}')
+            else:
+                _build_external_jigsaw(
+                    backend=selected_backend,
+                    pixi_exe=pixi_exe,
+                    conda_exe=conda_exe,
+                    jigsaw_python_dir=jigsaw_python_dir,
+                    python_version=python_version,
+                    jigsaw_version=jigsaw_version,
+                    log_filename=log_filename,
+                    quiet=quiet,
+                    slot_dir=slot_dir,
+                    tools_dir=_jigsaw_tools_dir(shared_root=shared_root),
+                )
 
-        _write_jigsaw_cache_key(slot_dir=slot_dir, cache_key=cache_key)
+                # Written last: the sentinel is what marks the slot usable,
+                # so a slot mid-build never reads as a cache hit.
+                _write_jigsaw_cache_key(slot_dir=slot_dir, cache_key=cache_key)
 
     return JigsawBuildResult(
         channel_uri=_get_local_channel_uri(output_dir=slot_dir),
@@ -592,6 +613,58 @@ def _jigsaw_tools_dir(*, shared_root: Path) -> Path:
     most of the benefit of sharing it.
     """
     return shared_root / 'tools'
+
+
+@contextmanager
+def _jigsaw_cache_lock(*, shared_root: Path, quiet: bool) -> Iterator[bool]:
+    """
+    Serialize builds that share a cache, yielding whether the lock is held.
+
+    Worktrees of one clone share a cache directory, so two deploys running
+    at once would otherwise write the same build tree. On a filesystem
+    without working ``flock`` we warn and proceed anyway: that is no worse
+    than the unlocked behavior this replaces, and failing the deploy
+    outright would be.
+    """
+    lock_path = shared_root / '.lock'
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    held = False
+    try:
+        deadline = time.monotonic() + JIGSAW_LOCK_TIMEOUT
+        announced = False
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                held = True
+                break
+            except BlockingIOError:
+                if not announced:
+                    if not quiet:
+                        print(
+                            'Waiting for another mache JIGSAW build to '
+                            f'finish (lock: {lock_path})'
+                        )
+                    announced = True
+                if time.monotonic() >= deadline:
+                    raise RuntimeError(
+                        f'Timed out after {JIGSAW_LOCK_TIMEOUT:.0f}s waiting '
+                        f'for the JIGSAW build lock at {lock_path}. If no '
+                        'build is running, it is safe to delete that file.'
+                    ) from None
+                time.sleep(JIGSAW_LOCK_POLL)
+            except OSError as e:
+                # e.g. NFS without lockd, or a mount with -o nolock
+                print(
+                    f'Warning: could not lock {lock_path} ({e.strerror}); '
+                    'proceeding without a build lock.'
+                )
+                break
+
+        yield held
+    finally:
+        # Closing the descriptor releases the lock, if we hold it.
+        os.close(fd)
 
 
 def _read_jigsaw_cache_key(*, slot_dir: Path) -> str | None:

--- a/mache/jigsaw/__init__.py
+++ b/mache/jigsaw/__init__.py
@@ -6,6 +6,7 @@ import platform
 import re
 import shlex
 import shutil
+import subprocess
 import sys
 from dataclasses import dataclass
 from importlib import resources
@@ -466,39 +467,25 @@ def _get_jigsaw_version(jigsaw_python_dir: Path) -> str:
     return version
 
 
+def _run_git(args: list[str], *, cwd: Path) -> str | None:
+    try:
+        output = subprocess.check_output(
+            ['git', '-C', str(cwd), *args],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return output.strip() or None
+
+
 def _get_git_head(repo_dir: Path) -> str:
-    git_dir = repo_dir / '.git'
-    if git_dir.is_dir():
-        git_root = git_dir
-    elif git_dir.is_file():
-        git_file = git_dir.read_text(encoding='utf-8').strip()
-        if not git_file.startswith('gitdir:'):
-            raise RuntimeError(
-                f'Unexpected .git file format in {repo_dir}: {git_file!r}'
-            )
-        gitdir_path = git_file.split(':', 1)[1].strip()
-        git_root = (repo_dir / gitdir_path).resolve()
-    else:
+    head = _run_git(['rev-parse', 'HEAD'], cwd=repo_dir)
+    if head is None:
         raise RuntimeError(
-            f'Expected git checkout at {repo_dir} but .git not found.'
+            f'Expected git checkout at {repo_dir} but could not read HEAD.'
         )
-
-    head_file = git_root / 'HEAD'
-    if not head_file.is_file():
-        raise RuntimeError(
-            f'Expected git checkout at {repo_dir} but HEAD not found in '
-            f'{git_root}.'
-        )
-
-    head_ref = head_file.read_text(encoding='utf-8').strip()
-    if head_ref.startswith('ref:'):
-        ref_path = head_ref.split(' ', 1)[1].strip()
-        ref_file = git_root / ref_path
-        if not ref_file.is_file():
-            raise RuntimeError(f'Git ref {ref_path} not found in {git_root}.')
-        return ref_file.read_text(encoding='utf-8').strip()
-
-    return head_ref
+    return head
 
 
 def _compute_jigsaw_cache_key(

--- a/mache/jigsaw/__init__.py
+++ b/mache/jigsaw/__init__.py
@@ -516,6 +516,60 @@ def _cache_key_path() -> Path:
     return _get_jigsaw_cache_dir() / '.jigsaw_cache_key'
 
 
+def _find_git_clone_root(repo_root: Path) -> Path | None:
+    """
+    Find the original clone that ``repo_root`` belongs to, or None if
+    ``repo_root`` is not itself the top of a git work tree.
+
+    For a linked worktree this is the clone the worktree was created from,
+    which is what lets every worktree share one build cache.
+    """
+    repo_root = repo_root.resolve()
+    toplevel = _run_git(['rev-parse', '--show-toplevel'], cwd=repo_root)
+    if toplevel is None or Path(toplevel).resolve() != repo_root:
+        # repo_root is not a work-tree top, so a surrounding repository is
+        # some unrelated checkout we must not anchor to.
+        return None
+
+    common_dir = _run_git(['rev-parse', '--git-common-dir'], cwd=repo_root)
+    if common_dir is None:
+        return None
+
+    # --git-common-dir is relative ('.git') for an original clone but
+    # absolute for a linked worktree.
+    common_path = Path(common_dir)
+    if not common_path.is_absolute():
+        common_path = repo_root / common_path
+
+    return common_path.resolve().parent
+
+
+def _get_jigsaw_shared_cache_dir(*, repo_root: Path) -> Path:
+    """
+    The build cache shared by every worktree of ``repo_root``'s clone.
+    """
+    clone_root = _find_git_clone_root(repo_root)
+    if clone_root is None:
+        return _get_jigsaw_workspace_dir(repo_root=repo_root)
+    return (clone_root / '.mache_cache' / 'jigsaw').resolve()
+
+
+def _get_jigsaw_workspace_dir(*, repo_root: Path) -> Path:
+    """
+    Per-worktree scratch space, for things derived from this checkout
+    rather than from the cache key.
+    """
+    return (repo_root / '.mache_cache' / 'jigsaw').resolve()
+
+
+def _jigsaw_slot_dir(*, shared_root: Path, cache_key: str) -> Path:
+    return shared_root / cache_key
+
+
+def _jigsaw_tools_dir(*, shared_root: Path) -> Path:
+    return shared_root / 'tools'
+
+
 def _get_jigsaw_cache_dir() -> Path:
     return Path('.mache_cache/jigsaw').resolve()
 

--- a/tests/test_jigsaw.py
+++ b/tests/test_jigsaw.py
@@ -108,7 +108,9 @@ def test_deploy_jigsawpy_in_conda_environment(monkeypatch, tmp_path: Path):
     assert command.endswith('jigsawpy=0.0.1')
 
 
-def test_build_jigsawpy_package_conda_backend_without_pixi(monkeypatch):
+def test_build_jigsawpy_package_conda_backend_without_pixi(
+    monkeypatch, tmp_path: Path
+):
     """Verify conda build backend works without a pixi executable."""
 
     recorded = {}
@@ -142,7 +144,7 @@ def test_build_jigsawpy_package_conda_backend_without_pixi(monkeypatch):
     result = jigsaw.build_jigsawpy_package(
         python_version='3.14',
         jigsaw_python_path='jigsaw-python',
-        repo_root='.',
+        repo_root=str(tmp_path),
         log_filename='test.log',
         quiet=True,
         backend='conda',
@@ -315,10 +317,11 @@ def test_deploy_jigsawpy_pixi_local_manifest_copy(monkeypatch, tmp_path: Path):
         backend='pixi',
         pixi_manifest=str(source_manifest),
         pixi_local=True,
+        repo_root=str(tmp_path),
     )
 
     local_manifest = (
-        jigsaw._get_jigsaw_cache_dir() / 'pixi-local' / 'pixi.toml'
+        tmp_path / '.mache_cache' / 'jigsaw' / 'pixi-local' / 'pixi.toml'
     ).resolve()
     assert local_manifest.is_file()
     assert local_manifest.read_text(
@@ -369,10 +372,11 @@ def test_deploy_jigsawpy_pixi_local_adds_isolated_jigsaw_environment(
         backend='pixi',
         pixi_manifest=str(source_manifest),
         pixi_local=True,
+        repo_root=str(tmp_path),
     )
 
     local_manifest = (
-        jigsaw._get_jigsaw_cache_dir() / 'pixi-local' / 'pixi.toml'
+        tmp_path / '.mache_cache' / 'jigsaw' / 'pixi-local' / 'pixi.toml'
     ).resolve()
     local_text = local_manifest.read_text(encoding='utf-8')
     assert '[feature.jigsaw.dependencies]' in local_text

--- a/tests/test_jigsaw_cache.py
+++ b/tests/test_jigsaw_cache.py
@@ -59,6 +59,11 @@ def _platform_name() -> str:
     return platform_name
 
 
+def _slot(shared: Path, cache_key: str) -> Path:
+    """The slot directory for a key, whose name is a truncation of it."""
+    return shared / cache_key[: jigsaw.JIGSAW_SLOT_KEY_LEN]
+
+
 def _fake_out_build(
     monkeypatch,
     cache_key: str = 'a' * 64,
@@ -215,11 +220,14 @@ def test_build_writes_slot_and_sentinel(monkeypatch, tmp_path: Path):
     result = _build(clone)
 
     shared = clone / '.mache_cache' / 'jigsaw'
-    slot = shared / ('a' * 64)
+    slot = _slot(shared, 'a' * 64)
     assert result.cache_hit is False
     assert result.cache_root == shared
     assert result.channel_dir == slot
     assert result.channel_uri == slot.as_uri()
+    # The slot is named by a truncation of the key, but the sentinel holds
+    # the full key so validation stays exact.
+    assert slot.name == 'a' * jigsaw.JIGSAW_SLOT_KEY_LEN
     sentinel = slot / '.jigsaw_cache_key'
     assert sentinel.read_text(encoding='utf-8').strip() == 'a' * 64
 
@@ -243,7 +251,9 @@ def test_second_worktree_hits_cache_built_by_first(
     assert second.cache_hit is True
     assert len(builds) == 1
     assert second.channel_dir == first.channel_dir
-    assert first.channel_dir == clone / '.mache_cache' / 'jigsaw' / ('a' * 64)
+    assert first.channel_dir == _slot(
+        clone / '.mache_cache' / 'jigsaw', 'a' * 64
+    )
     # Nothing was written into either worktree.
     assert not (worktree_a / '.mache_cache').exists()
     assert not (worktree_b / '.mache_cache').exists()
@@ -274,8 +284,8 @@ def test_distinct_keys_get_distinct_slots(monkeypatch, tmp_path: Path):
     second = _build(clone)
 
     assert second.cache_hit is False
-    assert (shared / ('a' * 64) / '.jigsaw_cache_key').is_file()
-    assert (shared / ('b' * 64) / '.jigsaw_cache_key').is_file()
+    assert (_slot(shared, 'a' * 64) / '.jigsaw_cache_key').is_file()
+    assert (_slot(shared, 'b' * 64) / '.jigsaw_cache_key').is_file()
 
 
 def test_tools_dir_is_shared_across_keys(monkeypatch, tmp_path: Path):
@@ -295,7 +305,7 @@ def test_tools_dir_is_shared_across_keys(monkeypatch, tmp_path: Path):
     tools_dirs = [build['tools_dir'] for build in builds]
     assert tools_dirs == [shared / 'tools', shared / 'tools']
     slot_dirs = [build['slot_dir'] for build in builds]
-    assert slot_dirs == [shared / ('a' * 64), shared / ('b' * 64)]
+    assert slot_dirs == [_slot(shared, 'a' * 64), _slot(shared, 'b' * 64)]
 
 
 def test_build_rechecks_cache_after_taking_lock(monkeypatch, tmp_path: Path):
@@ -306,7 +316,7 @@ def test_build_rechecks_cache_after_taking_lock(monkeypatch, tmp_path: Path):
     clone = _make_clone(tmp_path / 'clone')
     builds = _fake_out_build(monkeypatch)
 
-    slot = clone / '.mache_cache' / 'jigsaw' / ('a' * 64)
+    slot = _slot(clone / '.mache_cache' / 'jigsaw', 'a' * 64)
     answers = iter([False, True])
 
     def _valid_once_locked(**_):
@@ -381,7 +391,7 @@ def test_build_proceeds_when_locking_unsupported(
     result = _build(clone)
 
     assert result.cache_hit is False
-    assert (clone / '.mache_cache' / 'jigsaw' / ('a' * 64)).is_dir()
+    assert _slot(clone / '.mache_cache' / 'jigsaw', 'a' * 64).is_dir()
     assert 'proceeding without a build lock' in capsys.readouterr().out
 
 

--- a/tests/test_jigsaw_cache.py
+++ b/tests/test_jigsaw_cache.py
@@ -8,8 +8,10 @@ tests build real (tiny) git repositories in ``tmp_path``.
 
 from __future__ import annotations
 
+import errno
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -294,3 +296,108 @@ def test_tools_dir_is_shared_across_keys(monkeypatch, tmp_path: Path):
     assert tools_dirs == [shared / 'tools', shared / 'tools']
     slot_dirs = [build['slot_dir'] for build in builds]
     assert slot_dirs == [shared / ('a' * 64), shared / ('b' * 64)]
+
+
+def test_build_rechecks_cache_after_taking_lock(monkeypatch, tmp_path: Path):
+    """
+    A deploy that waits on the lock should find the build the process it
+    waited for produced, rather than redo it.
+    """
+    clone = _make_clone(tmp_path / 'clone')
+    builds = _fake_out_build(monkeypatch)
+
+    slot = clone / '.mache_cache' / 'jigsaw' / ('a' * 64)
+    answers = iter([False, True])
+
+    def _valid_once_locked(**_):
+        valid = next(answers)
+        if valid:
+            # Stand in for the build the process we waited on finished.
+            channel = slot / _platform_name()
+            channel.mkdir(parents=True, exist_ok=True)
+            (channel / 'repodata.json').write_text('{}\n', encoding='utf-8')
+        return valid
+
+    monkeypatch.setattr(
+        jigsaw, '_is_cached_jigsaw_build_valid', _valid_once_locked
+    )
+
+    result = _build(clone)
+
+    assert result.cache_hit is True
+    assert result.channel_dir == slot
+    assert builds == []
+
+
+def test_cache_lock_is_exclusive_across_processes(tmp_path: Path):
+    shared = tmp_path / 'cache'
+    script = (
+        'import fcntl, sys\n'
+        f'fd = open({str(shared / ".lock")!r}, "r+")\n'
+        'try:\n'
+        '    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)\n'
+        'except BlockingIOError:\n'
+        '    print("blocked")\n'
+        '    sys.exit(0)\n'
+        'print("acquired")\n'
+    )
+
+    with jigsaw._jigsaw_cache_lock(shared_root=shared, quiet=True) as held:
+        assert held is True
+        other = subprocess.run(
+            [sys.executable, '-c', script],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    assert other.stdout.strip() == 'blocked'
+
+    # Released on exit, so a later process can take it.
+    after = subprocess.run(
+        [sys.executable, '-c', script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert after.stdout.strip() == 'acquired'
+
+
+def test_build_proceeds_when_locking_unsupported(
+    monkeypatch, capsys, tmp_path: Path
+):
+    """
+    Some filesystems cannot flock. Warn, but never fail the deploy over
+    it: unlocked is how this worked before the cache was shared.
+    """
+    clone = _make_clone(tmp_path / 'clone')
+    _fake_out_build(monkeypatch)
+
+    def _no_flock(*_args, **_kwargs):
+        raise OSError(errno.ENOLCK, 'no locks available')
+
+    monkeypatch.setattr(jigsaw.fcntl, 'flock', _no_flock)
+
+    result = _build(clone)
+
+    assert result.cache_hit is False
+    assert (clone / '.mache_cache' / 'jigsaw' / ('a' * 64)).is_dir()
+    assert 'proceeding without a build lock' in capsys.readouterr().out
+
+
+def test_cache_lock_times_out(monkeypatch, tmp_path: Path):
+    """
+    A build that never releases the lock must not hang a deploy forever.
+    """
+    shared = tmp_path / 'cache'
+    monkeypatch.setattr(jigsaw, 'JIGSAW_LOCK_TIMEOUT', 0.0)
+    monkeypatch.setattr(jigsaw, 'JIGSAW_LOCK_POLL', 0.0)
+
+    def _always_contended(*_args, **_kwargs):
+        raise BlockingIOError()
+
+    monkeypatch.setattr(jigsaw.fcntl, 'flock', _always_contended)
+
+    with pytest.raises(RuntimeError, match='Timed out'):
+        with jigsaw._jigsaw_cache_lock(shared_root=shared, quiet=True):
+            pass

--- a/tests/test_jigsaw_cache.py
+++ b/tests/test_jigsaw_cache.py
@@ -1,0 +1,94 @@
+"""
+Tests for the JIGSAW build cache: source-revision detection, where the cache
+is anchored, how build artifacts are laid out, and the build lock.
+
+The cache is shared across git worktrees of the same clone, so most of these
+tests build real (tiny) git repositories in ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import mache.jigsaw as jigsaw
+
+pytestmark = pytest.mark.skipif(
+    shutil.which('git') is None, reason='git is required for cache tests'
+)
+
+
+def _git(*args: str, cwd: Path) -> str:
+    env = {
+        'GIT_AUTHOR_NAME': 'mache tests',
+        'GIT_AUTHOR_EMAIL': 'mache@example.com',
+        'GIT_COMMITTER_NAME': 'mache tests',
+        'GIT_COMMITTER_EMAIL': 'mache@example.com',
+        'GIT_CONFIG_GLOBAL': '/dev/null',
+        'GIT_CONFIG_SYSTEM': '/dev/null',
+        'PATH': '/usr/bin:/bin:/usr/local/bin',
+        'HOME': str(cwd),
+    }
+    return subprocess.check_output(
+        ['git', '-C', str(cwd), *args], text=True, env=env
+    ).strip()
+
+
+def _make_clone(root: Path) -> Path:
+    """Create a git clone with a single commit and return its path."""
+    root.mkdir(parents=True, exist_ok=True)
+    _git('init', '--initial-branch=main', cwd=root)
+    (root / 'README.md').write_text('demo\n', encoding='utf-8')
+    _git('add', 'README.md', cwd=root)
+    _git('commit', '-m', 'initial', cwd=root)
+    return root
+
+
+def _add_worktree(clone: Path, path: Path, branch: str) -> Path:
+    _git('worktree', 'add', '-b', branch, str(path), 'main', cwd=clone)
+    return path
+
+
+def test_get_git_head_matches_rev_parse(tmp_path: Path):
+    clone = _make_clone(tmp_path / 'clone')
+    expected = _git('rev-parse', 'HEAD', cwd=clone)
+
+    assert jigsaw._get_git_head(clone) == expected
+
+
+def test_get_git_head_reads_packed_refs(tmp_path: Path):
+    """
+    Branch refs may be packed rather than stored as loose ref files.
+    """
+    clone = _make_clone(tmp_path / 'clone')
+    expected = _git('rev-parse', 'HEAD', cwd=clone)
+
+    _git('pack-refs', '--all', cwd=clone)
+    loose_ref = clone / '.git' / 'refs' / 'heads' / 'main'
+    if loose_ref.is_file():
+        loose_ref.unlink()
+
+    assert jigsaw._get_git_head(clone) == expected
+
+
+def test_get_git_head_in_linked_worktree(tmp_path: Path):
+    """
+    In a linked worktree, loose refs live in the common dir, not in the
+    worktree's own gitdir.
+    """
+    clone = _make_clone(tmp_path / 'clone')
+    worktree = _add_worktree(clone, tmp_path / 'wt', 'feature')
+    expected = _git('rev-parse', 'HEAD', cwd=worktree)
+
+    assert jigsaw._get_git_head(worktree) == expected
+
+
+def test_get_git_head_outside_git_checkout(tmp_path: Path):
+    plain = tmp_path / 'plain'
+    plain.mkdir()
+
+    with pytest.raises(RuntimeError, match='could not read HEAD'):
+        jigsaw._get_git_head(plain)

--- a/tests/test_jigsaw_cache.py
+++ b/tests/test_jigsaw_cache.py
@@ -92,3 +92,62 @@ def test_get_git_head_outside_git_checkout(tmp_path: Path):
 
     with pytest.raises(RuntimeError, match='could not read HEAD'):
         jigsaw._get_git_head(plain)
+
+
+def test_shared_cache_dir_uses_git_common_dir_parent(tmp_path: Path):
+    """
+    A worktree must resolve to its clone's cache, not to its own.
+
+    This is the whole point of sharing the cache: deploying in a new
+    worktree reuses the build that some other worktree already paid for.
+    """
+    clone = _make_clone(tmp_path / 'clone')
+    worktree = _add_worktree(clone, tmp_path / 'wt', 'feature')
+
+    shared = jigsaw._get_jigsaw_shared_cache_dir(repo_root=worktree)
+
+    assert shared == clone / '.mache_cache' / 'jigsaw'
+    assert shared == jigsaw._get_jigsaw_shared_cache_dir(repo_root=clone)
+
+
+def test_shared_cache_dir_for_original_clone_is_unchanged(tmp_path: Path):
+    """
+    In the original clone the shared cache is where the cache has always
+    been, so upgrading needs no migration.
+    """
+    clone = _make_clone(tmp_path / 'clone')
+
+    shared = jigsaw._get_jigsaw_shared_cache_dir(repo_root=clone)
+
+    assert shared == jigsaw._get_jigsaw_workspace_dir(repo_root=clone)
+    assert shared == clone / '.mache_cache' / 'jigsaw'
+
+
+def test_shared_cache_dir_falls_back_outside_git(monkeypatch, tmp_path: Path):
+    """
+    Tarball installs have no clone to anchor to and keep today's layout.
+    """
+    plain = tmp_path / 'plain'
+    plain.mkdir()
+    # Keep git from finding a repository somewhere above tmp_path.
+    monkeypatch.setenv('GIT_CEILING_DIRECTORIES', str(tmp_path))
+
+    shared = jigsaw._get_jigsaw_shared_cache_dir(repo_root=plain)
+
+    assert shared == plain / '.mache_cache' / 'jigsaw'
+
+
+def test_shared_cache_dir_falls_back_when_repo_root_is_not_toplevel(
+    tmp_path: Path,
+):
+    """
+    A repo_root nested inside an unrelated checkout must not anchor to
+    that checkout's clone.
+    """
+    clone = _make_clone(tmp_path / 'clone')
+    nested = clone / 'subdir'
+    nested.mkdir()
+
+    shared = jigsaw._get_jigsaw_shared_cache_dir(repo_root=nested)
+
+    assert shared == nested / '.mache_cache' / 'jigsaw'

--- a/tests/test_jigsaw_cache.py
+++ b/tests/test_jigsaw_cache.py
@@ -52,6 +52,59 @@ def _add_worktree(clone: Path, path: Path, branch: str) -> Path:
     return path
 
 
+def _platform_name() -> str:
+    platform_name, _ = jigsaw._get_conda_platform_and_system()
+    return platform_name
+
+
+def _fake_out_build(
+    monkeypatch,
+    cache_key: str = 'a' * 64,
+    builds: list[dict] | None = None,
+) -> list[dict]:
+    """
+    Stub out everything that would touch the network or run rattler-build,
+    leaving the cache layout itself under test. Returns a list that
+    records the kwargs of each _build_external_jigsaw call; pass ``builds``
+    to keep recording across a change of cache key.
+    """
+    if builds is None:
+        builds = []
+
+    def _fake_build_external_jigsaw(**kwargs):
+        builds.append(kwargs)
+        slot_dir = kwargs['slot_dir']
+        channel = slot_dir / _platform_name()
+        channel.mkdir(parents=True, exist_ok=True)
+        (channel / 'repodata.json').write_text('{}\n', encoding='utf-8')
+        # rattler-build also leaves scratch behind in its output dir
+        (slot_dir / 'bld').mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(
+        jigsaw, '_ensure_jigsaw_python_source', lambda **_: None
+    )
+    monkeypatch.setattr(
+        jigsaw, '_compute_jigsaw_cache_key', lambda **_: cache_key
+    )
+    monkeypatch.setattr(jigsaw, '_get_jigsaw_version', lambda *_: '0.0.1')
+    monkeypatch.setattr(
+        jigsaw, '_build_external_jigsaw', _fake_build_external_jigsaw
+    )
+    return builds
+
+
+def _build(repo_root: Path):
+    return jigsaw.build_jigsawpy_package(
+        python_version='3.14',
+        jigsaw_python_path='jigsaw-python',
+        repo_root=str(repo_root),
+        log_filename='test.log',
+        quiet=True,
+        backend='conda',
+        conda_exe='conda',
+    )
+
+
 def test_get_git_head_matches_rev_parse(tmp_path: Path):
     clone = _make_clone(tmp_path / 'clone')
     expected = _git('rev-parse', 'HEAD', cwd=clone)
@@ -151,3 +204,93 @@ def test_shared_cache_dir_falls_back_when_repo_root_is_not_toplevel(
     shared = jigsaw._get_jigsaw_shared_cache_dir(repo_root=nested)
 
     assert shared == nested / '.mache_cache' / 'jigsaw'
+
+
+def test_build_writes_slot_and_sentinel(monkeypatch, tmp_path: Path):
+    clone = _make_clone(tmp_path / 'clone')
+    _fake_out_build(monkeypatch)
+
+    result = _build(clone)
+
+    shared = clone / '.mache_cache' / 'jigsaw'
+    slot = shared / ('a' * 64)
+    assert result.cache_hit is False
+    assert result.cache_root == shared
+    assert result.channel_dir == slot
+    assert result.channel_uri == slot.as_uri()
+    sentinel = slot / '.jigsaw_cache_key'
+    assert sentinel.read_text(encoding='utf-8').strip() == 'a' * 64
+
+
+def test_second_worktree_hits_cache_built_by_first(
+    monkeypatch, tmp_path: Path
+):
+    """
+    The point of the whole change: a fresh worktree reuses the build that
+    another worktree of the same clone already paid for.
+    """
+    clone = _make_clone(tmp_path / 'clone')
+    worktree_a = _add_worktree(clone, tmp_path / 'wt_a', 'branch_a')
+    worktree_b = _add_worktree(clone, tmp_path / 'wt_b', 'branch_b')
+    builds = _fake_out_build(monkeypatch)
+
+    first = _build(worktree_a)
+    second = _build(worktree_b)
+
+    assert first.cache_hit is False
+    assert second.cache_hit is True
+    assert len(builds) == 1
+    assert second.channel_dir == first.channel_dir
+    assert first.channel_dir == clone / '.mache_cache' / 'jigsaw' / ('a' * 64)
+    # Nothing was written into either worktree.
+    assert not (worktree_a / '.mache_cache').exists()
+    assert not (worktree_b / '.mache_cache').exists()
+
+
+def test_second_build_in_same_clone_hits_cache(monkeypatch, tmp_path: Path):
+    clone = _make_clone(tmp_path / 'clone')
+    builds = _fake_out_build(monkeypatch)
+
+    _build(clone)
+    second = _build(clone)
+
+    assert second.cache_hit is True
+    assert len(builds) == 1
+
+
+def test_distinct_keys_get_distinct_slots(monkeypatch, tmp_path: Path):
+    """
+    Worktrees that disagree on the Python version or JIGSAW-Python commit
+    must not evict each other.
+    """
+    clone = _make_clone(tmp_path / 'clone')
+    shared = clone / '.mache_cache' / 'jigsaw'
+
+    _fake_out_build(monkeypatch, cache_key='a' * 64)
+    _build(clone)
+    _fake_out_build(monkeypatch, cache_key='b' * 64)
+    second = _build(clone)
+
+    assert second.cache_hit is False
+    assert (shared / ('a' * 64) / '.jigsaw_cache_key').is_file()
+    assert (shared / ('b' * 64) / '.jigsaw_cache_key').is_file()
+
+
+def test_tools_dir_is_shared_across_keys(monkeypatch, tmp_path: Path):
+    """
+    Tool envs are ~98% of the cache and do not depend on the cache key, so
+    they must live outside the per-key slots.
+    """
+    clone = _make_clone(tmp_path / 'clone')
+    shared = clone / '.mache_cache' / 'jigsaw'
+
+    builds = _fake_out_build(monkeypatch, cache_key='a' * 64)
+    _build(clone)
+    _fake_out_build(monkeypatch, cache_key='b' * 64, builds=builds)
+    _build(clone)
+
+    assert len(builds) == 2
+    tools_dirs = [build['tools_dir'] for build in builds]
+    assert tools_dirs == [shared / 'tools', shared / 'tools']
+    slot_dirs = [build['slot_dir'] for build in builds]
+    assert slot_dirs == [shared / ('a' * 64), shared / ('b' * 64)]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Rather than caching the jigsaw build in each worktree, this merge detects the location of the original repo clone and caches the build(s) there.  This means we only rebuild jigsaw when its code actually changes, not when we create a new worktree.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] User's Guide has been updated if needed
- [x] Developer's Guide has been updated if needed
- [ ] Documentation [builds](https://docs.e3sm.org/mache/main/developers_guide/building_docs.html) cleanly and changes look as expected
- [x] Tests pass and new features are covered by tests
- [x] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

