### PR TITLE
Let callers ask for a queue, partition or QOS -- and give Frontier one to ask for

### DIFF
--- a/conda/recipe/recipe.yaml
+++ b/conda/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: mache
-  version: "3.10.0"
+  version: "3.11.0"
 
 package:
   name: ${{ name|lower }}

--- a/docs/developers_guide/adding_new_machine.md
+++ b/docs/developers_guide/adding_new_machine.md
@@ -117,6 +117,11 @@ mache uses to decide whether such a request can be honored, so a target with
 no section can always be requested but never rejected. The first entry in each
 list is the machine's default.
 
+`parallel.constraints` is an availability list in the same sense -- the first
+entry is the default and a constraint can only be requested if it appears
+there -- but it takes no `[constraint.<name>]` section, since a constraint has
+no node-count or wall-clock limits to record.
+
 These options are used to:
 
 - detect available resources on the current allocation,

--- a/docs/developers_guide/adding_new_machine.md
+++ b/docs/developers_guide/adding_new_machine.md
@@ -82,6 +82,27 @@ Supported keys are:
     no upper bound)
 - `max_wallclock`: maximum allowed wall-clock time (for example,
     `01:00:00`)
+- `max_wallclock_bins`: maximum allowed wall-clock time as a function of job
+    size, for machines whose policy varies with node count
+
+Some machines allow longer jobs the more nodes they use. Frontier's `batch`
+partition, for example, allows 2 hours for 1-91 nodes, 6 hours for 92-183
+nodes and 12 hours above that. Describe this with `max_wallclock_bins`
+instead of `max_wallclock`:
+
+```ini
+[partition.batch]
+min_nodes = 1
+max_nodes = 9472
+max_wallclock_bins = 91: 02:00:00,
+                     183: 06:00:00,
+                     9472: 12:00:00
+```
+
+Each entry is `<max nodes>: <max wallclock>` and the bin that applies is the
+first one, in increasing order of node count, whose node bound is at least the
+job's node count. Continuation lines must be indented. A section may set
+`max_wallclock` or `max_wallclock_bins` but not both.
 
 Downstream software can query these values with
 `MachineInfo.get_queue_specs()`, `MachineInfo.get_partition_specs()`,

--- a/docs/developers_guide/adding_new_machine.md
+++ b/docs/developers_guide/adding_new_machine.md
@@ -88,6 +88,14 @@ Downstream software can query these values with
 `MachineInfo.get_qos_specs()` or
 `MachineInfo.get_scheduler_specs()`.
 
+A scheduler target can only be requested by name (see
+{ref}`users-parallel`) if it is listed in `parallel.queues`,
+`parallel.partitions` or `parallel.qos`. The matching `[queue.<name>]`,
+`[partition.<name>]` or `[qos.<name>]` section is what supplies the limits
+mache uses to decide whether such a request can be honored, so a target with
+no section can always be requested but never rejected. The first entry in each
+list is the machine's default.
+
 These options are used to:
 
 - detect available resources on the current allocation,

--- a/docs/developers_guide/api.md
+++ b/docs/developers_guide/api.md
@@ -50,6 +50,7 @@ documentation.
     ParallelSystem.get_parallel_command
     ParallelSystem.get_scheduler_target
     ParallelSystem.resolve_submission
+    cap_wall_time
 ```
 
 ```{eval-rst}
@@ -76,8 +77,10 @@ documentation.
 .. autosummary::
     :toctree: generated/
 
+    SlurmOptions
     SlurmSystem
     SlurmSystem.get_slurm_options
+    SlurmSystem.resolve_slurm_options
 ```
 
 ```{eval-rst}
@@ -86,8 +89,10 @@ documentation.
 .. autosummary::
     :toctree: generated/
 
+    PbsOptions
     PbsSystem
     PbsSystem.get_pbs_options
+    PbsSystem.resolve_pbs_options
 ```
 
 ## spack

--- a/docs/users_guide/parallel.md
+++ b/docs/users_guide/parallel.md
@@ -136,15 +136,15 @@ machine metadata:
     `effective_nodes`, `adjustment` (`exact`, `decrease`, or `increase`),
     `honored`, and `reason`.
 - `SlurmSystem.resolve_slurm_options(config, nodes, min_nodes_allowed=None,
-    partition=None, qos=None, constraint=None, desired_wall_time=None)`
-    returns a `SlurmOptions` object with fields `partition`, `qos`,
-    `constraint`, `gpus_per_node`, `max_wallclock`, `effective_nodes`,
-    `wall_time`, `honored`, and `reason`.
+    partition=None, qos=None, constraint=None, desired_wall_time=None,
+    scheduler_target=None)` returns a `SlurmOptions` object with fields
+    `partition`, `qos`, `constraint`, `gpus_per_node`, `max_wallclock`,
+    `effective_nodes`, `wall_time`, `honored`, and `reason`.
 - `PbsSystem.resolve_pbs_options(config, nodes, min_nodes_allowed=None,
-    queue=None, constraint=None, desired_wall_time=None)` returns a
-    `PbsOptions` object with fields `queue`, `constraint`, `gpus_per_node`,
-    `max_wallclock`, `filesystems`, `effective_nodes`, `wall_time`,
-    `honored`, and `reason`.
+    queue=None, constraint=None, desired_wall_time=None,
+    scheduler_target=None)` returns a `PbsOptions` object with fields `queue`,
+    `constraint`, `gpus_per_node`, `max_wallclock`, `filesystems`,
+    `effective_nodes`, `wall_time`, `honored`, and `reason`.
 
 For invalid gaps between scheduler ranges, node count is adjusted to the
 nearest valid value, preferring lower adjustments when feasible. If
@@ -216,6 +216,36 @@ told its request was refused on the axes the machine does not use. There was
 no choice to deny, so `honored` stays `True` and `reason` stays `None`. A
 target missing from a list the machine *does* define is still a denied
 request.
+
+## Requesting a target without naming its axis
+
+Asking on every axis is still awkward for a caller whose intent is simply
+"use this machine's debug target". `scheduler_target` says it once and lets
+mache work out which axis this machine uses:
+
+```python
+options = SlurmSystem.resolve_slurm_options(
+    config=config,
+    nodes=2,
+    scheduler_target="debug",
+    desired_wall_time="00:20:00",
+)
+```
+
+This selects the `debug` partition on Chrysalis, the `debug` QOS on Frontier
+and Perlmutter (leaving the default `batch` partition in place on Frontier),
+and the `debug` queue on Aurora, with no spurious `reason` on any of them.
+Slurm machines are searched partitions-first and then QOS; PBS machines
+schedule by queue, so only queues are searched. `partition`, `qos` and `queue`
+take precedence on the axis they name, so a caller can set a broad
+`scheduler_target` and still pin one axis explicitly.
+
+Once an axis is chosen the target is resolved exactly as if it had been
+requested there, so it is still subject to that target's node and wall-clock
+metadata: `scheduler_target="debug"` with a three-hour wall time on Frontier
+falls back to the `normal` QOS and says why. A name that appears on no axis at
+all is a genuine failed request, and the `reason` lists what each axis does
+offer.
 
 When `desired_wall_time` is given, the returned `wall_time` is that value
 capped at the selected target's `max_wallclock`. The same capping is available

--- a/docs/users_guide/parallel.md
+++ b/docs/users_guide/parallel.md
@@ -130,18 +130,85 @@ machine metadata:
 - `ParallelSystem.get_scheduler_target(config, target_type, nodes)` selects
     one of `queue`, `partition`, or `qos`.
 - `ParallelSystem.resolve_submission(config, nodes, target_type,
-    min_nodes_allowed=None)` returns a `SubmissionResolution` with fields
-    `target`, `requested_nodes`, `effective_nodes`, and `adjustment`
-    (`exact`, `decrease`, or `increase`).
-- `SlurmSystem.get_slurm_options(config, nodes, min_nodes_allowed=None)`
-    returns `(partition, qos, constraint, gpus_per_node, max_wallclock,
-    effective_nodes)`.
-- `PbsSystem.get_pbs_options(config, nodes, min_nodes_allowed=None)` returns
-    `(queue, constraint, gpus_per_node, max_wallclock, filesystems,
-    effective_nodes)`.
+    min_nodes_allowed=None, requested=None, desired_wall_time=None)` returns a
+    `SubmissionResolution` with fields `target`, `requested_nodes`,
+    `effective_nodes`, `adjustment` (`exact`, `decrease`, or `increase`),
+    `honored`, and `reason`.
+- `SlurmSystem.resolve_slurm_options(config, nodes, min_nodes_allowed=None,
+    partition=None, qos=None, desired_wall_time=None)` returns a
+    `SlurmOptions` object with fields `partition`, `qos`, `constraint`,
+    `gpus_per_node`, `max_wallclock`, `effective_nodes`, `wall_time`,
+    `honored`, and `reason`.
+- `PbsSystem.resolve_pbs_options(config, nodes, min_nodes_allowed=None,
+    queue=None, desired_wall_time=None)` returns a `PbsOptions` object with
+    fields `queue`, `constraint`, `gpus_per_node`, `max_wallclock`,
+    `filesystems`, `effective_nodes`, `wall_time`, `honored`, and `reason`.
 
 For invalid gaps between scheduler ranges, node count is adjusted to the
 nearest valid value, preferring lower adjustments when feasible. If
 `min_nodes_allowed` disallows lower adjustments, resolution moves to the next
 valid higher range. If no feasible target exists, these functions raise
 `ValueError`.
+
+```{note}
+`SlurmSystem.get_slurm_options()` and `PbsSystem.get_pbs_options()` return the
+same values as tuples. They are deprecated as of v3.11.0 in favor of
+`resolve_slurm_options()` and `resolve_pbs_options()`, which can be extended
+with new fields without breaking positional unpacking.
+```
+
+## Requesting a specific queue, partition or QOS
+
+Callers that want a particular scheduler target -- for example a test suite
+that should run in the `debug` QOS -- can ask for one directly instead of
+rewriting the machine's config:
+
+```python
+from mache import MachineInfo
+from mache.parallel.slurm import SlurmSystem
+
+config = MachineInfo(machine="pm-cpu").config
+options = SlurmSystem.resolve_slurm_options(
+    config=config,
+    nodes=4,
+    qos="debug",
+    desired_wall_time="02:00:00",
+)
+
+if not options.honored:
+    print(f"Falling back to the {options.qos} qos: {options.reason}")
+```
+
+A requested target is a preference, not an assertion. mache honors it when the
+machine's metadata allows it and otherwise resolves the default target,
+setting `honored = False` and putting a printable explanation in `reason`. A
+request is not honored when:
+
+- the target is not in the machine's `[parallel]` `queues` / `partitions` /
+    `qos` list,
+- clamping the node count to the target's `min_nodes`/`max_nodes` would fall
+    below `min_nodes_allowed`, or
+- `desired_wall_time` is longer than the target's `max_wallclock`.
+
+Clamping the node count on its own does *not* prevent a target from being
+honored. The clamp is reported through `effective_nodes` and `adjustment`, and
+`min_nodes_allowed` is the guard for a clamp the caller cannot live with.
+
+`requested` values of `None`, an empty string, and placeholders of the form
+`<<<default>>>` all mean "no target was requested", so config-driven callers
+can pass their raw config value through without guarding against unset
+placeholders.
+
+When `desired_wall_time` is given, the returned `wall_time` is that value
+capped at the selected target's `max_wallclock`. The same capping is available
+on its own:
+
+```python
+from mache.parallel.system import cap_wall_time
+
+cap_wall_time("04:00:00", "00:30:00")  # "00:30:00"
+```
+
+Note that mache resolves the partition and the QOS independently and has no
+concept of one being valid only with the other. A caller that requests both is
+responsible for asking for a combination its machine accepts.

--- a/docs/users_guide/parallel.md
+++ b/docs/users_guide/parallel.md
@@ -136,14 +136,15 @@ machine metadata:
     `effective_nodes`, `adjustment` (`exact`, `decrease`, or `increase`),
     `honored`, and `reason`.
 - `SlurmSystem.resolve_slurm_options(config, nodes, min_nodes_allowed=None,
-    partition=None, qos=None, desired_wall_time=None)` returns a
-    `SlurmOptions` object with fields `partition`, `qos`, `constraint`,
-    `gpus_per_node`, `max_wallclock`, `effective_nodes`, `wall_time`,
-    `honored`, and `reason`.
+    partition=None, qos=None, constraint=None, desired_wall_time=None)`
+    returns a `SlurmOptions` object with fields `partition`, `qos`,
+    `constraint`, `gpus_per_node`, `max_wallclock`, `effective_nodes`,
+    `wall_time`, `honored`, and `reason`.
 - `PbsSystem.resolve_pbs_options(config, nodes, min_nodes_allowed=None,
-    queue=None, desired_wall_time=None)` returns a `PbsOptions` object with
-    fields `queue`, `constraint`, `gpus_per_node`, `max_wallclock`,
-    `filesystems`, `effective_nodes`, `wall_time`, `honored`, and `reason`.
+    queue=None, constraint=None, desired_wall_time=None)` returns a
+    `PbsOptions` object with fields `queue`, `constraint`, `gpus_per_node`,
+    `max_wallclock`, `filesystems`, `effective_nodes`, `wall_time`,
+    `honored`, and `reason`.
 
 For invalid gaps between scheduler ranges, node count is adjusted to the
 nearest valid value, preferring lower adjustments when feasible. If
