### PR TITLE
Make `pixi install` retries able to recover from stale repodata

### DIFF
--- a/mache/deploy/bootstrap.py
+++ b/mache/deploy/bootstrap.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 import time
+from functools import partial
 from pathlib import Path
 from typing import Dict, List  # noqa: F401
 
@@ -344,9 +345,18 @@ def check_call_with_retries(
     *,
     retries=3,
     retry_delay=2.0,
+    on_retry=None,
     **popen_kwargs,
 ):
-    """Run a command with a few retries for transient pixi/network failures."""
+    """Run a command with a few retries for transient pixi/network failures.
+
+    If ``on_retry`` is given, it is called with no arguments after a failed
+    attempt that will be followed by another attempt.  It is never called
+    before the first attempt or after the final failure.  It is meant to
+    change whatever state made the previous attempt fail (for example,
+    clearing a stale repodata cache).  A failure inside ``on_retry`` is
+    logged and ignored so that it cannot mask the original error.
+    """
 
     last_error = None
     for attempt in range(1, retries + 1):
@@ -357,18 +367,67 @@ def check_call_with_retries(
             if attempt >= retries:
                 raise
 
-            message = (
+            _log_message(
                 f'Command failed on attempt {attempt}/{retries}; '
-                f'retrying in {retry_delay:.0f}s...\n'
+                f'retrying in {retry_delay:.0f}s...\n',
+                log_filename,
+                quiet,
             )
-            with open(log_filename, 'a', encoding='utf-8') as log_file:
-                log_file.write(message)
-            if not quiet:
-                print(message)
+            if on_retry is not None:
+                _run_retry_hook(on_retry, log_filename, quiet)
             time.sleep(retry_delay)
 
     if last_error is not None:
         raise last_error
+
+
+def _log_message(message, log_filename, quiet):
+    """Append a message to the log file and echo it unless quiet."""
+    with open(log_filename, 'a', encoding='utf-8') as log_file:
+        log_file.write(message)
+    if not quiet:
+        print(message)
+
+
+def _run_retry_hook(on_retry, log_filename, quiet):
+    """Call a retry hook, logging (but not raising) any failure."""
+    try:
+        on_retry()
+    except Exception as exc:
+        _log_message(
+            f'The retry hook failed and was ignored: {exc}\n',
+            log_filename,
+            quiet,
+        )
+
+
+def _clear_pixi_repodata_cache(*, pixi_exe, log_filename, quiet):
+    """Drop cached repodata so the next solve refetches it.
+
+    A stale repodata cache makes every retry of a failed ``pixi install``
+    read the same cached (and possibly out-of-date) package index without
+    any network traffic, so the retries cannot succeed.  Clearing the cache
+    costs a few MB of downloads on the next attempt and only happens after
+    a command has already failed.
+    """
+    _log_message(
+        'Clearing the pixi repodata cache before retrying...\n',
+        log_filename,
+        quiet,
+    )
+    try:
+        check_call(
+            [pixi_exe, 'clean', 'cache', '--repodata', '-y'],
+            log_filename,
+            quiet,
+            env=build_pixi_env(),
+        )
+    except Exception as exc:
+        _log_message(
+            f'Could not clear the pixi repodata cache: {exc}\n',
+            log_filename,
+            quiet,
+        )
 
 
 def build_pixi_shell_hook_prefix(*, pixi_exe: str, pixi_toml: str) -> str:
@@ -555,6 +614,12 @@ def _run(log_filename):
             quiet,
             cwd=str(bootstrap_dir),
             env=build_pixi_env(),
+            on_retry=partial(
+                _clear_pixi_repodata_cache,
+                pixi_exe=pixi_exe,
+                log_filename=log_filename,
+                quiet=quiet,
+            ),
         )
 
         pixi_toml = str(pixi_toml_path.resolve())
@@ -584,6 +649,12 @@ def _run(log_filename):
             quiet,
             cwd=str(bootstrap_dir),
             env=build_pixi_env(),
+            on_retry=partial(
+                _clear_pixi_repodata_cache,
+                pixi_exe=pixi_exe,
+                log_filename=log_filename,
+                quiet=quiet,
+            ),
         )
 
 

--- a/tests/test_deploy_bootstrap.py
+++ b/tests/test_deploy_bootstrap.py
@@ -1,4 +1,8 @@
+import argparse
+import subprocess
 from pathlib import Path
+
+import pytest
 
 from mache.deploy import bootstrap
 
