### PR TITLE
Update jigsaw dependencies and add advanced arch support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,18 @@ These instructions apply to the whole repository unless a deeper
 - This repository uses Pixi as the primary development environment manager.
 - Check the root `.pixi/` and `pixi.toml` before creating or selecting any
   other Python environment.
-- Prefer `pixi run -e py314 <command>` for Python tools such as `python`,
-  `pytest`, `pre-commit`, `ruff`, and `mypy`.
-- If you need an interactive shell, use `pixi shell -e py314` from the repo
-  root instead of creating a new virtual environment.
+- Prefer the `default` environment for Python tools such as `python`,
+  `pytest`, `pre-commit`, `ruff`, and `mypy`: run `pixi run <command>` (or
+  `pixi shell` for an interactive shell) from the repo root. This is the
+  environment `pixi shell` creates, so it is usually the one already
+  installed under `.pixi/envs/`.
+- If the `default` environment is not available, fall back to an explicit
+  Python environment such as `pixi run -e py314 <command>` (`py310`
+  through `py314` are defined in `pixi.toml`). Note that selecting an
+  environment that is not yet installed will make Pixi solve and install
+  it, which can be slow.
+- If no Pixi environment is installed at all, ask the user to create one
+  (e.g. `pixi shell`) rather than building a separate virtual environment.
 - Do not treat `pytest: command not found` in a plain shell as a missing
   dependency until you have tried the command through Pixi.
 
@@ -42,12 +50,12 @@ These instructions apply to the whole repository unless a deeper
 
 - Run tests and linting through Pixi unless the task explicitly requires a
   different environment.
-- Prefer `pixi run -e py314 pytest` for tests.
+- Prefer `pixi run pytest` for tests (the `default` environment; see the
+  "Python environment" section for fallbacks).
 - Do not run `workflow_tests/test_deploy_workflow.py` during routine
   validation unless the user explicitly requests that workflow test.
 - pre-commit on changed files is required before finishing; if sandboxed
   execution fails, request escalation and do not close the task until it has
   run or the user declines.
-- Prefer `pixi run -e py314 pre-commit run --files ...` for required
-  validation.
+- Prefer `pixi run pre-commit run --files ...` for required validation.
 - Prefer fixing lint and formatting issues rather than suppressing them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Code Instructions
+
+Follow the instructions in [AGENTS.md](AGENTS.md). They apply to the whole
+repository and cover the Python environment (Pixi), style, and validation
+requirements.

--- a/conda/recipe/recipe.yaml
+++ b/conda/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: mache
-  version: "3.8.0"
+  version: "3.9.0"
 
 package:
   name: ${{ name|lower }}

--- a/mache/jigsaw/__init__.py
+++ b/mache/jigsaw/__init__.py
@@ -9,6 +9,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -529,6 +530,52 @@ def _get_git_head(repo_dir: Path) -> str:
     return head
 
 
+def _get_git_worktree_hash(repo_dir: Path) -> str | None:
+    """
+    Content hash of the working tree at ``repo_dir``, including any
+    uncommitted changes, or None if it cannot be computed.
+
+    Committing must not be a prerequisite for rebuilding JIGSAW: a developer
+    who edits the JIGSAW source in place has to get a fresh build, so the
+    cache key has to reflect the working tree and not just HEAD. We stage the
+    whole tree into a throwaway index -- leaving the developer's real index
+    untouched -- and let ``git write-tree`` hash it. Ignored paths such as
+    the build cache itself are excluded, exactly as they are from a commit.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        env = dict(os.environ, GIT_INDEX_FILE=os.path.join(tmp_dir, 'index'))
+        try:
+            subprocess.check_call(
+                ['git', '-C', str(repo_dir), 'add', '-A'],
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            tree = subprocess.check_output(
+                ['git', '-C', str(repo_dir), 'write-tree'],
+                env=env,
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+        except (OSError, subprocess.CalledProcessError):
+            return None
+    return tree.strip() or None
+
+
+def _get_jigsaw_source_id(repo_dir: Path) -> str:
+    """
+    Identify the JIGSAW source to build: its committed HEAD plus a hash of
+    the working tree, so that uncommitted edits trigger a rebuild instead of
+    reusing a stale cached build. On a clean checkout the working-tree hash
+    is a stable function of HEAD, so the id does not churn between builds.
+    """
+    head = _get_git_head(repo_dir)
+    worktree = _get_git_worktree_hash(repo_dir)
+    if worktree is None:
+        return head
+    return f'{head}:{worktree}'
+
+
 def _get_build_recipe_id(platform_name: str) -> str:
     """
     Hash of the mache-owned files that define how JIGSAW is built: the