@@ -190,6 +191,12 @@ request is not honored when:
 - clamping the node count to the target's `min_nodes`/`max_nodes` would fall
     below `min_nodes_allowed`, or
 - `desired_wall_time` is longer than the target's `max_wallclock`.
+
+A constraint can be requested the same way. Unlike a queue, partition or QOS,
+it has no node-count or wall-clock metadata and no `[constraint.*]` section, so
+it is validated only against the machine's `[parallel] constraints` list: a
+constraint that is not on that list falls back to the machine's default with a
+`reason`, exactly as the other targets do.
 
 Clamping the node count on its own does *not* prevent a target from being
 honored. The clamp is reported through `effective_nodes` and `adjustment`, and

--- a/docs/users_guide/parallel.md
+++ b/docs/users_guide/parallel.md
@@ -196,7 +196,8 @@ A constraint can be requested the same way. Unlike a queue, partition or QOS,
 it has no node-count or wall-clock metadata and no `[constraint.*]` section, so
 it is validated only against the machine's `[parallel] constraints` list: a
 constraint that is not on that list falls back to the machine's default with a
-`reason`, exactly as the other targets do.
+`reason`, exactly as the other targets do, and a machine that defines no
+constraints ignores the request entirely.
 
 Clamping the node count on its own does *not* prevent a target from being
 honored. The clamp is reported through `effective_nodes` and `adjustment`, and
@@ -206,6 +207,15 @@ honored. The clamp is reported through `effective_nodes` and `adjustment`, and
 `<<<default>>>` all mean "no target was requested", so config-driven callers
 can pass their raw config value through without guarding against unset
 placeholders.
+
+A request is also ignored, rather than denied, when the machine defines no
+targets of that type at all. Machines hang a concept like "debug" off
+different axes -- a partition on Chrysalis, a QOS on Frontier and Perlmutter,
+a queue on Aurora -- so a caller that asks on more than one axis should not be
+told its request was refused on the axes the machine does not use. There was
+no choice to deny, so `honored` stays `True` and `reason` stays `None`. A
+target missing from a list the machine *does* define is still a denied
+request.
 
 When `desired_wall_time` is given, the returned `wall_time` is that value
 capped at the selected target's `max_wallclock`. The same capping is available

--- a/docs/users_guide/parallel.md
+++ b/docs/users_guide/parallel.md
@@ -102,7 +102,8 @@ A common pattern is to generate scheduler directives separately, then use
 - Use `MachineInfo.get_account_defaults()` to populate account/partition/QOS.
 - Use `MachineInfo.get_queue_specs()`, `MachineInfo.get_partition_specs()` or
     `MachineInfo.get_qos_specs()` for optional scheduler-target policy
-    metadata (`min_nodes`, `max_nodes`, `max_wallclock`) when available.
+    metadata (`min_nodes`, `max_nodes`, `max_wallclock`,
+    `max_wallclock_bins`) when available.
 - Render scheduler headers (`#SBATCH` or `#PBS`) in your template logic.
 - Use `get_parallel_command()` to build the executable line.
 
@@ -212,3 +213,23 @@ cap_wall_time("04:00:00", "00:30:00")  # "00:30:00"
 Note that mache resolves the partition and the QOS independently and has no
 concept of one being valid only with the other. A caller that requests both is
 responsible for asking for a combination its machine accepts.
+
+## Wall-clock limits that depend on job size
+
+On some machines, the maximum wall time depends on how many nodes a job asks
+for. Frontier's `batch` partition allows 2 hours for 1-91 nodes, 6 hours for
+92-183 nodes, and 12 hours above that. These machines describe their policy
+with `max_wallclock_bins` rather than a single `max_wallclock` (see
+{ref}`dev-new-config-file`), and mache selects the bin that matches the
+resolved node count:
+
+```python
+options = SlurmSystem.resolve_slurm_options(config=config, nodes=8)
+options.max_wallclock  # "02:00:00" on Frontier
+
+options = SlurmSystem.resolve_slurm_options(config=config, nodes=200)
+options.max_wallclock  # "12:00:00" on Frontier
+```
+
+When both a partition and a QOS set a limit, the more restrictive of the two
+is reported, and that is also the limit `wall_time` is capped at.

--- a/mache/machine_info.py
+++ b/mache/machine_info.py
@@ -2,11 +2,12 @@ import configparser
 import os
 import pwd
 from importlib import resources as importlib_resources
-from typing import Dict
+from typing import Any, Dict
 
 from lxml import etree
 
 from mache.discover import discover_machine