@@ -379,3 +383,247 @@ def test_merge_pixi_toml_dependencies_adds_missing_channels(
 
     text = target.read_text(encoding='utf-8')
     assert 'channels = ["conda-forge", "custom"]' in text
+
+
+def _fail_check_call(failures, monkeypatch):
+    """Make ``check_call`` fail ``failures`` times, then succeed."""
+    calls = {'count': 0}
+
+    def fake_check_call(commands, log_file, is_quiet, **kwargs):
+        calls['count'] += 1
+        if calls['count'] <= failures:
+            raise subprocess.CalledProcessError(1, commands)
+        return 'ok'
+
+    monkeypatch.setattr(bootstrap, 'check_call', fake_check_call)
+    monkeypatch.setattr(bootstrap.time, 'sleep', lambda seconds: None)
+    return calls
+
+
+def test_check_call_with_retries_skips_on_retry_when_first_try_works(
+    monkeypatch, tmp_path: Path
+):
+    log_filename = str(tmp_path / 'bootstrap.log')
+    _fail_check_call(0, monkeypatch)
+    retries = []
+
+    result = bootstrap.check_call_with_retries(
+        ['pixi', 'install'],
+        log_filename,
+        True,
+        on_retry=lambda: retries.append(1),
+    )
+
+    assert result == 'ok'
+    assert retries == []
+
+
+def test_check_call_with_retries_calls_on_retry_between_attempts(
+    monkeypatch, tmp_path: Path
+):
+    log_filename = str(tmp_path / 'bootstrap.log')
+    calls = _fail_check_call(2, monkeypatch)
+    retries = []
+
+    result = bootstrap.check_call_with_retries(
+        ['pixi', 'install'],
+        log_filename,
+        True,
+        on_retry=lambda: retries.append(1),
+    )
+
+    assert result == 'ok'
+    assert calls['count'] == 3
+    assert len(retries) == 2
+
+
+def test_check_call_with_retries_never_calls_on_retry_after_last_failure(
+    monkeypatch, tmp_path: Path
+):
+    log_filename = str(tmp_path / 'bootstrap.log')
+    calls = _fail_check_call(5, monkeypatch)
+    retries = []
+
+    with pytest.raises(subprocess.CalledProcessError):
+        bootstrap.check_call_with_retries(
+            ['pixi', 'install'],
+            log_filename,
+            True,
+            retries=3,
+            on_retry=lambda: retries.append(1),
+        )
+
+    assert calls['count'] == 3
+    assert len(retries) == 2
+
+
+def test_check_call_with_retries_ignores_on_retry_failures(
+    monkeypatch, tmp_path: Path
+):
+    log_filename = str(tmp_path / 'bootstrap.log')
+    _fail_check_call(5, monkeypatch)
+
+    def broken_on_retry():
+        raise RuntimeError('cache clear exploded')
+
+    with pytest.raises(subprocess.CalledProcessError):
+        bootstrap.check_call_with_retries(
+            ['pixi', 'install'],
+            log_filename,
+            True,
+            retries=3,
+            on_retry=broken_on_retry,
+        )
+
+    log_text = Path(log_filename).read_text(encoding='utf-8')
+    assert 'cache clear exploded' in log_text
+
+
+def test_clear_pixi_repodata_cache_runs_pixi_clean_cache(
+    monkeypatch, tmp_path: Path
+):
+    recorded = {}
+
+    def fake_check_call(commands, log_filename, quiet, **kwargs):
+        recorded['commands'] = commands
+        recorded['kwargs'] = kwargs
+
+    monkeypatch.setattr(bootstrap, 'check_call', fake_check_call)
+    monkeypatch.setenv('PIXI_CACHE_DIR', str(tmp_path / 'pixi-cache'))
+
+    bootstrap._clear_pixi_repodata_cache(
+        pixi_exe='/path/to/pixi',
+        log_filename=str(tmp_path / 'bootstrap.log'),
+        quiet=True,
+    )
+
+    assert recorded['commands'] == [
+        '/path/to/pixi',
+        'clean',
+        'cache',
+        '--repodata',
+        '-y',
+    ]
+    env = recorded['kwargs']['env']
+    assert env['PIXI_CACHE_DIR'] == str(tmp_path / 'pixi-cache')
+    assert 'PIXI_IN_SHELL' not in env
+
+
+def test_clear_pixi_repodata_cache_tolerates_failure(
+    monkeypatch, tmp_path: Path
+):
+    def fake_check_call(commands, log_filename, quiet, **kwargs):
+        raise subprocess.CalledProcessError(1, commands)
+
+    monkeypatch.setattr(bootstrap, 'check_call', fake_check_call)
+
+    log_filename = tmp_path / 'bootstrap.log'
+    bootstrap._clear_pixi_repodata_cache(
+        pixi_exe='/path/to/pixi',
+        log_filename=str(log_filename),
+        quiet=True,
+    )
+
+    log_text = log_filename.read_text(encoding='utf-8')
+    assert 'Could not clear the pixi repodata cache' in log_text
+
+
+def _stub_bootstrap_run(monkeypatch, tmp_path: Path, *, dev_mache):
+    """Stub out everything ``_run`` does apart from the pixi install."""
+    monkeypatch.chdir(tmp_path)
+
+    args = argparse.Namespace(
+        software='polaris',
+        quiet=True,
+        mache_version='3.11.0',
+        pixi=None,
+        pixi_path=None,
+        python='3.12',
+        recreate=False,
+        mache_fork='E3SM-Project/mache' if dev_mache else None,
+        mache_branch='main' if dev_mache else None,
+    )
+
+    monkeypatch.setattr(bootstrap, '_parse_args', lambda: args)
+    monkeypatch.setattr(bootstrap, 'check_location', lambda software: None)
+    monkeypatch.setattr(
+        bootstrap,
+        '_get_pixi_executable',
+        lambda pixi, log_filename, quiet: '/path/to/pixi',
+    )
+    monkeypatch.setattr(
+        bootstrap,
+        '_write_bootstrap_pixi_config',
+        lambda bootstrap_dir: None,
+    )
+    monkeypatch.setattr(
+        bootstrap,
+        '_clone_mache_repo',
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        bootstrap,
+        '_copy_mache_pixi_toml',
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        bootstrap,
+        '_write_bootstrap_pixi_toml_with_mache',
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        bootstrap,
+        'build_pixi_shell_hook_prefix',
+        lambda **kwargs: 'prefix &&',
+    )
+    monkeypatch.setattr(
+        bootstrap,
+        'install_dev_mache',
+        lambda **kwargs: None,
+    )
+
+    recorded = {}
+
+    def fake_check_call_with_retries(commands, log_filename, quiet, **kwargs):
+        recorded['commands'] = commands
+        recorded['kwargs'] = kwargs
+
+    monkeypatch.setattr(
+        bootstrap,
+        'check_call_with_retries',
+        fake_check_call_with_retries,
+    )
+
+    cleared = []
+    monkeypatch.setattr(
+        bootstrap,
+        '_clear_pixi_repodata_cache',
+        lambda **kwargs: cleared.append(kwargs),
+    )
+
+    return recorded, cleared
+
+
+@pytest.mark.parametrize('dev_mache', [True, False])
+def test_run_clears_repodata_cache_between_install_attempts(
+    monkeypatch, tmp_path: Path, dev_mache: bool
+):
+    recorded, cleared = _stub_bootstrap_run(
+        monkeypatch, tmp_path, dev_mache=dev_mache
+    )
+
+    log_filename = str(tmp_path / 'bootstrap.log')
+    bootstrap._run(log_filename)
+
+    assert recorded['commands'] == ['/path/to/pixi', 'install']
+
+    on_retry = recorded['kwargs']['on_retry']
+    on_retry()
+
+    assert cleared == [
+        {
+            'pixi_exe': '/path/to/pixi',
+            'log_filename': log_filename,
+            'quiet': True,
+        }
+    ]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

## Problem

`bootstrap.py` wraps its two `pixi install` calls in `check_call_with_retries()` (3 attempts, 2 s apart), but for the most common real-world failure — a stale cached copy of conda-forge's sharded repodata — those retries cannot possibly succeed. While a cached shard index is still considered fresh, pixi does zero network I/O, so every attempt reads the same stale cache and fails identically. This was seen on Chrysalis while bootstrapping Polaris against `mache = 3.11.0`: the noarch shard index in the cache predated the 3.11.0 upload, so all three attempts reported `No candidates were found for mache ==3.11.0`. The retry loop burned 6 s and reported a confusing "package does not exist" error; the only thing that helped was waiting out the cache TTL.

## Changes

- Add a keyword-only `on_retry=None` hook to `check_call_with_retries()`, called after a failed attempt that will be followed by another one — never before the first attempt, never after the final failure.
- Swallow and log any exception raised inside `on_retry` so it cannot mask the original `subprocess.CalledProcessError`.
- Add `_clear_pixi_repodata_cache()`, which runs `pixi clean cache --repodata -y` with `build_pixi_env()` so it targets the same `PIXI_CACHE_DIR` the failed install used, and tolerates its own failure.
- Wire both bootstrap `pixi install` call sites (dev-mache and release-mache paths) to that hook via `functools.partial`.
- Factor the log-and-echo pattern into a `_log_message()` helper now that three call sites need it.
- Leave the three `mache/jigsaw` call sites and the default behavior of `check_call_with_retries()` unchanged.

## Tests

- 7 new tests in `tests/test_deploy_bootstrap.py` (17 → 24) covering hook timing (first-attempt success, two failures then success, all attempts fail), error isolation, the exact `pixi clean cache` argv and environment, tolerated cache-clear failure, and both bootstrap install paths.
- `tests/test_jigsaw.py` is unchanged and still passes, which is the regression guard for the shared retry helper.

## Notes

- The new code path only runs after a command has already failed, so the cost is a few MB of repodata on a failure path.
- No docs change: nothing in `docs/` describes the bootstrap retry behavior.
- Not included: an escalating retry delay for the pixi calls. Clearing repodata addresses the local-cache case directly, and a longer delay only helps if the upstream CDN edge is itself stale, at the price of sitting in a retry loop against a 20-minute TTL.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
- [ ] Tests pass and new features are covered by tests

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