@@ -556,11 +603,11 @@ def _compute_jigsaw_cache_key(
 ) -> str:
     platform_name, _ = _get_conda_platform_and_system()
     jigsaw_version = _get_jigsaw_version(jigsaw_python_dir)
-    git_head = _get_git_head(jigsaw_python_dir)
+    jigsaw_source = _get_jigsaw_source_id(jigsaw_python_dir)
     python_variant = PYTHON_VARIANTS.get(python_version, '')
 
     payload = {
-        'git_head': git_head,
+        'jigsaw_source': jigsaw_source,
         'jigsaw_version': jigsaw_version,
         'python_version': python_version,
         'python_variant': python_variant,

--- a/mache/jigsaw/__init__.py
+++ b/mache/jigsaw/__init__.py
@@ -529,6 +529,26 @@ def _get_git_head(repo_dir: Path) -> str:
     return head
 
 
+def _get_build_recipe_id(platform_name: str) -> str:
+    """
+    Hash of the mache-owned files that define how JIGSAW is built: the
+    recipe, the build script, and the platform's dependency pins. These are
+    not part of the JIGSAW source, so changing them (e.g. bumping a
+    dependency) would otherwise leave the cache key unchanged and reuse a
+    stale build.
+    """
+    digest = hashlib.sha256()
+    for name in ('recipe.yaml.j2', 'build.sh', f'{platform_name}.yaml.j2'):
+        try:
+            contents = resources.read_text('mache.jigsaw', name)
+        except FileNotFoundError:
+            contents = ''
+        digest.update(f'{name}\0'.encode('utf-8'))
+        digest.update(contents.encode('utf-8'))
+        digest.update(b'\0')
+    return digest.hexdigest()
+
+
 def _compute_jigsaw_cache_key(
     *,
     jigsaw_python_dir: Path,
@@ -545,6 +565,7 @@ def _compute_jigsaw_cache_key(
         'python_version': python_version,
         'python_variant': python_variant,
         'platform': platform_name,
+        'build_recipe': _get_build_recipe_id(platform_name),
     }
 
     digest = hashlib.sha256()

--- a/mache/jigsaw/linux-64.yaml.j2
+++ b/mache/jigsaw/linux-64.yaml.j2
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 libnetcdf:
-- '4.10.0'
+- '4.10.1'
 numpy:
 - '2'
 python:

--- a/mache/jigsaw/linux-aarch64.yaml.j2
+++ b/mache/jigsaw/linux-aarch64.yaml.j2
@@ -1,29 +1,19 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '19'
+- '14'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
 channel_sources:
 - conda-forge
-channel_targets:
-- conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '19'
+- '14'
 libnetcdf:
 - '4.10.1'
-llvm_openmp:
-- '19'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
 - '2'
 python:
@@ -31,7 +21,7 @@ python:
 python_impl:
 - cpython
 target_platform:
-- osx-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/mache/jigsaw/osx-arm64.yaml.j2
+++ b/mache/jigsaw/osx-arm64.yaml.j2
@@ -23,7 +23,7 @@ libnetcdf:
 llvm_openmp:
 - '19'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 numpy:
 - '2'
 python:
@@ -31,7 +31,7 @@ python:
 python_impl:
 - cpython
 target_platform:
-- osx-64
+- osx-arm64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/mache/version.py
+++ b/mache/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (3, 8, 0)
+__version_info__ = (3, 9, 0)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/tests/test_jigsaw_cache.py
+++ b/tests/test_jigsaw_cache.py
@@ -154,6 +154,62 @@ def test_get_git_head_outside_git_checkout(tmp_path: Path):
         jigsaw._get_git_head(plain)
 
 
+def test_worktree_hash_is_stable_when_clean(tmp_path: Path):
+    clone = _make_clone(tmp_path / 'clone')
+
+    first = jigsaw._get_git_worktree_hash(clone)
+
+    assert first is not None
+    assert first == jigsaw._get_git_worktree_hash(clone)
+
+
+def test_worktree_hash_changes_with_uncommitted_edit(tmp_path: Path):
+    clone = _make_clone(tmp_path / 'clone')
+    before = jigsaw._get_git_worktree_hash(clone)
+
+    # An in-place edit that is never committed must change the hash.
+    (clone / 'README.md').write_text('changed\n', encoding='utf-8')
+    modified = jigsaw._get_git_worktree_hash(clone)
+
+    # A brand-new, untracked file must change it too.
+    (clone / 'extra.txt').write_text('new\n', encoding='utf-8')
+    added = jigsaw._get_git_worktree_hash(clone)
+
+    assert before != modified
+    assert modified != added
+
+
+def test_worktree_hash_leaves_real_index_untouched(tmp_path: Path):
+    clone = _make_clone(tmp_path / 'clone')
+    (clone / 'README.md').write_text('changed\n', encoding='utf-8')
+
+    jigsaw._get_git_worktree_hash(clone)
+
+    # The developer's own index must not have been staged behind their back:
+    # the edit stays a working-tree change (porcelain ' M'), not staged
+    # ('M '). _git strips the output, collapsing the leading space.
+    assert _git('status', '--porcelain', cwd=clone) == 'M README.md'
+
+
+def test_worktree_hash_outside_git_checkout(tmp_path: Path):
+    plain = tmp_path / 'plain'
+    plain.mkdir()
+
+    assert jigsaw._get_git_worktree_hash(plain) is None
+
+
+def test_source_id_reflects_uncommitted_changes(tmp_path: Path):
+    clone = _make_clone(tmp_path / 'clone')
+    clean = jigsaw._get_jigsaw_source_id(clone)
+
+    (clone / 'README.md').write_text('changed\n', encoding='utf-8')
+    dirty = jigsaw._get_jigsaw_source_id(clone)
+
+    head = _git('rev-parse', 'HEAD', cwd=clone)
+    assert clean.startswith(head)
+    assert clean != dirty
+
+
 def test_build_recipe_id_tracks_dependency_files(monkeypatch):
     platform_name = _platform_name()
     baseline = jigsaw._get_build_recipe_id(platform_name)

--- a/tests/test_jigsaw_cache.py
+++ b/tests/test_jigsaw_cache.py
@@ -154,6 +154,23 @@ def test_get_git_head_outside_git_checkout(tmp_path: Path):
         jigsaw._get_git_head(plain)
 
 
+def test_build_recipe_id_tracks_dependency_files(monkeypatch):
+    platform_name = _platform_name()
+    baseline = jigsaw._get_build_recipe_id(platform_name)
+
+    real_read_text = jigsaw.resources.read_text
+
+    def _bump_variant(package, name, *args, **kwargs):
+        text = real_read_text(package, name, *args, **kwargs)
+        if name == f'{platform_name}.yaml.j2':
+            text += '\n# a changed dependency pin\n'
+        return text
+
+    monkeypatch.setattr(jigsaw.resources, 'read_text', _bump_variant)
+
+    assert jigsaw._get_build_recipe_id(platform_name) != baseline
+
+
 def test_shared_cache_dir_uses_git_common_dir_parent(tmp_path: Path):
     """
     A worktree must resolve to its clone's cache, not to its own.


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Update to v3.9.0 for a release

Fix jigsaw build hashing to include:
* changes to the jigsaw(py) code
* dependency changes

Fix agent instructions to support Claude and to refer to the `default` environment.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] Tests pass and new features are covered by tests
- [x] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