+from mache.parallel.system import _get_wallclock_bins
 
 SCHEDULER_TARGET_MAP = {
     'queue': 'queues',
@@ -240,7 +241,7 @@ class MachineInfo:
 
         return account, partition, constraint, qos
 
-    def get_queue_specs(self) -> Dict[str, Dict[str, int | str | None]]:
+    def get_queue_specs(self) -> Dict[str, Dict[str, Any]]:
         """
         Get queue policy metadata for the machine.
 
@@ -250,6 +251,8 @@ class MachineInfo:
         - ``min_nodes`` (int)
         - ``max_nodes`` (int)
         - ``max_wallclock`` (str, e.g. ``01:00:00``)
+        - ``max_wallclock_bins`` (list of (int, str) tuples, for targets
+          whose wall-clock limit depends on the job size)
 
         Returns
         -------
@@ -259,7 +262,7 @@ class MachineInfo:
         """
         return self.get_scheduler_specs(target_type='queue')
 
-    def get_partition_specs(self) -> Dict[str, Dict[str, int | str | None]]:
+    def get_partition_specs(self) -> Dict[str, Dict[str, Any]]:
         """
         Get partition policy metadata for the machine.
 
@@ -270,6 +273,8 @@ class MachineInfo:
         - ``min_nodes`` (int)
         - ``max_nodes`` (int)
         - ``max_wallclock`` (str, e.g. ``01:00:00``)
+        - ``max_wallclock_bins`` (list of (int, str) tuples, for targets
+          whose wall-clock limit depends on the job size)
 
         Returns
         -------
@@ -279,7 +284,7 @@ class MachineInfo:
         """
         return self.get_scheduler_specs(target_type='partition')
 
-    def get_qos_specs(self) -> Dict[str, Dict[str, int | str | None]]:
+    def get_qos_specs(self) -> Dict[str, Dict[str, Any]]:
         """
         Get quality-of-service (QOS) policy metadata for the machine.
 
@@ -289,6 +294,8 @@ class MachineInfo:
         - ``min_nodes`` (int)
         - ``max_nodes`` (int)
         - ``max_wallclock`` (str, e.g. ``01:00:00``)
+        - ``max_wallclock_bins`` (list of (int, str) tuples, for targets
+          whose wall-clock limit depends on the job size)
 
         Returns
         -------
@@ -300,7 +307,7 @@ class MachineInfo:
 
     def get_scheduler_specs(
         self, target_type: str
-    ) -> Dict[str, Dict[str, int | str | None]]:
+    ) -> Dict[str, Dict[str, Any]]:
         """
         Get scheduler target metadata for queues or partitions.
 
@@ -313,8 +320,10 @@ class MachineInfo:
         -------
         target_specs : dict
             Mapping from target name to metadata with keys ``min_nodes``,
-            ``max_nodes`` and ``max_wallclock``. If a target section is
-            missing, all metadata values are ``None``.
+            ``max_nodes``, ``max_wallclock`` and ``max_wallclock_bins``. If a
+            target section is missing, all metadata values are ``None``.
+            ``max_wallclock`` and ``max_wallclock_bins`` are mutually
+            exclusive, so at most one of them is set.
         """
         if target_type not in SCHEDULER_TARGET_MAP:
             expected = ', '.join(SCHEDULER_TARGET_MAP.keys())
@@ -334,12 +343,13 @@ class MachineInfo:
             if target.strip() != ''
         ]
 
-        target_specs: Dict[str, Dict[str, int | str | None]] = {}
+        target_specs: Dict[str, Dict[str, Any]] = {}
         for target in targets:
             section = f'{target_type}.{target}'
             min_nodes = self._get_scheduler_int(section, 'min_nodes')
             max_nodes = self._get_scheduler_int(section, 'max_nodes')
             max_wallclock = self._get_scheduler_value(section, 'max_wallclock')
+            max_wallclock_bins = _get_wallclock_bins(config, section)
 
             if (
                 min_nodes is not None
@@ -355,6 +365,7 @@ class MachineInfo:
                 'min_nodes': min_nodes,
                 'max_nodes': max_nodes,
                 'max_wallclock': max_wallclock,
+                'max_wallclock_bins': max_wallclock_bins,
             }
 
         return target_specs

--- a/mache/machines/frontier.cfg
+++ b/mache/machines/frontier.cfg
@@ -47,7 +47,10 @@ system = slurm
 account = cli115
 
 # available partition(s) (default is the first)
-partitions = batch
+partitions = batch, extended
+
+# available quality of service (default is the first)
+qos = normal, debug
 
 # whether to use mpirun or srun to run a task
 parallel_executable = srun -l -K --threads-per-core=1
@@ -69,6 +72,45 @@ distribution = block:cyclic
 
 # gpu binding
 gpu_bind =
+
+
+# partition policy metadata for downstream job-script generation
+[partition.batch]
+
+# batch is the default partition for production work; the maximum wall clock
+# depends on the job-size bin
+min_nodes = 1
+max_nodes = 9472
+max_wallclock_bins = 91: 02:00:00,
+                     183: 06:00:00,
+                     9472: 12:00:00
+
+
+[partition.extended]
+
+# extended is for smaller long-running jobs
+min_nodes = 1
+max_nodes = 64
+max_wallclock = 24:00:00
+
+
+# qos policy metadata for downstream job-script generation
+[qos.normal]
+
+# normal adds no limits of its own; the partition is what binds
+min_nodes = 1
+max_nodes =
+max_wallclock =
+
+
+[qos.debug]
+
+# debug is for short, non-production debugging; jobs asking for more than two
+# hours are rejected at submission.  It is only meaningful on the batch
+# partition -- extended exists for 24-hour jobs.
+min_nodes = 1
+max_nodes =
+max_wallclock = 02:00:00
 
 
 # parallel options related to the craygnu-mphipcc compiler

--- a/mache/parallel/pbs.py
+++ b/mache/parallel/pbs.py
@@ -9,6 +9,7 @@ from typing import List
 from mache.parallel.system import (
     ParallelSystem,
     _ceil_division,
+    _combine_reasons,
     cap_wall_time,
 )
 
@@ -106,6 +107,7 @@ class PbsSystem(ParallelSystem):
         nodes: int,
         min_nodes_allowed: int | None = None,
         queue: str | None = None,
+        constraint: str | None = None,
         desired_wall_time: str | None = None,
     ) -> PbsOptions:
         """
@@ -129,6 +131,9 @@ class PbsSystem(ParallelSystem):
         queue : str, optional
             A specific queue the caller would like to use.
 
+        constraint : str, optional
+            A specific constraint the caller would like to use.
+
         desired_wall_time : str, optional
             The wall time (``HH:MM:SS``) the caller intends to request. A
             requested queue that does not allow it is not honored, and the
@@ -150,8 +155,11 @@ class PbsSystem(ParallelSystem):
         queue_name = queue_resolution.target
         effective_nodes = queue_resolution.effective_nodes
 
-        constraint, gpus_per_node, filesystems = (
-            cls._get_common_submission_options(config)
+        _, gpus_per_node, filesystems = cls._get_common_submission_options(
+            config
+        )
+        constraint_name, constraint_reason = cls._resolve_constraint(
+            config, constraint
         )
         max_wallclock = cls._get_max_wallclock(
             config, 'queue', queue_name, effective_nodes
@@ -163,14 +171,16 @@ class PbsSystem(ParallelSystem):
 
         return PbsOptions(
             queue=queue_name,
-            constraint=constraint,
+            constraint=constraint_name,
             gpus_per_node=gpus_per_node,
             max_wallclock=max_wallclock,
             filesystems=filesystems,
             effective_nodes=effective_nodes,
             wall_time=wall_time,
-            honored=queue_resolution.honored,
-            reason=queue_resolution.reason,
+            honored=(queue_resolution.honored and constraint_reason is None),
+            reason=_combine_reasons(
+                queue_resolution.reason, constraint_reason
+            ),
         )
 
     @classmethod

--- a/mache/parallel/pbs.py
+++ b/mache/parallel/pbs.py
@@ -1,10 +1,68 @@
 import os
 import re
 import subprocess
+import warnings
 from configparser import ConfigParser
+from dataclasses import dataclass
 from typing import List
 
-from mache.parallel.system import ParallelSystem, _ceil_division
+from mache.parallel.system import (
+    ParallelSystem,
+    _ceil_division,
+    cap_wall_time,
+)
+
+
+@dataclass(frozen=True)
+class PbsOptions:
+    """
+    PBS submission options resolved from a machine's config.
+
+    Attributes
+    ----------
+    queue : str
+        The PBS queue, or an empty string if the machine defines none.
+
+    constraint : str
+        The constraint, or an empty string if the machine defines none.
+
+    gpus_per_node : str
+        The number of GPUs per node, or an empty string if not configured.
+
+    max_wallclock : str
+        The maximum wall clock (``HH:MM:SS``) of the selected queue, or an
+        empty string if the queue does not set one.
+
+    filesystems : str
+        The filesystems used for batch jobs, or an empty string if not
+        configured.
+
+    effective_nodes : int
+        The node count after clamping to the selected queue's limits.
+
+    wall_time : str
+        The requested wall time capped at ``max_wallclock``, or an empty
+        string if no wall time was requested.
+
+    honored : bool
+        Whether the requested queue was used. ``True`` when no queue was
+        requested.
+
+    reason : str or None
+        A human-readable explanation of why a requested queue could not be
+        honored, suitable for printing verbatim. ``None`` when ``honored``
+        is ``True``.
+    """
+
+    queue: str
+    constraint: str
+    gpus_per_node: str
+    max_wallclock: str
+    filesystems: str
+    effective_nodes: int
+    wall_time: str = ''
+    honored: bool = True
+    reason: str | None = None
 
 
 class PbsSystem(ParallelSystem):
@@ -42,34 +100,111 @@ class PbsSystem(ParallelSystem):
             self.gpus = gpus_per_node * nodes
 
     @classmethod
+    def resolve_pbs_options(
+        cls,
+        config: ConfigParser,
+        nodes: int,
+        min_nodes_allowed: int | None = None,
+        queue: str | None = None,
+        desired_wall_time: str | None = None,
+    ) -> PbsOptions:
+        """
+        Get PBS submission options for a requested node count.
+
+        A requested queue is honored when the machine's metadata allows it;
+        otherwise the default queue is used and the returned options explain
+        why.
+
+        Parameters
+        ----------
+        config : ConfigParser
+            Machine configuration parser.
+
+        nodes : int
+            Requested node count.
+
+        min_nodes_allowed : int, optional
+            Optional lower bound for adjusted node counts.
+
+        queue : str, optional
+            A specific queue the caller would like to use.
+
+        desired_wall_time : str, optional
+            The wall time (``HH:MM:SS``) the caller intends to request. A
+            requested queue that does not allow it is not honored, and the
+            returned ``wall_time`` is capped at ``max_wallclock``.
+
+        Returns
+        -------
+        PbsOptions
+            The resolved PBS submission options.
+        """
+        queue_resolution = cls.resolve_submission(
+            config=config,
+            nodes=nodes,
+            target_type='queue',
+            min_nodes_allowed=min_nodes_allowed,
+            requested=queue,
+            desired_wall_time=desired_wall_time,
+        )
+        queue_name = queue_resolution.target
+        effective_nodes = queue_resolution.effective_nodes
+
+        constraint, gpus_per_node, filesystems = (
+            cls._get_common_submission_options(config)
+        )
+        max_wallclock = cls._get_max_wallclock(config, 'queue', queue_name)
+
+        wall_time = ''
+        if desired_wall_time is not None:
+            wall_time = cap_wall_time(desired_wall_time, max_wallclock)
+
+        return PbsOptions(
+            queue=queue_name,
+            constraint=constraint,
+            gpus_per_node=gpus_per_node,
+            max_wallclock=max_wallclock,
+            filesystems=filesystems,
+            effective_nodes=effective_nodes,
+            wall_time=wall_time,
+            honored=queue_resolution.honored,
+            reason=queue_resolution.reason,
+        )
+
+    @classmethod
     def get_pbs_options(
         cls,
         config: ConfigParser,
         nodes: int,
         min_nodes_allowed: int | None = None,
     ) -> tuple[str, str, str, str, str, int]:
-        """Get PBS submission options for a requested node count."""
-        queue_resolution = cls.resolve_submission(
+        """
+        Get PBS submission options for a requested node count.
+
+        .. deprecated:: 3.11.0
+            Use :py:meth:`resolve_pbs_options` instead, which returns a
+            :py:class:`PbsOptions` object and supports requesting a specific
+            queue.
+        """
+        warnings.warn(
+            'PbsSystem.get_pbs_options() is deprecated and will be removed '
+            'in a future release. Use PbsSystem.resolve_pbs_options(), '
+            'which returns a PbsOptions object.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        options = cls.resolve_pbs_options(
             config=config,
             nodes=nodes,
-            target_type='queue',
             min_nodes_allowed=min_nodes_allowed,
         )
-        queue = queue_resolution.target
-        effective_nodes = queue_resolution.effective_nodes
-
-        constraint, gpus_per_node, filesystems = (
-            cls._get_common_submission_options(config)
-        )
-        max_wallclock = cls._get_max_wallclock(config, 'queue', queue)
-
         return (
-            queue,
-            constraint,
-            gpus_per_node,
-            max_wallclock,
-            filesystems,
-            effective_nodes,
+            options.queue,
+            options.constraint,
+            options.gpus_per_node,
+            options.max_wallclock,
+            options.filesystems,
+            options.effective_nodes,
         )
 
     def _get_parallel_args(

--- a/mache/parallel/pbs.py
+++ b/mache/parallel/pbs.py
@@ -153,7 +153,9 @@ class PbsSystem(ParallelSystem):
         constraint, gpus_per_node, filesystems = (
             cls._get_common_submission_options(config)
         )
-        max_wallclock = cls._get_max_wallclock(config, 'queue', queue_name)
+        max_wallclock = cls._get_max_wallclock(
+            config, 'queue', queue_name, effective_nodes
+        )
 
         wall_time = ''
         if desired_wall_time is not None:

--- a/mache/parallel/pbs.py
+++ b/mache/parallel/pbs.py
@@ -10,6 +10,7 @@ from mache.parallel.system import (
     ParallelSystem,
     _ceil_division,
     _combine_reasons,
+    _normalize_requested,
     cap_wall_time,
 )
 
@@ -46,11 +47,11 @@ class PbsOptions:
         string if no wall time was requested.
 
     honored : bool
-        Whether the requested queue was used. ``True`` when no queue was
-        requested.
+        Whether every requested target -- queue, constraint and
+        ``scheduler_target`` -- was used. ``True`` when none was requested.
 
     reason : str or None
-        A human-readable explanation of why a requested queue could not be
+        A human-readable explanation of why a requested target could not be
         honored, suitable for printing verbatim. ``None`` when ``honored``
         is ``True``.
     """
@@ -105,6 +106,7 @@ class PbsSystem(ParallelSystem):
         queue: str | None = None,
         constraint: str | None = None,
         desired_wall_time: str | None = None,
+        scheduler_target: str | None = None,
     ) -> PbsOptions:
         """
         Get PBS submission options for a requested node count.
@@ -135,11 +137,24 @@ class PbsSystem(ParallelSystem):
             requested queue that does not allow it is not honored, and the
             returned ``wall_time`` is capped at ``max_wallclock``.
 
+        scheduler_target : str, optional
+            A target named without saying which axis it is on, for callers
+            with one machine-independent intent such as "use the debug
+            target". PBS machines schedule by queue, so it is used as the
+            queue when this machine lists it as one. ``queue`` takes
+            precedence.
+
         Returns
         -------
         PbsOptions
             The resolved PBS submission options.
         """
+        target_type, target_reason = cls._find_scheduler_target(
+            config, scheduler_target, ('queue',)
+        )
+        if target_type == 'queue' and _normalize_requested(queue) is None:
+            queue = scheduler_target
+
         queue_resolution = cls.resolve_submission(
             config=config,
             nodes=nodes,
@@ -173,9 +188,13 @@ class PbsSystem(ParallelSystem):
             filesystems=filesystems,
             effective_nodes=effective_nodes,
             wall_time=wall_time,
-            honored=(queue_resolution.honored and constraint_reason is None),
+            honored=(
+                queue_resolution.honored
+                and constraint_reason is None
+                and target_reason is None
+            ),
             reason=_combine_reasons(
-                queue_resolution.reason, constraint_reason
+                target_reason, queue_resolution.reason, constraint_reason
             ),
         )
 

--- a/mache/parallel/pbs.py
+++ b/mache/parallel/pbs.py
@@ -92,11 +92,7 @@ class PbsSystem(ParallelSystem):
         self.mpi_allowed = True
 
         gpus_per_node = self.get_config_int('gpus_per_node')
-        if (
-            gpus_per_node is not None
-            and gpus_per_node != ''
-            and gpus_per_node != '0'
-        ):
+        if gpus_per_node is not None:
             self.gpus_per_node = gpus_per_node
             self.gpus = gpus_per_node * nodes
 

--- a/mache/parallel/slurm.py
+++ b/mache/parallel/slurm.py
@@ -101,6 +101,7 @@ class SlurmSystem(ParallelSystem):
         min_nodes_allowed: int | None = None,
         partition: str | None = None,
         qos: str | None = None,
+        constraint: str | None = None,
         desired_wall_time: str | None = None,
     ) -> SlurmOptions:
         """
@@ -127,6 +128,9 @@ class SlurmSystem(ParallelSystem):
 
         qos : str, optional
             A specific quality of service the caller would like to use.
+
+        constraint : str, optional
+            A specific constraint the caller would like to use.
 
         desired_wall_time : str, optional
             The wall time (``HH:MM:SS``) the caller intends to request. A
@@ -159,8 +163,9 @@ class SlurmSystem(ParallelSystem):
         qos_name = qos_resolution.target
         effective_nodes = qos_resolution.effective_nodes
 
-        constraint, gpus_per_node, _ = cls._get_common_submission_options(
-            config
+        _, gpus_per_node, _ = cls._get_common_submission_options(config)
+        constraint_name, constraint_reason = cls._resolve_constraint(
+            config, constraint
         )
 
         max_wallclock = cls._select_max_wallclock(
@@ -177,14 +182,20 @@ class SlurmSystem(ParallelSystem):
         return SlurmOptions(
             partition=partition_name,
             qos=qos_name,
-            constraint=constraint,
+            constraint=constraint_name,
             gpus_per_node=gpus_per_node,
             max_wallclock=max_wallclock,
             effective_nodes=effective_nodes,
             wall_time=wall_time,
-            honored=(partition_resolution.honored and qos_resolution.honored),
+            honored=(
+                partition_resolution.honored
+                and qos_resolution.honored
+                and constraint_reason is None
+            ),
             reason=_combine_reasons(
-                partition_resolution.reason, qos_resolution.reason
+                partition_resolution.reason,
+                qos_resolution.reason,
+                constraint_reason,
             ),
         )
 

--- a/mache/parallel/slurm.py
+++ b/mache/parallel/slurm.py
@@ -164,8 +164,10 @@ class SlurmSystem(ParallelSystem):
         )
 
         max_wallclock = cls._select_max_wallclock(
-            cls._get_max_wallclock(config, 'partition', partition_name),
-            cls._get_max_wallclock(config, 'qos', qos_name),
+            cls._get_max_wallclock(
+                config, 'partition', partition_name, effective_nodes
+            ),
+            cls._get_max_wallclock(config, 'qos', qos_name, effective_nodes),
         )
 
         wall_time = ''

--- a/mache/parallel/slurm.py
+++ b/mache/parallel/slurm.py
@@ -1,12 +1,68 @@
 import os
+import warnings
 from configparser import ConfigParser
+from dataclasses import dataclass
 from typing import List
 
 from mache.parallel.system import (
     ParallelSystem,
     _ceil_division,
+    _combine_reasons,
     _get_subprocess_int,
+    cap_wall_time,
 )
+
+
+@dataclass(frozen=True)
+class SlurmOptions:
+    """
+    Slurm submission options resolved from a machine's config.
+
+    Attributes
+    ----------
+    partition : str
+        The Slurm partition, or an empty string if the machine defines none.
+
+    qos : str
+        The Slurm quality of service, or an empty string if the machine
+        defines none.
+
+    constraint : str
+        The Slurm constraint, or an empty string if the machine defines none.
+
+    gpus_per_node : str
+        The number of GPUs per node, or an empty string if not configured.
+
+    max_wallclock : str
+        The most restrictive maximum wall clock (``HH:MM:SS``) of the
+        selected partition and QOS, or an empty string if neither sets one.
+
+    effective_nodes : int
+        The node count after clamping to the selected targets' limits.
+
+    wall_time : str
+        The requested wall time capped at ``max_wallclock``, or an empty
+        string if no wall time was requested.
+
+    honored : bool
+        Whether the requested partition and QOS were both used. ``True``
+        when neither was requested.
+
+    reason : str or None
+        A human-readable explanation of why a requested partition or QOS
+        could not be honored, suitable for printing verbatim. ``None`` when
+        ``honored`` is ``True``.
+    """
+
+    partition: str
+    qos: str
+    constraint: str
+    gpus_per_node: str
+    max_wallclock: str
+    effective_nodes: int
+    wall_time: str = ''
+    honored: bool = True
+    reason: str | None = None
 
 
 class SlurmSystem(ParallelSystem):
@@ -38,46 +94,133 @@ class SlurmSystem(ParallelSystem):
             self.gpus = self.gpus_per_node * nodes
 
     @classmethod
-    def get_slurm_options(
+    def resolve_slurm_options(
         cls,
         config: ConfigParser,
         nodes: int,
         min_nodes_allowed: int | None = None,
-    ) -> tuple[str, str, str, str, str, int]:
-        """Get Slurm submission options for a requested node count."""
+        partition: str | None = None,
+        qos: str | None = None,
+        desired_wall_time: str | None = None,
+    ) -> SlurmOptions:
+        """
+        Get Slurm submission options for a requested node count.
+
+        The partition is resolved first and the QOS is then resolved against
+        the resulting node count. A requested partition or QOS is honored
+        when the machine's metadata allows it; otherwise the default is used
+        and the returned options explain why.
+
+        Parameters
+        ----------
+        config : ConfigParser
+            Machine configuration parser.
+
+        nodes : int
+            Requested node count.
+
+        min_nodes_allowed : int, optional
+            Optional lower bound for adjusted node counts.
+
+        partition : str, optional
+            A specific partition the caller would like to use.
+
+        qos : str, optional
+            A specific quality of service the caller would like to use.
+
+        desired_wall_time : str, optional
+            The wall time (``HH:MM:SS``) the caller intends to request. A
+            requested target that does not allow it is not honored, and the
+            returned ``wall_time`` is capped at ``max_wallclock``.
+
+        Returns
+        -------
+        SlurmOptions
+            The resolved Slurm submission options.
+        """
         partition_resolution = cls.resolve_submission(
             config=config,
             nodes=nodes,
             target_type='partition',
             min_nodes_allowed=min_nodes_allowed,
+            requested=partition,
+            desired_wall_time=desired_wall_time,
         )
-        partition = partition_resolution.target
-        effective_nodes = partition_resolution.effective_nodes
+        partition_name = partition_resolution.target
 
         qos_resolution = cls.resolve_submission(
             config=config,
-            nodes=effective_nodes,
+            nodes=partition_resolution.effective_nodes,
             target_type='qos',
             min_nodes_allowed=min_nodes_allowed,
+            requested=qos,
+            desired_wall_time=desired_wall_time,
         )
-        qos = qos_resolution.target
+        qos_name = qos_resolution.target
+        effective_nodes = qos_resolution.effective_nodes
 
         constraint, gpus_per_node, _ = cls._get_common_submission_options(
             config
         )
 
         max_wallclock = cls._select_max_wallclock(
-            cls._get_max_wallclock(config, 'partition', partition),
-            cls._get_max_wallclock(config, 'qos', qos),
+            cls._get_max_wallclock(config, 'partition', partition_name),
+            cls._get_max_wallclock(config, 'qos', qos_name),
         )
 
+        wall_time = ''
+        if desired_wall_time is not None:
+            wall_time = cap_wall_time(desired_wall_time, max_wallclock)
+
+        return SlurmOptions(
+            partition=partition_name,
+            qos=qos_name,
+            constraint=constraint,
+            gpus_per_node=gpus_per_node,
+            max_wallclock=max_wallclock,
+            effective_nodes=effective_nodes,
+            wall_time=wall_time,
+            honored=(partition_resolution.honored and qos_resolution.honored),
+            reason=_combine_reasons(
+                partition_resolution.reason, qos_resolution.reason
+            ),
+        )
+
+    @classmethod
+    def get_slurm_options(
+        cls,
+        config: ConfigParser,
+        nodes: int,
+        min_nodes_allowed: int | None = None,
+    ) -> tuple[str, str, str, str, str, int]:
+        """
+        Get Slurm submission options for a requested node count.
+
+        .. deprecated:: 3.11.0
+            Use :py:meth:`resolve_slurm_options` instead, which returns a
+            :py:class:`SlurmOptions` object and supports requesting a
+            specific partition or QOS.
+        """
+        warnings.warn(
+            'SlurmSystem.get_slurm_options() is deprecated and will be '
+            'removed in a future release. Use '
+            'SlurmSystem.resolve_slurm_options(), which returns a '
+            'SlurmOptions object.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        options = cls.resolve_slurm_options(
+            config=config,
+            nodes=nodes,
+            min_nodes_allowed=min_nodes_allowed,
+        )
         return (
-            partition,
-            qos,
-            constraint,
-            gpus_per_node,
-            max_wallclock,
-            effective_nodes,
+            options.partition,
+            options.qos,
+            options.constraint,
+            options.gpus_per_node,
+            options.max_wallclock,
+            options.effective_nodes,
         )
 
     def _get_parallel_args(

--- a/mache/parallel/slurm.py
+++ b/mache/parallel/slurm.py
@@ -9,6 +9,7 @@ from mache.parallel.system import (
     _ceil_division,
     _combine_reasons,
     _get_subprocess_int,
+    _normalize_requested,
     cap_wall_time,
 )
 
@@ -45,13 +46,13 @@ class SlurmOptions:
         string if no wall time was requested.
 
     honored : bool
-        Whether the requested partition and QOS were both used. ``True``
-        when neither was requested.
+        Whether every requested target -- partition, QOS, constraint and
+        ``scheduler_target`` -- was used. ``True`` when none was requested.
 
     reason : str or None
-        A human-readable explanation of why a requested partition or QOS
-        could not be honored, suitable for printing verbatim. ``None`` when
-        ``honored`` is ``True``.
+        A human-readable explanation of why a requested target could not be
+        honored, suitable for printing verbatim. ``None`` when ``honored``
+        is ``True``.
     """
 
     partition: str
@@ -103,6 +104,7 @@ class SlurmSystem(ParallelSystem):
         qos: str | None = None,
         constraint: str | None = None,
         desired_wall_time: str | None = None,
+        scheduler_target: str | None = None,
     ) -> SlurmOptions:
         """
         Get Slurm submission options for a requested node count.
@@ -137,11 +139,29 @@ class SlurmSystem(ParallelSystem):
             requested target that does not allow it is not honored, and the
             returned ``wall_time`` is capped at ``max_wallclock``.
 
+        scheduler_target : str, optional
+            A target named without saying which axis it is on, for callers
+            with one machine-independent intent such as "use the debug
+            target". It is used as the partition or the QOS, whichever this
+            machine lists it under, checking partitions first. ``partition``
+            and ``qos`` take precedence on the axis they name.
+
         Returns
         -------
         SlurmOptions
             The resolved Slurm submission options.
         """
+        target_type, target_reason = cls._find_scheduler_target(
+            config, scheduler_target, ('partition', 'qos')
+        )
+        if (
+            target_type == 'partition'
+            and _normalize_requested(partition) is None
+        ):
+            partition = scheduler_target
+        elif target_type == 'qos' and _normalize_requested(qos) is None:
+            qos = scheduler_target
+
         partition_resolution = cls.resolve_submission(
             config=config,
             nodes=nodes,
@@ -191,8 +211,10 @@ class SlurmSystem(ParallelSystem):
                 partition_resolution.honored
                 and qos_resolution.honored
                 and constraint_reason is None
+                and target_reason is None
             ),
             reason=_combine_reasons(
+                target_reason,
                 partition_resolution.reason,
                 qos_resolution.reason,
                 constraint_reason,

--- a/mache/parallel/system.py
+++ b/mache/parallel/system.py
@@ -450,6 +450,40 @@ class ParallelSystem:
         return constraint, gpus_per_node_str, filesystems
 
     @classmethod
+    def _resolve_constraint(
+        cls, config: ConfigParser, requested: str | None
+    ) -> tuple[str, str | None]:
+        """
+        Resolve a constraint, honoring a requested one when it is available.
+
+        Unlike queues, partitions and QOS, a constraint has no node-count or
+        wall-clock metadata, so it is only checked against the machine's
+        ``[parallel] constraints`` list.
+
+        Returns the constraint and either ``None`` (nothing was requested or
+        the request was honored) or a reason why the request could not be.
+        """
+        parallel_configs = _get_parallel_configs(config)
+        constraints = _parse_list(parallel_configs.get('constraints'))
+        default = constraints[0] if len(constraints) > 0 else ''
+
+        requested_constraint = _normalize_requested(requested)
+        if requested_constraint is None:
+            return default, None
+
+        if requested_constraint in constraints:
+            return requested_constraint, None
+
+        if len(constraints) == 0:
+            available = 'this machine defines no constraints'
+        else:
+            available = f'available: {", ".join(constraints)}'
+        return default, (
+            f'"{requested_constraint}" is not an available constraint on '
+            f'this machine ({available})'
+        )
+
+    @classmethod
     def _get_max_wallclock(
         cls,
         config: ConfigParser,

--- a/mache/parallel/system.py
+++ b/mache/parallel/system.py
@@ -449,6 +449,52 @@ class ParallelSystem:
         return constraint, gpus_per_node_str, filesystems
 
     @classmethod
+    def _find_scheduler_target(
+        cls,
+        config: ConfigParser,
+        scheduler_target: str | None,
+        target_types: tuple[str, ...],
+    ) -> tuple[str | None, str | None]:
+        """
+        Find which scheduler axis a target name belongs to on this machine.
+
+        Machines hang a concept such as "debug" off whichever axis they use,
+        so a caller with one machine-independent intent can name it once and
+        let mache decide whether it is a queue, a partition or a QOS here.
+
+        ``target_types`` is searched in order, so the first axis that lists
+        the name wins.
+
+        Returns the target type that lists ``scheduler_target``, or ``None``
+        along with a reason when no axis in ``target_types`` does.  Both are
+        ``None`` when nothing was requested.
+        """
+        requested = _normalize_requested(scheduler_target)
+        if requested is None:
+            return None, None
+
+        parallel_configs = _get_parallel_configs(config)
+
+        described = []
+        for target_type in target_types:
+            plural = TARGET_TYPE_MAP[target_type]
+            targets = _parse_list(parallel_configs.get(plural))
+            if requested in targets:
+                return target_type, None
+            if len(targets) > 0:
+                described.append(f'{plural}: {", ".join(targets)}')
+
+        if len(described) == 0:
+            available = 'this machine defines no scheduler targets'
+        else:
+            available = '; '.join(described)
+
+        return None, (
+            f'"{requested}" is not an available scheduler target on this '
+            f'machine ({available})'
+        )
+
+    @classmethod
     def _resolve_constraint(
         cls, config: ConfigParser, requested: str | None
     ) -> tuple[str, str | None]:

--- a/mache/parallel/system.py
+++ b/mache/parallel/system.py
@@ -1,17 +1,52 @@
 import subprocess
 from configparser import ConfigParser
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Dict, List, Literal
+
+# the config option in [parallel] that lists each type of scheduler target
+TARGET_TYPE_MAP = {
+    'queue': 'queues',
+    'partition': 'partitions',
+    'qos': 'qos',
+}
 
 
 @dataclass(frozen=True)
 class SubmissionResolution:
-    """Resolved scheduler target and effective node count."""
+    """
+    Resolved scheduler target and effective node count.
+
+    Attributes
+    ----------
+    target : str
+        The selected queue, partition or QOS, or an empty string if the
+        machine does not define any for this target type.
+
+    requested_nodes : int
+        The node count the caller asked for.
+
+    effective_nodes : int
+        The node count after clamping to the selected target's limits.
+
+    adjustment : {'exact', 'decrease', 'increase'}
+        How ``effective_nodes`` compares with ``requested_nodes``.
+
+    honored : bool
+        Whether a requested target was used. ``True`` when no target was
+        requested.
+
+    reason : str or None
+        A human-readable explanation of why a requested target could not be
+        honored, suitable for printing verbatim. ``None`` when ``honored``
+        is ``True``.
+    """
 
     target: str
     requested_nodes: int
     effective_nodes: int
     adjustment: Literal['exact', 'decrease', 'increase']
+    honored: bool = True
+    reason: str | None = None
 
 
 class ParallelSystem:
@@ -136,17 +171,24 @@ class ParallelSystem:
         nodes: int,
         target_type: str,
         min_nodes_allowed: int | None = None,
+        requested: str | None = None,
+        desired_wall_time: str | None = None,
     ) -> SubmissionResolution:
         """
         Resolve a scheduler target and effective node count.
 
         Policy:
 
-        - Prefer exact match when available.
+        - If ``requested`` is given and can be honored, use it.
+        - Otherwise, prefer exact match when available.
         - Otherwise choose the nearest valid node count.
         - Tie-break toward lower (decrease) adjustments.
         - If a lower adjustment violates ``min_nodes_allowed``, choose the
           nearest feasible higher adjustment.
+
+        A requested target is a preference, not an assertion: if it cannot be
+        honored, the default target is resolved instead and the returned
+        resolution has ``honored=False`` along with a ``reason``.
 
         Parameters
         ----------
@@ -162,11 +204,62 @@ class ParallelSystem:
         min_nodes_allowed : int, optional
             Optional lower bound for adjusted node counts.
 
+        requested : str, optional
+            A specific target the caller would like to use. ``None``, an
+            empty string and placeholders such as ``<<<default>>>`` all mean
+            "no target was requested".
+
+        desired_wall_time : str, optional
+            The wall time (``HH:MM:SS``) the caller intends to request. When
+            given, a requested target whose ``max_wallclock`` is shorter is
+            not honored.
+
         Returns
         -------
         SubmissionResolution
             The selected target and adjusted node count.
         """
+        targets = cls._get_targets(
+            config, nodes, target_type, min_nodes_allowed
+        )
+
+        requested_target = _normalize_requested(requested)
+        if requested_target is None:
+            return cls._resolve_default(
+                config, nodes, target_type, min_nodes_allowed, targets
+            )
+
+        effective_nodes, reason = cls._check_requested(
+            config=config,
+            nodes=nodes,
+            target_type=target_type,
+            min_nodes_allowed=min_nodes_allowed,
+            targets=targets,
+            requested=requested_target,
+            desired_wall_time=desired_wall_time,
+        )
+        if reason is None:
+            return SubmissionResolution(
+                target=requested_target,
+                requested_nodes=nodes,
+                effective_nodes=effective_nodes,
+                adjustment=_get_adjustment(nodes, effective_nodes),
+            )
+
+        fallback = cls._resolve_default(
+            config, nodes, target_type, min_nodes_allowed, targets
+        )
+        return replace(fallback, honored=False, reason=reason)
+
+    @classmethod
+    def _get_targets(
+        cls,
+        config: ConfigParser,
+        nodes: int,
+        target_type: str,
+        min_nodes_allowed: int | None,
+    ) -> list[str]:
+        """Validate arguments and get the available targets."""
         if nodes <= 0:
             raise ValueError(f'nodes must be positive, got {nodes}.')
         if min_nodes_allowed is not None and min_nodes_allowed <= 0:
@@ -174,21 +267,104 @@ class ParallelSystem:
                 f'min_nodes_allowed must be positive, got {min_nodes_allowed}.'
             )
 
-        target_map = {
-            'queue': 'queues',
-            'partition': 'partitions',
-            'qos': 'qos',
-        }
-        if target_type not in target_map:
-            expected = ', '.join(target_map.keys())
+        if target_type not in TARGET_TYPE_MAP:
+            expected = ', '.join(TARGET_TYPE_MAP.keys())
             raise ValueError(
                 f'Unexpected target_type: {target_type}. Expected one of: '
                 f'{expected}.'
             )
 
         parallel_configs = _get_parallel_configs(config)
-        targets_value = parallel_configs.get(target_map[target_type])
-        targets = _parse_list(targets_value)
+        targets_value = parallel_configs.get(TARGET_TYPE_MAP[target_type])
+        return _parse_list(targets_value)
+
+    @classmethod
+    def _check_requested(
+        cls,
+        config: ConfigParser,
+        nodes: int,
+        target_type: str,
+        min_nodes_allowed: int | None,
+        targets: list[str],
+        requested: str,
+        desired_wall_time: str | None,
+    ) -> tuple[int, str | None]:
+        """
+        Check whether a requested target can be honored.
+
+        Returns the effective node count and either ``None`` (the request can
+        be honored) or a reason why it cannot.
+        """
+        if requested not in targets:
+            if len(targets) == 0:
+                plural = TARGET_TYPE_MAP[target_type]
+                available = f'this machine defines no {plural}'
+            else:
+                available = f'available: {", ".join(targets)}'
+            return nodes, (
+                f'"{requested}" is not an available {target_type} on this '
+                f'machine ({available})'
+            )
+
+        effective_nodes = cls._get_effective_nodes(
+            config, target_type, requested, nodes
+        )
+
+        if (
+            min_nodes_allowed is not None
+            and effective_nodes < min_nodes_allowed
+        ):
+            return effective_nodes, (
+                f'the "{requested}" {target_type} would run on '
+                f'{effective_nodes} nodes but at least {min_nodes_allowed} '
+                f'are required'
+            )
+
+        max_wallclock = cls._get_max_wallclock(config, target_type, requested)
+        if _wall_time_exceeds(desired_wall_time, max_wallclock):
+            return effective_nodes, (
+                f'the "{requested}" {target_type} allows a maximum wall '
+                f'clock of {max_wallclock} but {desired_wall_time} was '
+                f'requested'
+            )
+
+        return effective_nodes, None
+
+    @classmethod
+    def _get_effective_nodes(
+        cls,
+        config: ConfigParser,
+        target_type: str,
+        target: str,
+        nodes: int,
+    ) -> int:
+        """Clamp a node count to a target's ``min_nodes``/``max_nodes``."""
+        section = f'{target_type}.{target}'
+        min_nodes = _get_int_option(config, section, 'min_nodes')
+        max_nodes = _get_int_option(config, section, 'max_nodes')
+
+        if (
+            min_nodes is not None
+            and max_nodes is not None
+            and min_nodes > max_nodes
+        ):
+            raise ValueError(
+                f'Invalid {target_type} config [{section}]: min_nodes '
+                f'({min_nodes}) is greater than max_nodes ({max_nodes}).'
+            )
+
+        return _clamp_nodes(nodes, min_nodes, max_nodes)
+
+    @classmethod
+    def _resolve_default(
+        cls,
+        config: ConfigParser,
+        nodes: int,
+        target_type: str,
+        min_nodes_allowed: int | None,
+        targets: list[str],
+    ) -> SubmissionResolution:
+        """Resolve a target from the node count alone."""
         if len(targets) == 0:
             return SubmissionResolution(
                 target='',
@@ -200,21 +376,9 @@ class ParallelSystem:
         candidates: list[tuple[str, int, int]] = []
         # tuple: (target, effective_nodes, order)
         for index, target in enumerate(targets):
-            section = f'{target_type}.{target}'
-            min_nodes = _get_int_option(config, section, 'min_nodes')
-            max_nodes = _get_int_option(config, section, 'max_nodes')
-
-            if (
-                min_nodes is not None
-                and max_nodes is not None
-                and min_nodes > max_nodes
-            ):
-                raise ValueError(
-                    f'Invalid {target_type} config [{section}]: min_nodes '
-                    f'({min_nodes}) is greater than max_nodes ({max_nodes}).'
-                )
-
-            effective_nodes = _clamp_nodes(nodes, min_nodes, max_nodes)
+            effective_nodes = cls._get_effective_nodes(
+                config, target_type, target, nodes
+            )
 
             if (
                 min_nodes_allowed is not None
@@ -259,18 +423,11 @@ class ParallelSystem:
                     key=lambda item: (item[1], item[2]),
                 )
 
-        if best_nodes == nodes:
-            adjustment: Literal['exact', 'decrease', 'increase'] = 'exact'
-        elif best_nodes < nodes:
-            adjustment = 'decrease'
-        else:
-            adjustment = 'increase'
-
         return SubmissionResolution(
             target=best_target,
             requested_nodes=nodes,
             effective_nodes=best_nodes,
-            adjustment=adjustment,
+            adjustment=_get_adjustment(nodes, best_nodes),
         )
 
     @classmethod
@@ -322,6 +479,87 @@ class ParallelSystem:
         if seconds_a <= seconds_b:
             return max_wallclock_a
         return max_wallclock_b
+
+
+def cap_wall_time(desired: str, max_wallclock: str) -> str:
+    """
+    Cap a desired wall time at a scheduler target's maximum.
+
+    Parameters
+    ----------
+    desired : str
+        The wall time (``HH:MM:SS``) the caller would like to request.
+
+    max_wallclock : str
+        The maximum wall time (``HH:MM:SS``) the target allows, typically
+        from ``SlurmOptions.max_wallclock`` or ``PbsOptions.max_wallclock``.
+
+    Returns
+    -------
+    wall_time : str
+        ``max_wallclock`` if it is shorter than ``desired``, otherwise
+        ``desired`` unchanged. ``desired`` is also returned unchanged if
+        either value is empty or cannot be parsed.
+    """
+    if not _wall_time_exceeds(desired, max_wallclock):
+        return desired
+    return max_wallclock
+
+
+def _normalize_requested(requested: str | None) -> str | None:
+    """
+    Normalize a requested target, treating placeholders as no request.
+
+    ``None``, an empty string and placeholders such as ``<<<default>>>``
+    (used by downstream config files to mean "let mache choose") all become
+    ``None``.
+    """
+    if requested is None:
+        return None
+
+    requested = requested.strip()
+    if requested == '':
+        return None
+    if requested.startswith('<<<') and requested.endswith('>>>'):
+        return None
+    return requested
+
+
+def _get_adjustment(
+    nodes: int, effective_nodes: int
+) -> Literal['exact', 'decrease', 'increase']:
+    """Describe how an effective node count differs from the request."""
+    if effective_nodes == nodes:
+        return 'exact'
+    if effective_nodes < nodes:
+        return 'decrease'
+    return 'increase'
+
+
+def _wall_time_exceeds(desired: str | None, max_wallclock: str) -> bool:
+    """
+    Check whether a desired wall time is longer than a maximum.
+
+    Returns ``False`` if either value is missing or cannot be parsed, since
+    an unknown limit is not a reason to reject anything.
+    """
+    if desired is None or desired == '' or max_wallclock == '':
+        return False
+
+    desired_seconds = _max_wallclock_to_seconds(desired)
+    max_seconds = _max_wallclock_to_seconds(max_wallclock)
+    if desired_seconds is None or max_seconds is None:
+        return False
+
+    return desired_seconds > max_seconds
+
+
+def _combine_reasons(*reasons: str | None) -> str | None:
+    """Join the reasons from several resolutions into one message."""
+    present = [reason for reason in reasons if reason is not None]
+    if len(present) == 0:
+        return None
+    return '; '.join(present)
 
 
 def _get_parallel_configs(config: ConfigParser) -> Dict[str, str]:

--- a/mache/parallel/system.py
+++ b/mache/parallel/system.py
@@ -207,7 +207,9 @@ class ParallelSystem:
         requested : str, optional
             A specific target the caller would like to use. ``None``, an
             empty string and placeholders such as ``<<<default>>>`` all mean
-            "no target was requested".
+            "no target was requested".  A request is also ignored when the
+            machine defines no targets of this type at all, since there is
+            then no choice for the request to have been denied.
 
         desired_wall_time : str, optional
             The wall time (``HH:MM:SS``) the caller intends to request. When
@@ -224,7 +226,9 @@ class ParallelSystem:
         )
 
         requested_target = _normalize_requested(requested)
-        if requested_target is None:
+        if requested_target is None or len(targets) == 0:
+            # A machine that defines no targets of this type has no notion
+            # of one, so a request is a no-op rather than a denied request.
             return cls._resolve_default(
                 config, nodes, target_type, min_nodes_allowed, targets
             )
@@ -296,14 +300,9 @@ class ParallelSystem:
         be honored) or a reason why it cannot.
         """
         if requested not in targets:
-            if len(targets) == 0:
-                plural = TARGET_TYPE_MAP[target_type]
-                available = f'this machine defines no {plural}'
-            else:
-                available = f'available: {", ".join(targets)}'
             return nodes, (
                 f'"{requested}" is not an available {target_type} on this '
-                f'machine ({available})'
+                f'machine (available: {", ".join(targets)})'
             )
 
         effective_nodes = cls._get_effective_nodes(
@@ -468,19 +467,17 @@ class ParallelSystem:
         default = constraints[0] if len(constraints) > 0 else ''
 
         requested_constraint = _normalize_requested(requested)
-        if requested_constraint is None:
+        if requested_constraint is None or len(constraints) == 0:
+            # A machine that defines no constraints has no notion of one, so
+            # a request is a no-op rather than a denied request.
             return default, None
 
         if requested_constraint in constraints:
             return requested_constraint, None
 
-        if len(constraints) == 0:
-            available = 'this machine defines no constraints'
-        else:
-            available = f'available: {", ".join(constraints)}'
         return default, (
             f'"{requested_constraint}" is not an available constraint on '
-            f'this machine ({available})'
+            f'this machine (available: {", ".join(constraints)})'
         )
 
     @classmethod

--- a/mache/parallel/system.py
+++ b/mache/parallel/system.py
@@ -320,7 +320,9 @@ class ParallelSystem:
                 f'are required'
             )
 
-        max_wallclock = cls._get_max_wallclock(config, target_type, requested)
+        max_wallclock = cls._get_max_wallclock(
+            config, target_type, requested, effective_nodes
+        )
         if _wall_time_exceeds(desired_wall_time, max_wallclock):
             return effective_nodes, (
                 f'the "{requested}" {target_type} allows a maximum wall '
@@ -449,13 +451,27 @@ class ParallelSystem:
 
     @classmethod
     def _get_max_wallclock(
-        cls, config: ConfigParser, target_type: str, target: str
+        cls,
+        config: ConfigParser,
+        target_type: str,
+        target: str,
+        nodes: int,
     ) -> str:
-        """Get max wall-clock metadata for a selected scheduler target."""
+        """
+        Get max wall-clock metadata for a selected scheduler target.
+
+        Targets whose limit depends on the job size supply
+        ``max_wallclock_bins`` instead of ``max_wallclock``, in which case
+        the bin containing ``nodes`` is used.
+        """
         if target == '':
             return ''
 
         section = f'{target_type}.{target}'
+        bins = _get_wallclock_bins(config, section)
+        if bins is not None:
+            return _select_wallclock_bin(bins, nodes)
+
         max_wallclock = _get_string_option(config, section, 'max_wallclock')
         if max_wallclock is None:
             return ''
@@ -504,6 +520,80 @@ def cap_wall_time(desired: str, max_wallclock: str) -> str:
     if not _wall_time_exceeds(desired, max_wallclock):
         return desired
     return max_wallclock
+
+
+def _get_wallclock_bins(
+    config: ConfigParser, section: str
+) -> list[tuple[int, str]] | None:
+    """
+    Get the parsed ``max_wallclock_bins`` for a scheduler target section.
+
+    Returns ``None`` if the section does not define job-size-dependent wall
+    clocks. Raises ``ValueError`` if the section also defines a plain
+    ``max_wallclock``, since the two would be ambiguous.
+    """
+    value = _get_string_option(config, section, 'max_wallclock_bins')
+    if value is None:
+        return None
+
+    if _get_string_option(config, section, 'max_wallclock') is not None:
+        raise ValueError(
+            f'Invalid config [{section}]: max_wallclock and '
+            f'max_wallclock_bins cannot both be set.'
+        )
+
+    return _parse_wallclock_bins(value, section)
+
+
+def _parse_wallclock_bins(value: str, section: str) -> list[tuple[int, str]]:
+    """
+    Parse ``<max nodes>: <max wallclock>`` entries into sorted bins.
+
+    Entries are comma-separated and each is split on its first colon, since
+    the wall clock itself contains colons.
+    """
+    bins: list[tuple[int, str]] = []
+    for entry in value.split(','):
+        entry = entry.strip()
+        if entry == '':
+            continue
+
+        node_bound_str, _, max_wallclock = entry.partition(':')
+        max_wallclock = max_wallclock.strip()
+        try:
+            node_bound = int(node_bound_str.strip())
+        except ValueError:
+            raise ValueError(
+                f'Invalid max_wallclock_bins entry "{entry}" in [{section}]: '
+                f'expected an integer node count before the colon.'
+            ) from None
+
+        if _max_wallclock_to_seconds(max_wallclock) is None:
+            raise ValueError(
+                f'Invalid max_wallclock_bins entry "{entry}" in [{section}]: '
+                f'expected a wall clock of the form HH:MM:SS after the '
+                f'colon.'
+            )
+
+        bins.append((node_bound, max_wallclock))
+
+    if len(bins) == 0:
+        raise ValueError(
+            f'Invalid config [{section}]: max_wallclock_bins is set but has '
+            f'no entries.'
+        )
+
+    return sorted(bins)
+
+
+def _select_wallclock_bin(bins: list[tuple[int, str]], nodes: int) -> str:
+    """Get the wall clock for the bin containing a node count."""
+    for node_bound, max_wallclock in bins:
+        if nodes <= node_bound:
+            return max_wallclock
+
+    # a node count above every bin gets the largest bin's wall clock
+    return bins[-1][1]
 
 
 def _normalize_requested(requested: str | None) -> str | None:

--- a/mache/version.py
+++ b/mache/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (3, 10, 0)
+__version_info__ = (3, 11, 0)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/tests/test_machine_info.py
+++ b/tests/test_machine_info.py
@@ -42,16 +42,19 @@ def test_get_queue_specs_aurora():
         'min_nodes': 1,
         'max_nodes': 16,
         'max_wallclock': '168:00:00',
+        'max_wallclock_bins': None,
     }
     assert queue_specs['prod'] == {
         'min_nodes': 256,
         'max_nodes': None,
         'max_wallclock': '12:00:00',
+        'max_wallclock_bins': None,
     }
     assert queue_specs['debug'] == {
         'min_nodes': 1,
         'max_nodes': 2,
         'max_wallclock': '01:00:00',
+        'max_wallclock_bins': None,
     }
 
 
@@ -69,11 +72,13 @@ def test_get_partition_specs_chrysalis():
         'min_nodes': 1,
         'max_nodes': None,
         'max_wallclock': '168:00:00',
+        'max_wallclock_bins': None,
     }
     assert partition_specs['debug'] == {
         'min_nodes': 1,
         'max_nodes': 10,
         'max_wallclock': '168:00:00',
+        'max_wallclock_bins': None,
     }
 
 
@@ -86,11 +91,13 @@ def test_get_partition_specs_compy():
         'min_nodes': 1,
         'max_nodes': 440,
         'max_wallclock': '36:00:00',
+        'max_wallclock_bins': None,
     }
     assert partition_specs['short'] == {
         'min_nodes': 1,
         'max_nodes': 50,
         'max_wallclock': '02:00:00',
+        'max_wallclock_bins': None,
     }
 
 
@@ -103,16 +110,19 @@ def test_get_qos_specs_pm_cpu():
         'min_nodes': 1,
         'max_nodes': 8,
         'max_wallclock': '00:30:00',
+        'max_wallclock_bins': None,
     }
     assert qos_specs['regular'] == {
         'min_nodes': 1,
         'max_nodes': None,
         'max_wallclock': '48:00:00',
+        'max_wallclock_bins': None,
     }
     assert qos_specs['premium'] == {
         'min_nodes': 1,
         'max_nodes': None,
         'max_wallclock': '48:00:00',
+        'max_wallclock_bins': None,
     }
 
 
@@ -125,16 +135,19 @@ def test_get_qos_specs_pm_gpu():
         'min_nodes': 1,
         'max_nodes': 8,
         'max_wallclock': '00:30:00',
+        'max_wallclock_bins': None,
     }
     assert qos_specs['regular'] == {
         'min_nodes': 1,
         'max_nodes': 3072,
         'max_wallclock': '48:00:00',
+        'max_wallclock_bins': None,
     }
     assert qos_specs['premium'] == {
         'min_nodes': 1,
         'max_nodes': 3072,
         'max_wallclock': '48:00:00',
+        'max_wallclock_bins': None,
     }
 
 
@@ -147,11 +160,13 @@ def test_get_queue_specs_polaris():
         'min_nodes': 1,
         'max_nodes': 2,
         'max_wallclock': '01:00:00',
+        'max_wallclock_bins': None,
     }
     assert queue_specs['prod'] == {
         'min_nodes': 1,
         'max_nodes': 512,
         'max_wallclock': '24:00:00',
+        'max_wallclock_bins': None,
     }
 
 
@@ -204,6 +219,37 @@ def test_frontier_parallel_compiler_overrides(
         parallel_config['parallel_executable'] == expected_parallel_executable
     )
     assert parallel_config['distribution'] == expected_distribution
+
+
+def test_get_scheduler_specs_wallclock_bins():
+    machinfo = MachineInfo(machine='chrysalis')
+    config = machinfo.config
+    config.remove_option('partition.compute', 'max_wallclock')
+    config.set(
+        'partition.compute',
+        'max_wallclock_bins',
+        '91: 02:00:00,\n183: 06:00:00,\n1000: 12:00:00',
+    )
+
+    partition_specs = machinfo.get_partition_specs()
+
+    assert partition_specs['compute']['max_wallclock'] is None
+    assert partition_specs['compute']['max_wallclock_bins'] == [
+        (91, '02:00:00'),
+        (183, '06:00:00'),
+        (1000, '12:00:00'),
+    ]
+    assert partition_specs['debug']['max_wallclock_bins'] is None
+
+
+def test_get_scheduler_specs_wallclock_bins_conflict():
+    machinfo = MachineInfo(machine='chrysalis')
+    machinfo.config.set(
+        'partition.compute', 'max_wallclock_bins', '91: 02:00:00'
+    )
+
+    with pytest.raises(ValueError, match='cannot both be set'):
+        machinfo.get_partition_specs()
 
 
 def test_get_scheduler_specs_invalid_target_type():

--- a/tests/test_parallel_args.py
+++ b/tests/test_parallel_args.py
@@ -278,3 +278,46 @@ def test_pbs_uses_minimum_nodes_for_task_count(monkeypatch):
 
     index = args.index('--ppn')
     assert args[index + 1] == '4'
+
+
+def test_pbs_detects_gpus_per_node(monkeypatch):
+    config = _get_config(
+        {
+            'parallel_executable': 'mpiexec --label',
+            'cores_per_node': '32',
+            'gpus_per_node': '4',
+        }
+    )
+
+    monkeypatch.setenv('PBS_JOBID', '12345.server')
+    monkeypatch.setattr(
+        PbsSystem, '_get_node_count_from_qstat', lambda self: 2
+    )
+
+    system = PbsSystem(config)
+
+    assert system.gpus_per_node == 4
+    assert system.gpus == 8
+
+
+def test_pbs_reports_no_gpus_as_zero(monkeypatch):
+    """A machine or compiler with gpus_per_node = 0 has no GPUs."""
+    config = _get_config(
+        {
+            'parallel_executable': 'mpiexec --label',
+            'cores_per_node': '32',
+            'gpus_per_node': '0',
+        }
+    )
+
+    monkeypatch.setenv('PBS_JOBID', '12345.server')
+    monkeypatch.setattr(
+        PbsSystem, '_get_node_count_from_qstat', lambda self: 2
+    )
+
+    system = PbsSystem(config)
+
+    # consistent with SlurmSystem and SingleNodeSystem, which also report a
+    # known absence of GPUs as 0 rather than as None
+    assert system.gpus_per_node == 0
+    assert system.gpus == 0

--- a/tests/test_scheduler_options.py
+++ b/tests/test_scheduler_options.py
@@ -1,7 +1,9 @@
+import pytest
+
 from mache import MachineInfo
 from mache.parallel.pbs import PbsSystem
 from mache.parallel.slurm import SlurmSystem
-from mache.parallel.system import ParallelSystem
+from mache.parallel.system import ParallelSystem, cap_wall_time
 
 
 def test_get_scheduler_target_aurora_gap_errors():
@@ -13,6 +15,8 @@ def test_get_scheduler_target_aurora_gap_errors():
     assert resolution.target == 'capacity'
     assert resolution.effective_nodes == 16
     assert resolution.adjustment == 'decrease'
+    assert resolution.honored
+    assert resolution.reason is None
 
 
 def test_resolve_submission_aurora_gap_with_min_nodes_allowed():
@@ -31,91 +35,280 @@ def test_resolve_submission_aurora_gap_with_min_nodes_allowed():
 
 def test_get_pbs_options_aurora_capacity():
     config = MachineInfo(machine='aurora').config
-    (
-        queue,
-        constraint,
-        gpus_per_node,
-        max_wallclock,
-        filesystems,
-        effective_nodes,
-    ) = PbsSystem.get_pbs_options(config=config, nodes=8)
+    options = PbsSystem.resolve_pbs_options(config=config, nodes=8)
 
-    assert queue == 'capacity'
-    assert constraint == ''
-    assert gpus_per_node == ''
-    assert max_wallclock == '168:00:00'
-    assert filesystems == 'home:flare'
-    assert effective_nodes == 8
+    assert options.queue == 'capacity'
+    assert options.constraint == ''
+    assert options.gpus_per_node == ''
+    assert options.max_wallclock == '168:00:00'
+    assert options.filesystems == 'home:flare'
+    assert options.effective_nodes == 8
+    assert options.wall_time == ''
+    assert options.honored
+    assert options.reason is None
 
 
 def test_get_pbs_options_aurora_prod():
     config = MachineInfo(machine='aurora').config
-    (
-        queue,
-        constraint,
-        gpus_per_node,
-        max_wallclock,
-        filesystems,
-        effective_nodes,
-    ) = PbsSystem.get_pbs_options(config=config, nodes=256)
+    options = PbsSystem.resolve_pbs_options(config=config, nodes=256)
 
-    assert queue == 'prod'
-    assert constraint == ''
-    assert gpus_per_node == ''
-    assert max_wallclock == '12:00:00'
-    assert filesystems == 'home:flare'
-    assert effective_nodes == 256
+    assert options.queue == 'prod'
+    assert options.constraint == ''
+    assert options.gpus_per_node == ''
+    assert options.max_wallclock == '12:00:00'
+    assert options.filesystems == 'home:flare'
+    assert options.effective_nodes == 256
 
 
 def test_get_pbs_options_aurora_adjusted_nodes():
     config = MachineInfo(machine='aurora').config
-    (
-        queue,
-        _,
-        _,
-        max_wallclock,
-        _,
-        effective_nodes,
-    ) = PbsSystem.get_pbs_options(config=config, nodes=200)
+    options = PbsSystem.resolve_pbs_options(config=config, nodes=200)
 
-    assert queue == 'capacity'
-    assert effective_nodes == 16
-    assert max_wallclock == '168:00:00'
+    assert options.queue == 'capacity'
+    assert options.effective_nodes == 16
+    assert options.max_wallclock == '168:00:00'
 
 
 def test_get_slurm_options_compy():
     config = MachineInfo(machine='compy').config
-    (
-        partition,
-        qos,
-        constraint,
-        gpus_per_node,
-        max_wallclock,
-        effective_nodes,
-    ) = SlurmSystem.get_slurm_options(config=config, nodes=20)
+    options = SlurmSystem.resolve_slurm_options(config=config, nodes=20)
 
-    assert partition == 'slurm'
-    assert qos == 'regular'
-    assert constraint == ''
-    assert gpus_per_node == ''
-    assert max_wallclock == '36:00:00'
-    assert effective_nodes == 20
+    assert options.partition == 'slurm'
+    assert options.qos == 'regular'
+    assert options.constraint == ''
+    assert options.gpus_per_node == ''
+    assert options.max_wallclock == '36:00:00'
+    assert options.effective_nodes == 20
+    assert options.wall_time == ''
+    assert options.honored
+    assert options.reason is None
 
 
 def test_get_slurm_options_pm_gpu_uses_more_restrictive_qos_walltime():
     config = MachineInfo(machine='pm-gpu').config
-    (
-        partition,
-        qos,
-        constraint,
-        gpus_per_node,
-        max_wallclock,
-        effective_nodes,
-    ) = SlurmSystem.get_slurm_options(config=config, nodes=8)
+    options = SlurmSystem.resolve_slurm_options(config=config, nodes=8)
 
-    assert partition == ''
-    assert qos == 'regular'
-    assert constraint == 'gpu'
-    assert gpus_per_node == '4'
-    assert max_wallclock == '48:00:00'
-    assert effective_nodes == 8
+    assert options.partition == ''
+    assert options.qos == 'regular'
+    assert options.constraint == 'gpu'
+    assert options.gpus_per_node == '4'
+    assert options.max_wallclock == '48:00:00'
+    assert options.effective_nodes == 8
+
+
+def test_deprecated_get_slurm_options_matches_resolve():
+    config = MachineInfo(machine='compy').config
+    with pytest.warns(DeprecationWarning):
+        options_tuple = SlurmSystem.get_slurm_options(config=config, nodes=20)
+
+    options = SlurmSystem.resolve_slurm_options(config=config, nodes=20)
+
+    assert options_tuple == (
+        options.partition,
+        options.qos,
+        options.constraint,
+        options.gpus_per_node,
+        options.max_wallclock,
+        options.effective_nodes,
+    )
+    assert options_tuple == ('slurm', 'regular', '', '', '36:00:00', 20)
+
+
+def test_deprecated_get_pbs_options_matches_resolve():
+    config = MachineInfo(machine='aurora').config
+    with pytest.warns(DeprecationWarning):
+        options_tuple = PbsSystem.get_pbs_options(config=config, nodes=8)
+
+    options = PbsSystem.resolve_pbs_options(config=config, nodes=8)
+
+    assert options_tuple == (
+        options.queue,
+        options.constraint,
+        options.gpus_per_node,
+        options.max_wallclock,
+        options.filesystems,
+        options.effective_nodes,
+    )
+    assert options_tuple == (
+        'capacity',
+        '',
+        '',
+        '168:00:00',
+        'home:flare',
+        8,
+    )
+
+
+def test_requested_qos_honored_pm_cpu():
+    config = MachineInfo(machine='pm-cpu').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config,
+        nodes=4,
+        qos='debug',
+        desired_wall_time='00:20:00',
+    )
+
+    assert options.qos == 'debug'
+    assert options.max_wallclock == '00:30:00'
+    assert options.wall_time == '00:20:00'
+    assert options.effective_nodes == 4
+    assert options.honored
+    assert options.reason is None
+
+
+def test_requested_qos_wall_time_too_long_pm_cpu():
+    config = MachineInfo(machine='pm-cpu').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config,
+        nodes=4,
+        qos='debug',
+        desired_wall_time='02:00:00',
+    )
+
+    assert options.qos == 'regular'
+    assert options.wall_time == '02:00:00'
+    assert not options.honored
+    assert options.reason is not None
+    assert 'wall clock' in options.reason
+    assert '00:30:00' in options.reason
+    assert '02:00:00' in options.reason
+
+
+def test_requested_qos_not_available_pm_cpu():
+    config = MachineInfo(machine='pm-cpu').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=4, qos='nonexistent'
+    )
+
+    assert options.qos == 'regular'
+    assert not options.honored
+    assert options.reason is not None
+    assert 'not an available qos' in options.reason
+
+
+def test_requested_qos_honored_with_adjusted_nodes_pm_cpu():
+    config = MachineInfo(machine='pm-cpu').config
+    resolution = ParallelSystem.resolve_submission(
+        config=config, nodes=16, target_type='qos', requested='debug'
+    )
+
+    assert resolution.target == 'debug'
+    assert resolution.effective_nodes == 8
+    assert resolution.adjustment == 'decrease'
+    assert resolution.honored
+
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=16, qos='debug'
+    )
+
+    assert options.qos == 'debug'
+    assert options.effective_nodes == 8
+    assert options.honored
+
+
+def test_requested_qos_below_min_nodes_allowed_pm_cpu():
+    config = MachineInfo(machine='pm-cpu').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=16, qos='debug', min_nodes_allowed=16
+    )
+
+    assert options.qos == 'regular'
+    assert options.effective_nodes == 16
+    assert not options.honored
+    assert options.reason is not None
+    assert '16' in options.reason
+    assert 'at least' in options.reason
+
+
+@pytest.mark.parametrize('requested', [None, '', '   ', '<<<default>>>'])
+def test_requested_qos_placeholders_mean_no_request(requested):
+    config = MachineInfo(machine='pm-cpu').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=4, qos=requested
+    )
+
+    assert options.qos == 'regular'
+    assert options.honored
+    assert options.reason is None
+
+
+def test_requested_queue_honored_aurora():
+    config = MachineInfo(machine='aurora').config
+    options = PbsSystem.resolve_pbs_options(
+        config=config,
+        nodes=2,
+        queue='debug',
+        desired_wall_time='00:30:00',
+    )
+
+    assert options.queue == 'debug'
+    assert options.max_wallclock == '01:00:00'
+    assert options.wall_time == '00:30:00'
+    assert options.honored
+
+
+def test_requested_queue_wall_time_too_long_aurora():
+    config = MachineInfo(machine='aurora').config
+    options = PbsSystem.resolve_pbs_options(
+        config=config,
+        nodes=2,
+        queue='debug',
+        desired_wall_time='02:00:00',
+    )
+
+    assert options.queue == 'capacity'
+    assert options.wall_time == '02:00:00'
+    assert not options.honored
+    assert options.reason is not None
+    assert '01:00:00' in options.reason
+
+
+def test_requested_partition_honored_chrysalis():
+    config = MachineInfo(machine='chrysalis').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=4, partition='debug'
+    )
+
+    assert options.partition == 'debug'
+    assert options.effective_nodes == 4
+    assert options.honored
+
+
+def test_requested_target_on_machine_without_targets():
+    config = MachineInfo(machine='pm-cpu').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=4, partition='debug'
+    )
+
+    assert options.partition == ''
+    assert not options.honored
+    assert options.reason is not None
+    assert 'no partitions' in options.reason
+
+
+def test_resolve_submission_still_raises_when_infeasible():
+    config = MachineInfo(machine='aurora').config
+    with pytest.raises(ValueError, match='No queue matches'):
+        ParallelSystem.resolve_submission(
+            config=config,
+            target_type='queue',
+            nodes=8,
+            min_nodes_allowed=1024,
+        )
+
+
+@pytest.mark.parametrize(
+    'desired, max_wallclock, expected',
+    [
+        ('00:20:00', '00:30:00', '00:20:00'),
+        ('02:00:00', '00:30:00', '00:30:00'),
+        ('00:30:00', '00:30:00', '00:30:00'),
+        ('02:00:00', '', '02:00:00'),
+        ('', '00:30:00', ''),
+        ('bogus', '00:30:00', 'bogus'),
+        ('02:00:00', 'bogus', '02:00:00'),
+        ('1-00:00:00', '12:00:00', '1-00:00:00'),
+    ],
+)
+def test_cap_wall_time(desired, max_wallclock, expected):
+    assert cap_wall_time(desired, max_wallclock) == expected

--- a/tests/test_scheduler_options.py
+++ b/tests/test_scheduler_options.py
@@ -1,9 +1,38 @@
+from configparser import ConfigParser
+
 import pytest
 
 from mache import MachineInfo
 from mache.parallel.pbs import PbsSystem
 from mache.parallel.slurm import SlurmSystem
 from mache.parallel.system import ParallelSystem, cap_wall_time
+
+BINNED_CONFIG = """
+[parallel]
+system = slurm
+partitions = batch
+qos = normal, debug
+
+[partition.batch]
+min_nodes = 1
+max_nodes = 1000
+max_wallclock_bins = 91: 02:00:00,
+                     183: 06:00:00,
+                     1000: 12:00:00
+
+[qos.normal]
+min_nodes = 1
+
+[qos.debug]
+min_nodes = 1
+max_wallclock = 01:00:00
+"""
+
+
+def _config_from_string(text):
+    config = ConfigParser()
+    config.read_string(text)
+    return config
 
 
 def test_get_scheduler_target_aurora_gap_errors():
@@ -312,3 +341,134 @@ def test_resolve_submission_still_raises_when_infeasible():
 )
 def test_cap_wall_time(desired, max_wallclock, expected):
     assert cap_wall_time(desired, max_wallclock) == expected
+
+
+@pytest.mark.parametrize(
+    'nodes, expected',
+    [
+        (1, '02:00:00'),
+        (90, '02:00:00'),
+        (91, '02:00:00'),
+        (92, '06:00:00'),
+        (183, '06:00:00'),
+        (184, '12:00:00'),
+        (1000, '12:00:00'),
+        (2000, '12:00:00'),
+    ],
+)
+def test_wallclock_bins_select_by_node_count(nodes, expected):
+    config = _config_from_string(BINNED_CONFIG)
+    options = SlurmSystem.resolve_slurm_options(config=config, nodes=nodes)
+
+    assert options.partition == 'batch'
+    assert options.qos == 'normal'
+    assert options.max_wallclock == expected
+
+
+def test_wallclock_bins_single_entry_acts_like_max_wallclock():
+    config = _config_from_string(
+        """
+[parallel]
+system = slurm
+partitions = batch
+
+[partition.batch]
+min_nodes = 1
+max_wallclock_bins = 1000: 04:00:00
+"""
+    )
+    for nodes in [1, 500, 5000]:
+        options = SlurmSystem.resolve_slurm_options(config=config, nodes=nodes)
+        assert options.max_wallclock == '04:00:00'
+
+
+def test_wallclock_bins_combine_with_qos_limit():
+    config = _config_from_string(BINNED_CONFIG)
+
+    # the debug qos is more restrictive than the small-job bin
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=8, qos='debug'
+    )
+    assert options.max_wallclock == '01:00:00'
+    assert options.honored
+
+    # the small-job bin is more restrictive than the debug qos
+    config.set('qos.debug', 'max_wallclock', '04:00:00')
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=8, qos='debug'
+    )
+    assert options.max_wallclock == '02:00:00'
+
+
+def test_wallclock_bins_used_to_reject_a_request():
+    config = _config_from_string(BINNED_CONFIG)
+    options = SlurmSystem.resolve_slurm_options(
+        config=config,
+        nodes=8,
+        partition='batch',
+        desired_wall_time='04:00:00',
+    )
+
+    assert not options.honored
+    assert options.reason is not None
+    assert '02:00:00' in options.reason
+
+
+def test_wallclock_bins_are_sorted():
+    config = _config_from_string(
+        """
+[parallel]
+system = slurm
+partitions = batch
+
+[partition.batch]
+min_nodes = 1
+max_wallclock_bins = 1000: 12:00:00, 91: 02:00:00, 183: 06:00:00
+"""
+    )
+    options = SlurmSystem.resolve_slurm_options(config=config, nodes=8)
+
+    assert options.max_wallclock == '02:00:00'
+
+
+def test_wallclock_bins_conflict_with_max_wallclock():
+    config = _config_from_string(
+        """
+[parallel]
+system = slurm
+partitions = batch
+
+[partition.batch]
+min_nodes = 1
+max_wallclock = 12:00:00
+max_wallclock_bins = 91: 02:00:00
+"""
+    )
+    with pytest.raises(ValueError, match='cannot both be set'):
+        SlurmSystem.resolve_slurm_options(config=config, nodes=8)
+
+
+@pytest.mark.parametrize(
+    'bins, message',
+    [
+        ('lots: 02:00:00', 'expected an integer node count'),
+        ('91: two hours', 'expected a wall clock'),
+        ('02:00:00', 'expected a wall clock'),
+        ('91', 'expected a wall clock'),
+        (',', 'no entries'),
+    ],
+)
+def test_wallclock_bins_malformed(bins, message):
+    config = _config_from_string(
+        f"""
+[parallel]
+system = slurm
+partitions = batch
+
+[partition.batch]
+min_nodes = 1
+max_wallclock_bins = {bins}
+"""
+    )
+    with pytest.raises(ValueError, match=message):
+        SlurmSystem.resolve_slurm_options(config=config, nodes=8)

--- a/tests/test_scheduler_options.py
+++ b/tests/test_scheduler_options.py
@@ -344,6 +344,154 @@ def test_cap_wall_time(desired, max_wallclock, expected):
 
 
 @pytest.mark.parametrize(
+    'nodes, expected_wallclock',
+    [
+        (8, '02:00:00'),
+        (100, '06:00:00'),
+        (200, '12:00:00'),
+        (1000, '12:00:00'),
+    ],
+)
+def test_frontier_defaults(nodes, expected_wallclock):
+    config = MachineInfo(machine='frontier').config
+    options = SlurmSystem.resolve_slurm_options(config=config, nodes=nodes)
+
+    assert options.partition == 'batch'
+    assert options.qos == 'normal'
+    assert options.max_wallclock == expected_wallclock
+    assert options.effective_nodes == nodes
+    assert options.honored
+    assert options.reason is None
+
+
+def test_frontier_debug_qos_honored():
+    config = MachineInfo(machine='frontier').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config,
+        nodes=8,
+        qos='debug',
+        desired_wall_time='01:00:00',
+    )
+
+    assert options.partition == 'batch'
+    assert options.qos == 'debug'
+    assert options.max_wallclock == '02:00:00'
+    assert options.wall_time == '01:00:00'
+    assert options.honored
+
+
+def test_frontier_debug_qos_wall_time_too_long():
+    config = MachineInfo(machine='frontier').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config,
+        nodes=8,
+        qos='debug',
+        desired_wall_time='03:00:00',
+    )
+
+    assert options.qos == 'normal'
+    assert not options.honored
+    assert options.reason is not None
+    assert '02:00:00' in options.reason
+
+
+def test_frontier_debug_qos_binds_before_the_partition_bin():
+    config = MachineInfo(machine='frontier').config
+    # the batch bin allows 12 hours at 200 nodes, but debug allows only two
+    options = SlurmSystem.resolve_slurm_options(
+        config=config,
+        nodes=200,
+        qos='debug',
+        desired_wall_time='03:00:00',
+    )
+
+    assert options.qos == 'normal'
+    assert options.max_wallclock == '12:00:00'
+    assert not options.honored
+    assert options.reason is not None
+    assert '02:00:00' in options.reason
+
+
+def test_frontier_extended_partition_honored():
+    config = MachineInfo(machine='frontier').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config,
+        nodes=8,
+        partition='extended',
+        desired_wall_time='20:00:00',
+    )
+
+    assert options.partition == 'extended'
+    assert options.max_wallclock == '24:00:00'
+    assert options.wall_time == '20:00:00'
+    assert options.honored
+
+
+def test_frontier_extended_partition_clamps_nodes():
+    config = MachineInfo(machine='frontier').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=100, partition='extended'
+    )
+
+    assert options.partition == 'extended'
+    assert options.effective_nodes == 64
+    assert options.honored
+
+    resolution = ParallelSystem.resolve_submission(
+        config=config,
+        nodes=100,
+        target_type='partition',
+        requested='extended',
+    )
+    assert resolution.adjustment == 'decrease'
+
+
+def test_frontier_extended_partition_below_min_nodes_allowed():
+    config = MachineInfo(machine='frontier').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config,
+        nodes=100,
+        partition='extended',
+        min_nodes_allowed=100,
+    )
+
+    assert options.partition == 'batch'
+    assert options.effective_nodes == 100
+    assert not options.honored
+    assert options.reason is not None
+    assert '64' in options.reason
+    assert 'at least 100' in options.reason
+
+
+def test_frontier_wall_time_capped_at_the_small_job_bin():
+    config = MachineInfo(machine='frontier').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=8, desired_wall_time='04:00:00'
+    )
+
+    assert options.wall_time == '02:00:00'
+
+
+def test_frontier_partition_specs():
+    machinfo = MachineInfo(machine='frontier')
+    partition_specs = machinfo.get_partition_specs()
+
+    assert list(partition_specs.keys()) == ['batch', 'extended']
+    assert partition_specs['batch']['max_wallclock'] is None
+    assert partition_specs['batch']['max_wallclock_bins'] == [
+        (91, '02:00:00'),
+        (183, '06:00:00'),
+        (9472, '12:00:00'),
+    ]
+    assert partition_specs['extended'] == {
+        'min_nodes': 1,
+        'max_nodes': 64,
+        'max_wallclock': '24:00:00',
+        'max_wallclock_bins': None,
+    }
+
+
+@pytest.mark.parametrize(
     'nodes, expected',
     [
         (1, '02:00:00'),

--- a/tests/test_scheduler_options.py
+++ b/tests/test_scheduler_options.py
@@ -304,15 +304,28 @@ def test_requested_partition_honored_chrysalis():
 
 
 def test_requested_target_on_machine_without_targets():
+    """A machine that defines no partitions has none to deny."""
     config = MachineInfo(machine='pm-cpu').config
     options = SlurmSystem.resolve_slurm_options(
         config=config, nodes=4, partition='debug'
     )
 
     assert options.partition == ''
-    assert not options.honored
-    assert options.reason is not None
-    assert 'no partitions' in options.reason
+    assert options.honored
+    assert options.reason is None
+
+
+def test_requested_qos_on_machine_without_qos():
+    """A machine that defines no QOS has none to deny."""
+    config = MachineInfo(machine='chrysalis').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=4, partition='debug', qos='debug'
+    )
+
+    assert options.partition == 'debug'
+    assert options.qos == ''
+    assert options.honored
+    assert options.reason is None
 
 
 def test_requested_constraint_honored_pm_gpu():
@@ -352,18 +365,19 @@ def test_requested_constraint_placeholders_mean_no_request(requested):
 
 
 def test_requested_constraint_on_machine_without_constraints():
+    """A machine that defines no constraints has none to deny."""
     config = MachineInfo(machine='chrysalis').config
     options = SlurmSystem.resolve_slurm_options(
         config=config, nodes=4, constraint='anything'
     )
 
     assert options.constraint == ''
-    assert not options.honored
-    assert options.reason is not None
-    assert 'no constraints' in options.reason
+    assert options.honored
+    assert options.reason is None
 
 
 def test_requested_constraint_pbs():
+    """PBS machines ignore a constraint request the same way."""
     config = MachineInfo(machine='aurora').config
     options = PbsSystem.resolve_pbs_options(
         config=config, nodes=8, constraint='anything'
@@ -371,9 +385,8 @@ def test_requested_constraint_pbs():
 
     assert options.queue == 'capacity'
     assert options.constraint == ''
-    assert not options.honored
-    assert options.reason is not None
-    assert 'no constraints' in options.reason
+    assert options.honored
+    assert options.reason is None
 
 
 def test_honored_constraint_with_unhonored_qos():

--- a/tests/test_scheduler_options.py
+++ b/tests/test_scheduler_options.py
@@ -315,6 +315,94 @@ def test_requested_target_on_machine_without_targets():
     assert 'no partitions' in options.reason
 
 
+def test_requested_constraint_honored_pm_gpu():
+    config = MachineInfo(machine='pm-gpu').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=8, constraint='gpu'
+    )
+
+    assert options.constraint == 'gpu'
+    assert options.honored
+    assert options.reason is None
+
+
+def test_requested_constraint_not_available_pm_gpu():
+    config = MachineInfo(machine='pm-gpu').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=8, constraint='cpu'
+    )
+
+    assert options.constraint == 'gpu'
+    assert not options.honored
+    assert options.reason is not None
+    assert 'not an available constraint' in options.reason
+    assert 'available: gpu' in options.reason
+
+
+@pytest.mark.parametrize('requested', [None, '', '   ', '<<<default>>>'])
+def test_requested_constraint_placeholders_mean_no_request(requested):
+    config = MachineInfo(machine='pm-cpu').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=4, constraint=requested
+    )
+
+    assert options.constraint == 'cpu'
+    assert options.honored
+    assert options.reason is None
+
+
+def test_requested_constraint_on_machine_without_constraints():
+    config = MachineInfo(machine='chrysalis').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=4, constraint='anything'
+    )
+
+    assert options.constraint == ''
+    assert not options.honored
+    assert options.reason is not None
+    assert 'no constraints' in options.reason
+
+
+def test_requested_constraint_pbs():
+    config = MachineInfo(machine='aurora').config
+    options = PbsSystem.resolve_pbs_options(
+        config=config, nodes=8, constraint='anything'
+    )
+
+    assert options.queue == 'capacity'
+    assert options.constraint == ''
+    assert not options.honored
+    assert options.reason is not None
+    assert 'no constraints' in options.reason
+
+
+def test_honored_constraint_with_unhonored_qos():
+    config = MachineInfo(machine='pm-gpu').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=8, constraint='gpu', qos='nonexistent'
+    )
+
+    assert options.constraint == 'gpu'
+    assert options.qos == 'regular'
+    assert not options.honored
+    assert options.reason is not None
+    assert 'nonexistent' in options.reason
+
+
+def test_unhonored_constraint_and_qos_report_both_reasons():
+    config = MachineInfo(machine='pm-gpu').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=8, constraint='cpu', qos='nonexistent'
+    )
+
+    assert options.constraint == 'gpu'
+    assert options.qos == 'regular'
+    assert not options.honored
+    assert options.reason is not None
+    assert 'nonexistent' in options.reason
+    assert 'not an available constraint' in options.reason
+
+
 def test_resolve_submission_still_raises_when_infeasible():
     config = MachineInfo(machine='aurora').config
     with pytest.raises(ValueError, match='No queue matches'):

--- a/tests/test_scheduler_options.py
+++ b/tests/test_scheduler_options.py
@@ -721,3 +721,102 @@ max_wallclock_bins = {bins}
     )
     with pytest.raises(ValueError, match=message):
         SlurmSystem.resolve_slurm_options(config=config, nodes=8)
+
+
+@pytest.mark.parametrize(
+    'machine, expected_partition, expected_qos',
+    [
+        ('chrysalis', 'debug', ''),
+        ('pm-cpu', '', 'debug'),
+        ('pm-gpu', '', 'debug'),
+        ('frontier', 'batch', 'debug'),
+    ],
+)
+def test_scheduler_target_finds_the_right_axis(
+    machine, expected_partition, expected_qos
+):
+    """One intent lands on whichever axis the machine spells it on."""
+    config = MachineInfo(machine=machine).config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config,
+        nodes=2,
+        scheduler_target='debug',
+        desired_wall_time='00:20:00',
+    )
+
+    assert options.partition == expected_partition
+    assert options.qos == expected_qos
+    assert options.honored
+    assert options.reason is None
+
+
+def test_scheduler_target_on_pbs():
+    """PBS machines schedule by queue, so that is the axis used."""
+    config = MachineInfo(machine='aurora').config
+    options = PbsSystem.resolve_pbs_options(
+        config=config,
+        nodes=2,
+        scheduler_target='debug',
+        desired_wall_time='00:30:00',
+    )
+
+    assert options.queue == 'debug'
+    assert options.honored
+    assert options.reason is None
+
+
+def test_scheduler_target_on_no_axis():
+    """A name on no axis is a genuine failed request."""
+    config = MachineInfo(machine='frontier').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=2, scheduler_target='nonexistent'
+    )
+
+    assert options.partition == 'batch'
+    assert options.qos == 'normal'
+    assert not options.honored
+    assert options.reason is not None
+    assert 'not an available scheduler target' in options.reason
+    assert 'partitions: batch, extended' in options.reason
+    assert 'qos: normal, debug' in options.reason
+
+
+def test_scheduler_target_still_subject_to_wall_clock():
+    """Mapping to an axis does not exempt a target from its own limits."""
+    config = MachineInfo(machine='frontier').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config,
+        nodes=2,
+        scheduler_target='debug',
+        desired_wall_time='03:00:00',
+    )
+
+    assert options.qos == 'normal'
+    assert not options.honored
+    assert options.reason is not None
+    assert '02:00:00' in options.reason
+
+
+def test_explicit_target_beats_scheduler_target():
+    """An explicit axis request wins on the axis it names."""
+    config = MachineInfo(machine='frontier').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=2, scheduler_target='debug', qos='normal'
+    )
+
+    assert options.qos == 'normal'
+    assert options.honored
+
+
+@pytest.mark.parametrize('requested', [None, '', '   ', '<<<default>>>'])
+def test_scheduler_target_placeholders_mean_no_request(requested):
+    """Placeholders leave the machine defaults alone."""
+    config = MachineInfo(machine='frontier').config
+    options = SlurmSystem.resolve_slurm_options(
+        config=config, nodes=2, scheduler_target=requested
+    )
+
+    assert options.partition == 'batch'
+    assert options.qos == 'normal'
+    assert options.honored
+    assert options.reason is None


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

## What was broken

mache picked a machine's queue, partition or QOS entirely on its own, from the machine's list of available targets and the number of nodes a job wanted. There was no way for a caller to say "I want the debug QOS for this job." Tools built on mache worked around that by reaching into mache's own config: deep-copying it, rewriting the list of available targets down to the single one they wanted, calling mache, and then second-guessing whatever came back. That is fragile -- it depends on config details that are mache's business, and it duplicates logic mache already has.

The workaround also could not tell the difference between "this machine has no debug QOS" and "debug exists but this job is too big for it," so users got misleading messages about why they did not get what they asked for.

Frontier had a second, simpler problem: its config listed one partition, `batch`, with no limits attached and no QOS at all. Nothing recorded that Frontier has a debug QOS, an `extended` partition, or any wall-clock limits, so no caller could request a debug configuration there no matter how it asked, and nothing could tell a job that its wall time was longer than the scheduler would accept.

## What this fixes

Callers can now request a specific queue, partition, QOS or constraint directly, and mache either honors it or explains, in a sentence meant to be printed as-is, why it could not. A request is treated as a preference rather than a demand: if it cannot be honored, mache falls back to the machine's default and reports `honored = False` along with a `reason`, instead of failing. The three reasons are distinct and accurate -- the target does not exist on this machine, the job would be clamped to fewer nodes than the caller allows, or the requested wall time is longer than the target permits. A constraint has no node or wall-clock limits of its own, so it is checked only against the machine's list of available constraints, but it behaves the same way otherwise.

mache also now caps a desired wall time at the selected target's limit, so callers no longer need their own copy of that arithmetic.

Frontier gains the partitions and QOS that OLCF actually documents: the `extended` partition (24 hours, up to 64 nodes) alongside `batch`, and the `normal` and `debug` QOS (2 hours). Because Frontier's wall-clock limit on `batch` depends on job size -- 2 hours up to 91 nodes, 6 hours to 183, 12 hours above that -- machine configs can now express a limit that varies with node count instead of a single number. `batch` and `normal` remain the defaults, and an unqualified request resolves to exactly what it did before.

## What this means for downstream tools

Polaris can delete its config-rewriting workaround and pass its `[job] partition` / `qos` / `queue` / `constraint` settings straight through, printing `reason` when a request is not honored. Placeholder values such as `<<<default>>>` are understood as "no request", so config-driven callers do not need to guard against unset options.

`SlurmSystem.get_slurm_options()` and `PbsSystem.get_pbs_options()` still return the same tuples they always have, but are deprecated in favor of `resolve_slurm_options()` and `resolve_pbs_options()`, which return objects that can gain fields without breaking positional unpacking. One behavior change worth flagging: when a QOS restricts the node count more than the partition does, the returned node count now reflects that stricter limit. This version is 3.11.0.

## Testing

- `pytest tests/` -- 264 passed. (The `pixi run` wrapper fails in this environment with a lock-file version error unrelated to these changes, so tests and hooks were run with the interpreter in `.pixi/envs/default`, which is the same environment.)

- `pre-commit run --files <all changed files>` -- all hooks pass.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [x] User's Guide has been updated if needed
- [x] Developer's Guide has been updated if needed
- [x] API documentation lists any new or modified class, method, or function
- [x] Tests pass and new features are covered by tests
- [x] `Testing` comment, if appropriate, in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

